### PR TITLE
Package operator as a marketplace operator

### DIFF
--- a/deploy/olm-catalog/service-binding-operator/0.0.1/service-binding-operator.package.yaml
+++ b/deploy/olm-catalog/service-binding-operator/0.0.1/service-binding-operator.package.yaml
@@ -1,0 +1,4 @@
+packageName: service-binding-operator
+channels:
+- name: stable
+  currentCSV: service-binding-operator.v0.0.1

--- a/deploy/olm-catalog/service-binding-operator/0.0.1/service-binding-operator.servicebindingrequests.crd.yaml
+++ b/deploy/olm-catalog/service-binding-operator/0.0.1/service-binding-operator.servicebindingrequests.crd.yaml
@@ -1,0 +1,78 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicebindingrequests.apps.openshift.io
+spec:
+  group: apps.openshift.io
+  names:
+    kind: ServiceBindingRequest
+    listKind: ServiceBindingRequestList
+    plural: servicebindingrequests
+    singular: servicebindingrequest
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            applicationSelector:
+              description: "ApplicationSelector is used to identify the application
+                connecting to the backing service operator. Example 1: \tapplicationSelector:
+                \t\tmatchLabels: \t\t\tconnects-to: postgres \t\t\tenvironment: stage
+                \t\tresourceKind: Deployment Example 2: \tapplicationSelector: \t\tresourceKind:
+                Deployment \t\tresourceName: my-app"
+              properties:
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                resourceKind:
+                  type: string
+              required:
+              - matchLabels
+              - resourceKind
+              type: object
+            backingSelector:
+              description: "BackingSelector is used to identify the backing service
+                operator.  Refer: https://12factor.net/backing-services A backing
+                service is any service the app consumes over the network as part of
+                its normal operation. Examples include datastores (such as MySQL or
+                CouchDB), messaging/queueing systems (such as RabbitMQ or Beanstalkd),
+                SMTP services for outbound email (such as Postfix), and caching systems
+                (such as Memcached).  Example 1: \tbackingSelector: \t\tresourceName:
+                database.example.org Example 2: \tbackingSelector: \t\tresourceName:
+                database.example.org \t\tresourceVersion: v1alpha1"
+              properties:
+                resourceName:
+                  type: string
+                resourceVersion:
+                  type: string
+              required:
+              - resourceName
+              - resourceVersion
+              type: object
+          required:
+          - backingSelector
+          - applicationSelector
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/service-binding-operator/0.0.1/service-binding-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-binding-operator/0.0.1/service-binding-operator.v0.0.1.clusterserviceversion.yaml
@@ -1,0 +1,118 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"apps.openshift.io/v1alpha1","kind":"ServiceBindingRequest","metadata":{"name":"example-servicebindingrequest"},"spec":{"applicationSelector":{"matchLabels":{"connects-to":"postgres","environment":"production"},"resourceKind":"Deployment"},"backingSelector":{"resourceName":"database.example.org","resourceVersion":"v1alpha1"}}}]'
+    capabilities: Basic Install
+    containerImage: quay.io/redhat-developer/service-binding-operator:v0.0.1
+    description: An operator to support binding capabilities between imported apps and operator backed services
+  name: service-binding-operator.v0.0.1
+  namespace: placeholder
+spec:
+  links:
+  - name: Source Code
+    url: https://github.com/redhat-developer/service-binding-operator
+  maintainers:
+    - email: shbose@redhat.com
+      name: Shoubhik Bose
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: ServiceBindingRequest
+      name: servicebindingrequests.apps.openshift.io
+      version: v1alpha1
+  description: Placeholder description
+  displayName: Operator Service Binding Operator
+  install:
+    spec:
+      deployments:
+      - name: service-binding-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: service-binding-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: service-binding-operator
+            spec:
+              containers:
+              - command:
+                - service-binding-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: service-binding-operator
+                image: quay.io/redhat-developer/service-binding-operator:v0.0.1
+                imagePullPolicy: Always
+                name: service-binding-operator
+                resources: {}
+              serviceAccountName: service-binding-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - service-binding-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: service-binding-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  maturity: alpha
+  provider: 
+    name: Red Hat, Inc.
+  version: 0.0.1

--- a/deploy/olm-catalog/service-binding-operator/0.0.1/service-binding-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-binding-operator/0.0.1/service-binding-operator.v0.0.1.clusterserviceversion.yaml
@@ -113,6 +113,6 @@ spec:
   - supported: true
     type: AllNamespaces
   maturity: alpha
-  provider: 
+  provider:
     name: Red Hat, Inc.
   version: 0.0.1


### PR DESCRIPTION
Source the following:

```
OPERATOR_DIR=0.0.1
QUAY_NAMESPACE=redhat-developer
PACKAGE_NAME=service-binding-operator
PACKAGE_VERSION=0.0.1
TOKEN="basic c2----I5"
```

Run
```
operator-courier verify --ui_validate_io 0.0.1
```

Run 
```
operator-courier push "$OPERATOR_DIR" "$QUAY_NAMESPACE" "$PACKAGE_NAME" "$PACKAGE_VERSION" "$TOKEN"
```

This would push the artifacts into a Quay App Registry
https://quay.io/application/redhat-developer/service-binding-operator?tab=releases

After that, create an OperatorSource

```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: redhat-developer-operators
  namespace: openshift-marketplace
spec:
  type: appregistry
  endpoint: https://quay.io/cnr
  registryNamespace: redhat-developer
```

This should reconcile, and consequently the operator should show up

![image](https://user-images.githubusercontent.com/545280/60132938-824e2e00-976a-11e9-84c2-6e209a4470ca.png)

