### PR TITLE
Clarify the API

### DIFF
--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -13,7 +13,6 @@ type ServiceBindingRequestSpec struct {
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
 	// BackingSelector is used to identify the backing service operator.
-	// If version is not specified, the latest version will be picked up
 	//
 	// Refer: https://12factor.net/backing-services
 	// A backing service is any service the app consumes over the network as
@@ -25,12 +24,12 @@ type ServiceBindingRequestSpec struct {
 	// Example 1:
 	//	backingSelector:
 	//		resourceKind: Database
-	//		resourceName: my-db
+	//		resourceName: database.example.org
 	// Example 2:
 	//	backingSelector:
 	//		resourceKind: Database
-	//		resourceName: my-db
-	//		version: v0.1.2
+	//		resourceName: database.example.org
+	//		resourceVersion: v1alpha1
 	BackingSelector BackingSelector `json:"backingSelector"`
 
 	// ApplicationSelector is used to identify the application connecting to the
@@ -51,9 +50,9 @@ type ServiceBindingRequestSpec struct {
 // BackingSelector defines the selector based on resource name, version, and resource kind
 // +k8s:openapi-gen=true
 type BackingSelector struct {
-	ResourceKind string `json:"resourceKind"`
-	ResourceName string `json:"resourceName"`
-	Version      string `json:"version"`
+	ResourceKind    string `json:"resourceKind"`
+	ResourceName    string `json:"resourceName"`
+	ResourceVersion string `json:"resourceVersion"`
 }
 
 // ApplicationSelector defines the selector based on labels, resource name, and resource kind

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -23,11 +23,9 @@ type ServiceBindingRequestSpec struct {
 	//
 	// Example 1:
 	//	backingSelector:
-	//		resourceKind: Database
 	//		resourceName: database.example.org
 	// Example 2:
 	//	backingSelector:
-	//		resourceKind: Database
 	//		resourceName: database.example.org
 	//		resourceVersion: v1alpha1
 	BackingSelector BackingSelector `json:"backingSelector"`
@@ -50,7 +48,6 @@ type ServiceBindingRequestSpec struct {
 // BackingSelector defines the selector based on resource name, version, and resource kind
 // +k8s:openapi-gen=true
 type BackingSelector struct {
-	ResourceKind    string `json:"resourceKind"`
 	ResourceName    string `json:"resourceName"`
 	ResourceVersion string `json:"resourceVersion"`
 }


### PR DESCRIPTION
The resource details are looked up inside the CSV spec. For example, consider this CSV file:
https://github.com/operator-framework/community-operators/blob/0230c07c33ae36272151f918ad7c87d62ae13ee4/upstream-community-operators/etcd/etcdoperator.v0.9.4.clusterserviceversion.yaml#L232

Line no. 232 to 234 is what is used to identify the CSV.
