### PR TITLE
Ignore broken packages for the time being

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GIT_COMMITTER_NAME devtools
 ENV GIT_COMMITTER_EMAIL devtools@redhat.com
 
 RUN yum install epel-release -y \
-    && yum install --enablerepo=centosplus install -y --quiet \
+    && yum install --skip-broken --enablerepo=centosplus install -y --quiet \
     findutils \
     git \
     make \

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -7,7 +7,7 @@ ENV GIT_COMMITTER_NAME devtools
 ENV GIT_COMMITTER_EMAIL devtools@redhat.com
 
 RUN yum install epel-release -y \
-    && yum install --enablerepo=centosplus install -y --quiet \
+    && yum install --skip-broken --enablerepo=centosplus install -y --quiet \
     findutils \
     git \
     make \


### PR DESCRIPTION
.. to unblock PR/master builds which are now failing 

```
8/11/2019, 3:59:28 AMwarning: /var/cache/yum/x86_64/7/extras/packages/epel-release-7-11.noarch.rpm: Header V3 RSA/SHA256 Signature, key ID f4a80eb5: NOKEY
8/11/2019, 3:59:28 AMPublic key for epel-release-7-11.noarch.rpm is not installed
8/11/2019, 3:59:28 AMRetrieving key from file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
8/11/2019, 3:59:28 AMImporting GPG key 0xF4A80EB5: Userid : "CentOS-7 Key (CentOS 7 Official Signing Key) <security@centos.org>" Fingerprint: 6341 ab27 53d7 8a78 a7c2 7bb1 24c6 a8a7 f4a8 0eb5 Package : centos-release-7-6.1810.2.el7.centos.x86_64 (@CentOS) From : /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
8/11/2019, 3:59:28 AMRunning transaction check
8/11/2019, 3:59:28 AMRunning transaction test
8/11/2019, 3:59:28 AMTransaction test succeeded
8/11/2019, 3:59:28 AMRunning transaction
8/11/2019, 3:59:28 AM Installing : epel-release-7-11.noarch 1/1
8/11/2019, 3:59:28 AM Verifying : epel-release-7-11.noarch 1/1
8/11/2019, 3:59:28 AM Installed: epel-release.noarch 0:7-11
8/11/2019, 3:59:28 AMComplete!
8/11/2019, 3:59:36 AMhttps://ewr.edge.kernel.org/fedora-buffet/epel/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml does not match metalink for epel
8/11/2019, 3:59:36 AMTrying other mirror.
8/11/2019, 3:59:36 AMhttp://mirror.metrocast.net/fedora/epel/7/x86_64/repodata/7c1d7dbe8cd46ace6115206471fe9cfa1aedf1fd296b162dc103167f7d3ce381-primary.sqlite.bz2: [Errno 14] HTTP Error 404 - Not Found
8/11/2019, 3:59:36 AMTrying other mirror. To address this issue please refer to the below wiki article https://wiki.centos.org/yum-errors If above article doesn't help to resolve this issue please use https://bugs.centos.org/.
8/11/2019, 3:59:36 AMhttp://mirror.math.princeton.edu/pub/epel/7/x86_64/repodata/b2eaf4baa8f8f00c904d2d3fc0012d89fd2d0a43de7cc99ac1be47f05c31b121-updateinfo.xml.bz2: [Errno 14] HTTP Error 404 - Not Found
8/11/2019, 3:59:36 AMTrying other mirror.
8/11/2019, 3:59:37 AMhttps://mirror.steadfastnet.com/epel/7/x86_64/repodata/b2eaf4baa8f8f00c904d2d3fc0012d89fd2d0a43de7cc99ac1be47f05c31b121-updateinfo.xml.bz2: [Errno 14] HTTPS Error 404 - Not Found
8/11/2019, 3:59:37 AMTrying other mirror.
8/11/2019, 3:59:41 AMPackage 1:findutils-4.5.11-6.el7.x86_64 already installed and latest version
8/11/2019, 3:59:41 AMPackage procps-ng-3.3.10-23.el7.x86_64 already installed and latest version
8/11/2019, 3:59:41 AMPackage 2:tar-1.26-35.el7.x86_64 already installed and latest version
8/11/2019, 3:59:41 AMError: Package: python36-virtualenv-15.1.0-4.el7.noarch (epel) Requires: python(abi) = 3.6 Installed: python-2.7.5-76.el7.x86_64 (@CentOS) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-77.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-80.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python34-3.4.10-2.el7.x86_64 (epel) python(abi) = 3.4
8/11/2019, 3:59:41 AMError: Package: python36-setuptools-39.2.0-3.el7.noarch (epel) Requires: python(abi) = 3.6 Installed: python-2.7.5-76.el7.x86_64 (@CentOS) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-77.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-80.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python34-3.4.10-2.el7.x86_64 (epel) python(abi) = 3.4 Error: Package: python36-PyYAML-3.12-1.el7.x86_64 (epel) Requires: python(abi) = 3.6 Installed: python-2.7.5-76.el7.x86_64 (@CentOS) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-77.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-80.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python34-3.4.10-2.el7.x86_64 (epel) python(abi) = 3.4
8/11/2019, 3:59:41 AMError: Package: python36-pathspec-0.5.3-2.el7.noarch (epel) Requires: python(abi) = 3.6 Installed: python-2.7.5-76.el7.x86_64 (@CentOS) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-77.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-80.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python34-3.4.10-2.el7.x86_64 (epel) python(abi) = 3.4
8/11/2019, 3:59:41 AMError: Package: yamllint-1.16.0-1.el7.noarch (epel) Requires: python(abi) = 3.6 Installed: python-2.7.5-76.el7.x86_64 (@CentOS) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-77.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python-2.7.5-80.el7_6.x86_64 (updates) python(abi) = 2.7 python(abi) = 2.7 Available: python34-3.4.10-2.el7.x86_64 (epel) python(abi) = 3.4
8/11/2019, 3:59:41 AMError: Package: python36-PyYAML-3.12-1.el7.x86_64 (epel) Requires: libpython3.6m.so.1.0()(64bit)
8/11/2019, 3:59:41 AMError: Package: python36-setuptools-39.2.0-3.el7.noarch (epel) Requires: /usr/bin/python3.6
8/11/2019, 3:59:41 AMError: Package: python36-virtualenv-15.1.0-4.el7.noarch (epel) Requires: /usr/bin/python3.6
8/11/2019, 3:59:41 AMError: Package: yamllint-1.16.0-1.el7.noarch (epel) Requires: /usr/bin/python3.6
8/11/2019, 3:59:41 AMError: Package: python36-virtualenv-15.1.0-4.el7.noarch (epel) Requires: python36-devel
```