### PR TITLE
Convert namespace to lowercase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ $(GOLANGCI_LINT_BIN):
 
 # Generate namespace name for test
 ./out/test-namespace:
-	@echo -n "test-namespace-$(shell uuidgen)" > ./out/test-namespace
+	@echo -n "test-namespace-$(shell uuidgen | tr '[:upper:]' '[:lower:]')" > ./out/test-namespace
 
 .PHONY: get-test-namespace
 get-test-namespace: ./out/test-namespace


### PR DESCRIPTION
The uuidgen produce captial letters in Mac