### PR TITLE
Move planner into a separate package

### DIFF
--- a/pkg/controller/servicebindingrequest/planner/planner.go
+++ b/pkg/controller/servicebindingrequest/planner/planner.go
@@ -1,4 +1,4 @@
-package servicebindingrequest
+package planner
 
 import (
 	"context"

--- a/pkg/controller/servicebindingrequest/planner/planner_test.go
+++ b/pkg/controller/servicebindingrequest/planner/planner_test.go
@@ -1,4 +1,4 @@
-package servicebindingrequest
+package planner
 
 import (
 	"context"

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -14,6 +14,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/pkg/controller/servicebindingrequest/planner"
 )
 
 // Reconciler reconciles a ServiceBindingRequest object
@@ -66,8 +67,8 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	logger.WithValues("ServiceBindingRequest.Name", instance.Name).
 		Info("Found service binding request to inspect")
 
-	planner := NewPlanner(ctx, r.client, request.Namespace, instance)
-	plan, err := planner.Plan()
+	plnr := planner.NewPlanner(ctx, r.client, request.Namespace, instance)
+	plan, err := plnr.Plan()
 	if err != nil {
 		return RequeueOnNotFound(err)
 	}

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/redhat-developer/service-binding-operator/pkg/controller/servicebindingrequest/planner"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +19,7 @@ import (
 type Retriever struct {
 	ctx    context.Context   // request context
 	client client.Client     // Kubernetes API client
-	plan   *Plan             // plan instance
+	plan   *planner.Plan     // plan instance
 	logger logr.Logger       // logger instance
 	data   map[string][]byte // data retrieved
 }
@@ -182,7 +183,7 @@ func (r *Retriever) Retrieve() error {
 }
 
 // NewRetriever instantiate a new retriever instance.
-func NewRetriever(ctx context.Context, client client.Client, plan *Plan) *Retriever {
+func NewRetriever(ctx context.Context, client client.Client, plan *planner.Plan) *Retriever {
 	return &Retriever{
 		ctx:    ctx,
 		client: client,

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
+	"github.com/redhat-developer/service-binding-operator/pkg/controller/servicebindingrequest/planner"
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
@@ -27,7 +28,7 @@ func TestRetriever(t *testing.T) {
 	genericCR, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&cr)
 	require.Nil(t, err)
 
-	plan := &Plan{
+	plan := &planner.Plan{
 		Ns:             ns,
 		Name:           "retriever",
 		CRDDescription: &crdDescription,
@@ -116,7 +117,7 @@ func TestRetrieverNestedCRDKey(t *testing.T) {
 	genericCR, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&cr)
 	require.Nil(t, err)
 
-	plan := &Plan{
+	plan := &planner.Plan{
 		Ns:             ns,
 		Name:           "retriever",
 		CRDDescription: &crdDescription,


### PR DESCRIPTION
Moving into a separate package will make re-usability easier.