### PR TITLE
Add lint back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GIT_COMMITTER_NAME devtools
 ENV GIT_COMMITTER_EMAIL devtools@redhat.com
 
 RUN yum install epel-release -y \
-    && yum install --skip-broken --enablerepo=centosplus install -y --quiet \
+    && yum install --enablerepo=centosplus install -y --quiet \
     findutils \
     git \
     make \

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ PULL_NUMBER := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].pulls[0].number')
 
 .PHONY: lint
 ## Runs linters on Go code files and YAML files - DISABLED TEMPORARILY
-lint: #setup-venv lint-go-code lint-yaml courier
+lint: setup-venv lint-go-code lint-yaml courier
 
 YAML_FILES := $(shell find . -path ./vendor -prune -o -type f -regex ".*y[a]ml" -print)
 .PHONY: lint-yaml

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -7,7 +7,7 @@ ENV GIT_COMMITTER_NAME devtools
 ENV GIT_COMMITTER_EMAIL devtools@redhat.com
 
 RUN yum install epel-release -y \
-    && yum install --skip-broken --enablerepo=centosplus install -y --quiet \
+    && yum install --enablerepo=centosplus install -y --quiet \
     findutils \
     git \
     make \


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1739804
- Pushed branch to redhat-developer/.. so that it triggers a build on https://quay.io/repository/redhat-developer/app-binding-operator/build which is driven from the `/Dockerfile`