### PR TITLE
Install jq to root container for OpenShift CI.

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -17,6 +17,7 @@ RUN yum install epel-release -y \
     wget \
     which \
     bc \
+    jq \
     python36-virtualenv \
     && yum clean all
 


### PR DESCRIPTION
This PR adds `jq` among the tools installed in the `root` container for OpenShift CI.
The `jq` is a dependency for https://github.com/redhat-developer/service-binding-operator/pull/82.

The tool needs to be added and merged in a separated PR prior merging the actual PR that depends on it, because of how OpenShift CI and Prow works.