### PR TITLE
Make the annotations shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ statusDescriptors:
     path: dbCredentials
     x-descriptors:
       - urn:alm:descriptor:io.kubernetes:Secret
-      - urn:alm:descriptor:servicebindingrequest:env:object:secret:user
-      - urn:alm:descriptor:servicebindingrequest:env:object:secret:password
+      - binding:env:object:secret:user
+      - binding:env:object:secret:password
   description: Database connection IP address
     displayName: DB IP address
     path: dbConnectionIP
     x-descriptors:
-      - urn:alm:descriptor:servicebindingrequest:env:attribute
+      - binding:env:attribute
 ```
 
 ## Quick Start

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -26,11 +26,11 @@ type Retriever struct {
 }
 
 const (
-	basePrefix              = "urn:alm:descriptor:servicebindingrequest:env:object"
+	basePrefix              = "binding:env:object"
 	secretPrefix            = basePrefix + ":secret"
 	configMapPrefix         = basePrefix + ":configmap"
-	attributePrefix         = "urn:alm:descriptor:servicebindingrequest:env:attribute"
-	volumeMountSecretPrefix = "urn:alm:descriptor:servicebindingrequest:volumemount:secret"
+	attributePrefix         = "binding:env:attribute"
+	volumeMountSecretPrefix = "binding:volumemount:secret"
 )
 
 // getNestedValue retrieve value from dotted key path

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -56,8 +56,8 @@ func TestRetriever(t *testing.T) {
 	t.Run("read", func(t *testing.T) {
 		// reading from secret, from status attribute
 		err := retriever.read("status", "dbCredentials", []string{
-			"urn:alm:descriptor:servicebindingrequest:env:object:secret:user",
-			"urn:alm:descriptor:servicebindingrequest:env:object:secret:password",
+			"binding:env:object:secret:user",
+			"binding:env:object:secret:password",
 		})
 		assert.Nil(t, err)
 
@@ -67,7 +67,7 @@ func TestRetriever(t *testing.T) {
 
 		// reading from spec attribute
 		err = retriever.read("spec", "image", []string{
-			"urn:alm:descriptor:servicebindingrequest:env:attribute",
+			"binding:env:attribute",
 		})
 		assert.Nil(t, err)
 
@@ -78,7 +78,7 @@ func TestRetriever(t *testing.T) {
 
 	t.Run("extractSecretItemName", func(t *testing.T) {
 		assert.Equal(t, "user", retriever.extractSecretItemName(
-			"urn:alm:descriptor:servicebindingrequest:env:object:secret:user"))
+			"binding:env:object:secret:user"))
 	})
 
 	t.Run("readSecret", func(t *testing.T) {
@@ -193,8 +193,8 @@ func TestConfigMapRetriever(t *testing.T) {
 
 		// reading from configMap, from status attribute
 		err = retriever.read("spec", "dbConfigMap", []string{
-			"urn:alm:descriptor:servicebindingrequest:env:object:configmap:user",
-			"urn:alm:descriptor:servicebindingrequest:env:object:configmap:password",
+			"binding:env:object:configmap:user",
+			"binding:env:object:configmap:password",
 		})
 		assert.Nil(t, err)
 
@@ -205,7 +205,7 @@ func TestConfigMapRetriever(t *testing.T) {
 
 	t.Run("extractConfigMapItemName", func(t *testing.T) {
 		assert.Equal(t, "user", retriever.extractConfigMapItemName(
-			"urn:alm:descriptor:servicebindingrequest:env:object:configmap:user"))
+			"binding:env:object:configmap:user"))
 	})
 
 	t.Run("readConfigMap", func(t *testing.T) {

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -31,7 +31,7 @@ var (
 		DisplayName:  "Database Name",
 		Description:  "Database Name",
 		Path:         "dbName",
-		XDescriptors: []string{"urn:alm:descriptor:servicebindingrequest:env:attribute"},
+		XDescriptors: []string{"binding:env:attribute"},
 	}
 	// DBConfigMapSpecDesc spec descriptor to describe a operator that export username and password
 	// via config-map, instead of a usual secret.
@@ -41,8 +41,8 @@ var (
 		Path:        "dbConfigMap",
 		XDescriptors: []string{
 			"urn:alm:descriptor:io.kubernetes:ConfigMap",
-			"urn:alm:descriptor:servicebindingrequest:env:object:configmap:user",
-			"urn:alm:descriptor:servicebindingrequest:env:object:configmap:password",
+			"binding:env:object:configmap:user",
+			"binding:env:object:configmap:password",
 		},
 	}
 	// DBPasswordCredentialsOnEnvStatusDesc status descriptor to describe a database operator that
@@ -53,8 +53,8 @@ var (
 		Path:        "dbCredentials",
 		XDescriptors: []string{
 			"urn:alm:descriptor:io.kubernetes:Secret",
-			"urn:alm:descriptor:servicebindingrequest:env:object:secret:user",
-			"urn:alm:descriptor:servicebindingrequest:env:object:secret:password",
+			"binding:env:object:secret:user",
+			"binding:env:object:secret:password",
 		},
 	}
 	// DBPasswordCredentialsOnVolumeMountStatusDesc status descriptor to describe a operator that
@@ -65,8 +65,8 @@ var (
 		Path:        "dbCredentials",
 		XDescriptors: []string{
 			"urn:alm:descriptor:io.kubernetes:Secret",
-			"urn:alm:descriptor:servicebindingrequest:volumemount:secret:user",
-			"urn:alm:descriptor:servicebindingrequest:volumemount:secret:password",
+			"binding:volumemount:secret:user",
+			"binding:volumemount:secret:password",
 		},
 	}
 )


### PR DESCRIPTION
This was a feedback we received from Jessica during an API review. We don't really need the long strings.