### PR TITLE
Set GOCACHE for `go list` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ test-e2e: e2e-setup
 ## Runs the unit tests
 test-unit:
 	$(info Running unit test: $@)
-	$(Q)GO111MODULE=on GOCACHE=$(shell pwd)/out/gocache go test $(shell go list ./...|grep -v e2e) -v -mod vendor
+	$(Q)GO111MODULE=on GOCACHE=$(shell pwd)/out/gocache go test $(shell GOCACHE=$(shell pwd)/out/gocache go list ./...|grep -v e2e) -v -mod vendor
 
 #---------------------------------------------------------
 # Build and vendor tarets


### PR DESCRIPTION
In the CI environment, the default location is read-only. The cache needs to write access.