### PR TITLE
Refactor test to use sub tests

### DIFF
--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -47,7 +47,7 @@ func TestRetriever(t *testing.T) {
 		assert.NotEmpty(t, retriever.data)
 	})
 
-	t.Run("GetCRKey", func(t *testing.T) {
+	t.Run("getCRKey", func(t *testing.T) {
 		imageName, err := retriever.getCRKey("spec", "imageName")
 		assert.Nil(t, err)
 		assert.Equal(t, "postgres", imageName)
@@ -76,12 +76,12 @@ func TestRetriever(t *testing.T) {
 
 	})
 
-	t.Run("", func(t *testing.T) {
+	t.Run("extractSecretItemName", func(t *testing.T) {
 		assert.Equal(t, "user", retriever.extractSecretItemName(
 			"urn:alm:descriptor:servicebindingrequest:env:object:secret:user"))
 	})
 
-	t.Run("ReadSecret", func(t *testing.T) {
+	t.Run("readSecret", func(t *testing.T) {
 		retriever.data = make(map[string][]byte)
 
 		err := retriever.readSecret("db-credentials", []string{"user", "password"})
@@ -91,15 +91,14 @@ func TestRetriever(t *testing.T) {
 		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
 	})
 
-	t.Run("Store", func(t *testing.T) {
+	t.Run("store", func(t *testing.T) {
 		retriever.store("test", []byte("test"))
 		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_TEST")
 		assert.Equal(t, []byte("test"), retriever.data["SERVICE_BINDING_DATABASE_TEST"])
 	})
 
-	t.Run("SaveDataOnSecret", func(t *testing.T) {
+	t.Run("saveDataOnSecret", func(t *testing.T) {
 		err := retriever.saveDataOnSecret()
 		assert.Nil(t, err)
 	})
-
 }

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -14,10 +14,9 @@ import (
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
-var retriever *Retriever
-
-func TestRetrieverNew(t *testing.T) {
+func TestRetriever(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
+	var retriever *Retriever
 
 	ns := "testing"
 	crName := "db-testing"
@@ -41,65 +40,66 @@ func TestRetrieverNew(t *testing.T) {
 
 	retriever = NewRetriever(context.TODO(), fakeClient, plan)
 	require.NotNil(t, retriever)
-}
 
-func TestRetrieverGetCRKey(t *testing.T) {
-	imageName, err := retriever.getCRKey("spec", "imageName")
-	assert.Nil(t, err)
-	assert.Equal(t, "postgres", imageName)
-}
-
-func TestRetrieverRead(t *testing.T) {
-	// reading from secret, from status attribute
-	err := retriever.read("status", "dbCredentials", []string{
-		"urn:alm:descriptor:servicebindingrequest:env:object:secret:user",
-		"urn:alm:descriptor:servicebindingrequest:env:object:secret:password",
+	t.Run("retrive", func(t *testing.T) {
+		err := retriever.Retrieve()
+		assert.Nil(t, err)
+		assert.NotEmpty(t, retriever.data)
 	})
-	assert.Nil(t, err)
 
-	t.Logf("retriever.data '%#v'", retriever.data)
-	assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
-	assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
-
-	// reading from spec attribute
-	err = retriever.read("spec", "image", []string{
-		"urn:alm:descriptor:servicebindingrequest:env:attribute",
+	t.Run("GetCRKey", func(t *testing.T) {
+		imageName, err := retriever.getCRKey("spec", "imageName")
+		assert.Nil(t, err)
+		assert.Equal(t, "postgres", imageName)
 	})
-	assert.Nil(t, err)
 
-	t.Logf("retriever.data '%#v'", retriever.data)
-	assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_IMAGE")
+	t.Run("read", func(t *testing.T) {
+		// reading from secret, from status attribute
+		err := retriever.read("status", "dbCredentials", []string{
+			"urn:alm:descriptor:servicebindingrequest:env:object:secret:user",
+			"urn:alm:descriptor:servicebindingrequest:env:object:secret:password",
+		})
+		assert.Nil(t, err)
 
-}
+		t.Logf("retriever.data '%#v'", retriever.data)
+		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
+		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
 
-func TestRetrieverExtractSecretItemName(t *testing.T) {
-	assert.Equal(t, "user", retriever.extractSecretItemName(
-		"urn:alm:descriptor:servicebindingrequest:env:object:secret:user"))
-}
+		// reading from spec attribute
+		err = retriever.read("spec", "image", []string{
+			"urn:alm:descriptor:servicebindingrequest:env:attribute",
+		})
+		assert.Nil(t, err)
 
-func TestRetrieverReadSecret(t *testing.T) {
-	retriever.data = make(map[string][]byte)
+		t.Logf("retriever.data '%#v'", retriever.data)
+		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_IMAGE")
 
-	err := retriever.readSecret("db-credentials", []string{"user", "password"})
-	assert.Nil(t, err)
+	})
 
-	assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
-	assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
-}
+	t.Run("", func(t *testing.T) {
+		assert.Equal(t, "user", retriever.extractSecretItemName(
+			"urn:alm:descriptor:servicebindingrequest:env:object:secret:user"))
+	})
 
-func TestRetrieverStore(t *testing.T) {
-	retriever.store("test", []byte("test"))
-	assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_TEST")
-	assert.Equal(t, []byte("test"), retriever.data["SERVICE_BINDING_DATABASE_TEST"])
-}
+	t.Run("ReadSecret", func(t *testing.T) {
+		retriever.data = make(map[string][]byte)
 
-func TestRetrieverSaveDataOnSecret(t *testing.T) {
-	err := retriever.saveDataOnSecret()
-	assert.Nil(t, err)
-}
+		err := retriever.readSecret("db-credentials", []string{"user", "password"})
+		assert.Nil(t, err)
 
-func TestRetrieverRetrieve(t *testing.T) {
-	err := retriever.Retrieve()
-	assert.Nil(t, err)
-	assert.NotEmpty(t, retriever.data)
+		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
+		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
+	})
+
+	t.Run("Store", func(t *testing.T) {
+		retriever.store("test", []byte("test"))
+		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_TEST")
+		assert.Equal(t, []byte("test"), retriever.data["SERVICE_BINDING_DATABASE_TEST"])
+	})
+
+	t.Run("SaveDataOnSecret", func(t *testing.T) {
+		err := retriever.saveDataOnSecret()
+		assert.Nil(t, err)
+	})
+
 }


### PR DESCRIPTION
- Avoid global variable
- Make each sub test to run independently