### PR TITLE
Add wait in reconcile loop.

### DIFF
--- a/pkg/controller/servicebindingrequest/planner/planner.go
+++ b/pkg/controller/servicebindingrequest/planner/planner.go
@@ -3,6 +3,7 @@ package planner
 import (
 	"context"
 	"fmt"
+	"github.com/redhat-developer/service-binding-operator/pkg/utils"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -100,6 +101,10 @@ func (p *Planner) searchCR(kind string) (*ustrv1.Unstructured, error) {
 	}}
 	namespacedName := types.NamespacedName{Namespace: p.ns, Name: resourceRef}
 
+	err = utils.WaitUntilResourceFound(p.client, namespacedName, &cr)
+	if err != nil {
+		return nil, err
+	}
 	if err = p.client.Get(p.ctx, namespacedName, &cr); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/servicebindingrequest/planner/planner.go
+++ b/pkg/controller/servicebindingrequest/planner/planner.go
@@ -3,7 +3,7 @@ package planner
 import (
 	"context"
 	"fmt"
-	"github.com/redhat-developer/service-binding-operator/pkg/utils"
+	"github.com/redhat-developer/service-binding-operator/pkg/resourcepoll"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -101,7 +101,7 @@ func (p *Planner) searchCR(kind string) (*ustrv1.Unstructured, error) {
 	}}
 	namespacedName := types.NamespacedName{Namespace: p.ns, Name: resourceRef}
 
