### PR TITLE
Add operator-courier lint for validating manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ GO_PACKAGE_PATH ?= github.com/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}
 GOLANGCI_LINT_BIN=./out/golangci-lint
 .PHONY: lint
 ## Runs linters on Go code files and YAML files
-lint: lint-go-code lint-yaml
+lint: lint-go-code lint-yaml courier
 
 YAML_FILES := $(shell find . -path ./vendor -prune -o -type f -regex ".*y[a]ml" -print)
 .PHONY: lint-yaml
@@ -98,6 +98,16 @@ lint-go-code: ./vendor $(GOLANGCI_LINT_BIN)
 $(GOLANGCI_LINT_BIN):
 	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.17.1
 
+
+.PHONY: courier
+## Validate manifests using operator-courier
+courier:
+	$(Q)python3 -m venv ./out/venv3
+	$(Q)./out/venv3/bin/pip install --upgrade setuptools
+	$(Q)./out/venv3/bin/pip install --upgrade pip
+	$(Q)./out/venv3/bin/pip install operator-courier==2.0.2
+	$(Q)./out/venv3/bin/operator-courier flatten ./manifests ./out/manifests
+	$(Q)./out/venv3/bin/operator-courier verify ./out/manifests
 
 #------------------------------------------------------
 # Test targets


### PR DESCRIPTION
This target is to validate manifests using `operator-courier`.