### PR TITLE
Allow GET on all namespace-scoped CRs

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -46,3 +46,9 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - "*"
+  verbs:
+    - "get"


### PR DESCRIPTION
The controller would need to read the backing-service CR that would be bound. Since there is no way to know the API group or the resource in advance, we would have to let the service account `get` all resources in the namespace.