### PR TITLE
Add mountPathPrefix spec field in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ spec:
     resourceVersion: v1alpha1
     resourceRef: db-demo
   mountPathPrefix: “”
-
 EOS
 ```
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ spec:
     resourceKind: postgresql.baiju.dev
     resourceVersion: v1alpha1
     resourceRef: db-demo
+  mountPathPrefix: “”
+
 EOS
 ```
 


### PR DESCRIPTION
**Why**
Creation of `ServiceBindingRequest` requires `mountPathPrefix` field to be added in the spec.