-	err = utils.WaitUntilResourceFound(p.client, namespacedName, &cr)
+	err = resourcepoll.WaitUntilResourceFound(p.client, namespacedName, &cr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -137,7 +137,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// FIXME: find a way to DRY this block, and then add statefulsets and other kinds back again;
-		switch resourceKind {
+	switch resourceKind {
 	case "deploymentconfig":
 		logger.Info("Searching DeploymentConfig objects matching labels")
 

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -2,7 +2,7 @@ package servicebindingrequest
 
 import (
 	"context"
-	"github.com/redhat-developer/service-binding-operator/pkg/utils"
+	"github.com/redhat-developer/service-binding-operator/pkg/resourcepoll"
 	"strings"
 
 	osappsv1 "github.com/openshift/api/apps/v1"
@@ -142,7 +142,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		logger.Info("Searching DeploymentConfig objects matching labels")
 
 		deploymentConfigListObj := &osappsv1.DeploymentConfigList{}
-		err = utils.WaitUntilResourcesFound(r.client, &searchByLabelsOpts, deploymentConfigListObj)
+		err = resourcepoll.WaitUntilResourcesFound(r.client, &searchByLabelsOpts, deploymentConfigListObj)
 		if err != nil {
 			return RequeueOnNotFound(err)
 		}
@@ -190,7 +190,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		logger.Info("Searching Deployment objects matching labels")
 
 		deploymentListObj := &extv1beta1.DeploymentList{}
-		err = utils.WaitUntilResourcesFound(r.client, &searchByLabelsOpts, deploymentListObj)
+		err = resourcepoll.WaitUntilResourcesFound(r.client, &searchByLabelsOpts, deploymentListObj)
 		if err != nil {
 			return RequeueOnNotFound(err)
 		}

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -190,6 +190,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		logger.Info("Searching Deployment objects matching labels")
 
 		deploymentListObj := &extv1beta1.DeploymentList{}
+		err = utils.WaitUntilResourcesFound(r.client, &searchByLabelsOpts, deploymentListObj)
+		if err != nil {
+			return RequeueOnNotFound(err)
+		}
 		err = r.client.List(ctx, &searchByLabelsOpts, deploymentListObj)
 		if err != nil {
 			return RequeueOnNotFound(err)

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -2,6 +2,7 @@ package servicebindingrequest
 
 import (
 	"context"
+	"github.com/redhat-developer/service-binding-operator/pkg/utils"
 	"strings"
 
 	osappsv1 "github.com/openshift/api/apps/v1"
@@ -136,11 +137,15 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// FIXME: find a way to DRY this block, and then add statefulsets and other kinds back again;
-	switch resourceKind {
+		switch resourceKind {
 	case "deploymentconfig":
 		logger.Info("Searching DeploymentConfig objects matching labels")
 
 		deploymentConfigListObj := &osappsv1.DeploymentConfigList{}
+		err = utils.WaitUntilResourcesFound(r.client, &searchByLabelsOpts, deploymentConfigListObj)
+		if err != nil {
+			return RequeueOnNotFound(err)
+		}
 		err = r.client.List(ctx, &searchByLabelsOpts, deploymentConfigListObj)
 		if err != nil {
 			return RequeueOnNotFound(err)

--- a/pkg/resourcepoll/wait.go
+++ b/pkg/resourcepoll/wait.go
@@ -1,4 +1,4 @@
-package utils
+package resourcepoll
 
 import (
 	"context"

--- a/pkg/resourcepoll/wait.go
+++ b/pkg/resourcepoll/wait.go
@@ -10,11 +10,14 @@ import (
 	"time"
 )
 
+
 func WaitUntilResourceFound(client client.Client, nsd types.NamespacedName, typ runtime.Object) error {
 	var err error
-	err = wait.Poll(time.Second*5, time.Minute*2, func() (bool, error) {
+	count := 0
+	err = wait.Poll(time.Second * 5, time.Minute*5, func() (bool, error) {
+		count++
+		fmt.Printf("\nRetry count: %+d", count)
 		err = client.Get(context.TODO(), nsd, typ)
-		fmt.Printf("\nType is %+v and error is %+v", typ, err)
 		if err != nil {
 			return false, err
 		}
@@ -25,9 +28,11 @@ func WaitUntilResourceFound(client client.Client, nsd types.NamespacedName, typ 
 
 func WaitUntilResourcesFound(client client.Client, options *client.ListOptions, typ runtime.Object) error {
 	var err error
-	err = wait.Poll(time.Second*5, time.Minute*2, func() (bool, error) {
+	count := 0
+	err = wait.Poll(time.Second*5, time.Minute*5, func() (bool, error) {
+		count++
+		fmt.Printf("\nRetry count: %+d", count)
 		err = client.List(context.TODO(), options, typ)
-		fmt.Printf("\nType is %+v and error is %+v", typ, err)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/resourcepoll/wait.go
+++ b/pkg/resourcepoll/wait.go
@@ -23,10 +23,10 @@ func WaitUntilResourceFound(client client.Client, nsd types.NamespacedName, typ 
 	return err
 }
 
-func WaitUntilResourcesFound(client client.Client, nsd *client.ListOptions, typ runtime.Object) error {
+func WaitUntilResourcesFound(client client.Client, options *client.ListOptions, typ runtime.Object) error {
 	var err error
 	err = wait.Poll(time.Second*5, time.Minute*2, func() (bool, error) {
-		err = client.List(context.TODO(), nsd, typ)
+		err = client.List(context.TODO(), options, typ)
 		fmt.Printf("\nType is %+v and error is %+v", typ, err)
 		if err != nil {
 			return false, err

--- a/pkg/utils/wait_utils.go
+++ b/pkg/utils/wait_utils.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+func WaitUntilResourceFound(client client.Client, nsd types.NamespacedName, typ runtime.Object) error {
+	var err error
+	err = wait.Poll(time.Second*5, time.Minute*2, func() (bool, error) {
+		err = client.Get(context.TODO(), nsd, typ)
+		fmt.Printf("\nType is %+v and error is %+v", typ, err)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	return err
+}
+
+func WaitUntilResourcesFound(client client.Client, nsd *client.ListOptions, typ runtime.Object) error {
+	var err error
+	err = wait.Poll(time.Second*5, time.Minute*2, func() (bool, error) {
+		err = client.List(context.TODO(), nsd, typ)
+		fmt.Printf("\nType is %+v and error is %+v", typ, err)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	return err
+}


### PR DESCRIPTION
This PR adds utility functions to wait for k8s/Openshift resources.

**Why**
There are some gitOps use cases where `servicebindingrequest` would need to wait for resources(such as Deployment, backend Operator CR). 

**What is added**
This PR adds following two wait functions
1. `WaitUntilResourceFound` -> Function to wait for particular resource to be created. 
2. `WaitUntilResourcesFound` -> Function to wait for list of resources to be created.

**To Do**

- [x] Remove utils package (we don't need `utils` package as per @sbose78's suggestion).

