### PR TITLE
Change channel from stable to alpha

### DIFF
--- a/manifests/service-binding-operator.package.yaml
+++ b/manifests/service-binding-operator.package.yaml
@@ -1,4 +1,7 @@
 packageName: service-binding-operator
 channels:
-- name: alpha
+- name: dev
   currentCSV: service-binding-operator.v0.0.10
+- name: stable 
+  currentCSV: service-binding-operator.v0.0.10
+defaultChannel: dev

--- a/manifests/service-binding-operator.package.yaml
+++ b/manifests/service-binding-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: service-binding-operator
 channels:
-- name: stable
+- name: alpha
   currentCSV: service-binding-operator.v0.0.10


### PR DESCRIPTION
This PR provides two channels - `dev` and `stable`. In the future, we can have these channels pointing to different ClusterServiceVersion respectively. For development purpose, we can use the dev channel and a stable release can be under the stable channel.  By default the cannel is the `dev` channel.