### PR TITLE
Fix for trailing spaces lint error

### DIFF
--- a/deploy/crds/apps_v1alpha1_servicebindingrequest_cr.yaml
+++ b/deploy/crds/apps_v1alpha1_servicebindingrequest_cr.yaml
@@ -10,4 +10,4 @@ spec:
     matchLabels:
       connects-to: postgres
       environment: production
-    resourceKind: Deployment               
+    resourceKind: Deployment


### PR DESCRIPTION
`make lint`  is throwing error 
```
./deploy/crds/apps_v1alpha1_servicebindingrequest_cr.yaml
  13:29     error    trailing spaces  (trailing-spaces)
```
This patch removes those spaces.