### PR TITLE
Add objectName selector

### DIFF
--- a/deploy/crds/apps_v1alpha1_servicebindingrequest_crd.yaml
+++ b/deploy/crds/apps_v1alpha1_servicebindingrequest_crd.yaml
@@ -54,9 +54,12 @@ spec:
                 CouchDB), messaging/queueing systems (such as RabbitMQ or Beanstalkd),
                 SMTP services for outbound email (such as Postfix), and caching systems
                 (such as Memcached).  Example 1: \tbackingSelector: \t\tresourceName:
-                database.example.org Example 2: \tbackingSelector: \t\tresourceName:
-                database.example.org \t\tresourceVersion: v1alpha1"
+                database.example.org      objectName: mysql-database Example 2: \tbackingSelector:
+                \t\tresourceName: database.example.org \t\tresourceVersion: v1alpha1
+                \     objectName: mysql-database"
               properties:
+                objectName:
+                  type: string
                 resourceName:
                   type: string
                 resourceVersion:
@@ -64,6 +67,7 @@ spec:
               required:
               - resourceName
               - resourceVersion
+              - objectName
               type: object
           required:
           - backingSelector

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -24,10 +24,12 @@ type ServiceBindingRequestSpec struct {
 	// Example 1:
 	//	backingSelector:
 	//		resourceName: database.example.org
+	//      objectName: mysql-database
 	// Example 2:
 	//	backingSelector:
 	//		resourceName: database.example.org
 	//		resourceVersion: v1alpha1
+	//      objectName: mysql-database
 	BackingSelector BackingSelector `json:"backingSelector"`
 
 	// ApplicationSelector is used to identify the application connecting to the
@@ -50,6 +52,7 @@ type ServiceBindingRequestSpec struct {
 type BackingSelector struct {
 	ResourceName    string `json:"resourceName"`
 	ResourceVersion string `json:"resourceVersion"`
+	ObjectName      string `json:"objectName"`
 }
 
 // ApplicationSelector defines the selector based on labels and resource kind

--- a/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
@@ -72,8 +72,14 @@ func schema_pkg_apis_apps_v1alpha1_BackingSelector(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"objectName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
-				Required: []string{"resourceName", "resourceVersion"},
+				Required: []string{"resourceName", "resourceVersion", "objectName"},
 			},
 		},
 		Dependencies: []string{},
@@ -131,7 +137,7 @@ func schema_pkg_apis_apps_v1alpha1_ServiceBindingRequestSpec(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"backingSelector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BackingSelector is used to identify the backing service operator.\n\nRefer: https://12factor.net/backing-services A backing service is any service the app consumes over the network as part of its normal operation. Examples include datastores (such as MySQL or CouchDB), messaging/queueing systems (such as RabbitMQ or Beanstalkd), SMTP services for outbound email (such as Postfix), and caching systems (such as Memcached).\n\nExample 1:\n\tbackingSelector:\n\t\tresourceName: database.example.org\nExample 2:\n\tbackingSelector:\n\t\tresourceName: database.example.org\n\t\tresourceVersion: v1alpha1",
+							Description: "BackingSelector is used to identify the backing service operator.\n\nRefer: https://12factor.net/backing-services A backing service is any service the app consumes over the network as part of its normal operation. Examples include datastores (such as MySQL or CouchDB), messaging/queueing systems (such as RabbitMQ or Beanstalkd), SMTP services for outbound email (such as Postfix), and caching systems (such as Memcached).\n\nExample 1:\n\tbackingSelector:\n\t\tresourceName: database.example.org\n     objectName: mysql-database\nExample 2:\n\tbackingSelector:\n\t\tresourceName: database.example.org\n\t\tresourceVersion: v1alpha1\n     objectName: mysql-database",
 							Ref:         ref("github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1.BackingSelector"),
 						},
 					},


### PR DESCRIPTION
Using the instance name we can uniquely identify the CR. It would point to the correct instance because we can have many instances. But we need to be particular about the instance. Labels might match to more than one instance so label selectors would not be a good approach.