### PR TITLE
Add OPTIONAL triggerRebinding field in the Spec

### DIFF
--- a/deploy/crds/apps_v1alpha1_servicebindingrequest_crd.yaml
+++ b/deploy/crds/apps_v1alpha1_servicebindingrequest_crd.yaml
@@ -74,7 +74,7 @@ spec:
               type: string
             triggerRebinding:
               description: TriggerRebinding forcefully triggers a binding operation
-                if it the event for the same was missed for some reason
+                if the event for the same was missed for some reason
               type: boolean
           required:
           - backingServiceSelector

--- a/deploy/crds/apps_v1alpha1_servicebindingrequest_crd.yaml
+++ b/deploy/crds/apps_v1alpha1_servicebindingrequest_crd.yaml
@@ -72,6 +72,10 @@ spec:
             mountPathPrefix:
               description: MountPathPrefix is the prefix for volume mount
               type: string
+            triggerRebinding:
+              description: TriggerRebinding forcefully triggers a binding operation
+                if it the event for the same was missed for some reason
+              type: boolean
           required:
           - backingServiceSelector
           - applicationSelector

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -27,7 +27,7 @@ type ServiceBindingRequestSpec struct {
 	// backing service operator.
 	ApplicationSelector ApplicationSelector `json:"applicationSelector"`
 
-	// TriggerRebinding forcefully triggers a binding operation if it the event
+	// TriggerRebinding forcefully triggers a binding operation if the event
 	// for the same was missed for some reason
 	TriggerRebinding *bool `json:"triggerRebinding,omitempty"`
 }

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -26,6 +26,10 @@ type ServiceBindingRequestSpec struct {
 	// ApplicationSelector is used to identify the application connecting to the
 	// backing service operator.
 	ApplicationSelector ApplicationSelector `json:"applicationSelector"`
+
+	// TriggerRebinding forcefully triggers a binding operation if it the event
+	// for the same was missed for some reason
+	TriggerRebinding *bool `json:"triggerRebinding,omitempty"`
 }
 
 // ServiceBindingRequestStatus defines the observed state of ServiceBindingRequest

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -113,6 +113,11 @@ func (in *ServiceBindingRequestSpec) DeepCopyInto(out *ServiceBindingRequestSpec
 	*out = *in
 	out.BackingServiceSelector = in.BackingServiceSelector
 	in.ApplicationSelector.DeepCopyInto(&out.ApplicationSelector)
+	if in.TriggerRebinding != nil {
+		in, out := &in.TriggerRebinding, &out.TriggerRebinding
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
@@ -177,6 +177,13 @@ func schema_pkg_apis_apps_v1alpha1_ServiceBindingRequestSpec(ref common.Referenc
 							Ref:         ref("./pkg/apis/apps/v1alpha1.ApplicationSelector"),
 						},
 					},
+					"triggerRebinding": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TriggerRebinding forcefully triggers a binding operation if it the event for the same was missed for some reason",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"backingServiceSelector", "applicationSelector"},
 			},

--- a/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
@@ -179,7 +179,7 @@ func schema_pkg_apis_apps_v1alpha1_ServiceBindingRequestSpec(ref common.Referenc
 					},
 					"triggerRebinding": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TriggerRebinding forcefully triggers a binding operation if it the event for the same was missed for some reason",
+							Description: "TriggerRebinding forcefully triggers a binding operation if the event for the same was missed for some reason",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/controller/servicebindingrequest/common.go
+++ b/pkg/controller/servicebindingrequest/common.go
@@ -7,6 +7,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// ServiceBindingRequestKind defines the name of the CRD Kind.
+const ServiceBindingRequestKind = "ServiceBindingRequest"
+
 // RequeueOnNotFound inspect error, if not-found then returns Requeue, otherwise expose the error.
 func RequeueOnNotFound(err error, requeueAfter int64) (reconcile.Result, error) {
 	if errors.IsNotFound(err) {

--- a/pkg/controller/servicebindingrequest/controller.go
+++ b/pkg/controller/servicebindingrequest/controller.go
@@ -51,8 +51,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 				// we shall ignore it to avoid an infinite loop.
 				if newSBR.Spec.TriggerRebinding != nil &&
 					oldSBR.Spec.TriggerRebinding != nil &&
-					*newSBR.Spec.TriggerRebinding == false &&
-					*oldSBR.Spec.TriggerRebinding == true {
+					!*newSBR.Spec.TriggerRebinding &&
+					*oldSBR.Spec.TriggerRebinding {
 					return false
 				}
 			}

--- a/pkg/controller/servicebindingrequest/controller.go
+++ b/pkg/controller/servicebindingrequest/controller.go
@@ -47,9 +47,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 				oldSBR := e.ObjectOld.(*v1alpha1.ServiceBindingRequest)
 				newSBR := e.ObjectNew.(*v1alpha1.ServiceBindingRequest)
 
-				// if event was triggered as part of
-				// resetting TriggerRebinding True to False,
-				// we shall ignore it.
+				// if event was triggered as part of resetting TriggerRebinding True to False,
+				// we shall ignore it to avoid an infinite loop.
 				if newSBR.Spec.TriggerRebinding != nil &&
 					oldSBR.Spec.TriggerRebinding != nil &&
 					*newSBR.Spec.TriggerRebinding == false &&

--- a/pkg/controller/servicebindingrequest/controller.go
+++ b/pkg/controller/servicebindingrequest/controller.go
@@ -43,7 +43,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	pred := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 
-			if e.ObjectOld.DeepCopyObject().GetObjectKind().GroupVersionKind().Kind == "ServiceBindingRequest" {
+			if e.ObjectOld.DeepCopyObject().GetObjectKind().GroupVersionKind().Kind == ServiceBindingRequestKind {
 				oldSBR := e.ObjectOld.(*v1alpha1.ServiceBindingRequest)
 				newSBR := e.ObjectNew.(*v1alpha1.ServiceBindingRequest)
 

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -57,7 +57,7 @@ func (r *Reconciler) setTriggerRebindingFlag(
 	ctx context.Context,
 	instance *v1alpha1.ServiceBindingRequest,
 ) error {
-	if instance.Spec.TriggerRebinding != nil && *instance.Spec.TriggerRebinding == true {
+	if instance.Spec.TriggerRebinding != nil && *instance.Spec.TriggerRebinding {
 		newValue := false
 		instance.Spec.TriggerRebinding = &newValue
 		return r.client.Update(ctx, instance)
@@ -103,7 +103,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// As long the request was handled, we update the TriggerRebind
-	r.setTriggerRebindingFlag(ctx, instance)
+	err = r.setTriggerRebindingFlag(ctx, instance)
+	if err != nil {
+		return RequeueError(err)
+	}
 
 	logger = logger.WithValues("ServiceBindingRequest.Name", instance.Name)
 	logger.Info("Found service binding request to inspect")

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -52,13 +52,12 @@ func (r *Reconciler) setStatus(
 	return r.client.Status().Update(ctx, instance)
 }
 
-// setStatus update the CR status field.
+// setStatus always updates the TriggerRebindingFlag field to False, if present
 func (r *Reconciler) setTriggerRebindingFlag(
 	ctx context.Context,
 	instance *v1alpha1.ServiceBindingRequest,
-	currentValue *bool,
 ) error {
-	if currentValue != nil && *currentValue == true {
+	if instance.Spec.TriggerRebinding != nil && *instance.Spec.TriggerRebinding == true {
 		newValue := false
 		instance.Spec.TriggerRebinding = &newValue
 		return r.client.Update(ctx, instance)
@@ -104,7 +103,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// As long the request was handled, we update the TriggerRebind
-	r.setTriggerRebindingFlag(ctx, instance, instance.Spec.TriggerRebinding)
+	r.setTriggerRebindingFlag(ctx, instance)
 
 	logger = logger.WithValues("ServiceBindingRequest.Name", instance.Name)
 	logger.Info("Found service binding request to inspect")

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -2,7 +2,6 @@ package servicebindingrequest
 
 import (
 	"context"
-	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -60,7 +59,6 @@ func (r *Reconciler) setTriggerRebindingFlag(
 	currentValue *bool,
 ) error {
 	if currentValue != nil && *currentValue == true {
-		fmt.Println("TRUEEEEEE")
 		newValue := false
 		instance.Spec.TriggerRebinding = &newValue
 		return r.client.Update(ctx, instance)

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -79,6 +79,88 @@ func TestReconcilerReconcileUsingSecret(t *testing.T) {
 	})
 }
 
+// TestReconcilerForForcedTriggeringOfBinding test the reconciliation process using a secret,
+// and using TriggerRebind = true, false
+func TestReconcilerForForcedTriggeringOfBinding(t *testing.T) {
+	ctx := context.TODO()
+	resourceRef := "test-for-forced-trigger"
+	matchLabels := map[string]string{
+		"connects-to": "database",
+		"environment": "reconciler",
+	}
+
+	f := mocks.NewFake(t, reconcilerNs)
+	f.AddMockedServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
+
+	f.AddMockedUnstructuredCSV("cluster-service-version-list-forced-trigger")
+	f.AddMockedDatabaseCRList(resourceRef)
+	f.AddMockedUnstructuredDeployment(reconcilerName, matchLabels)
+	f.AddMockedSecret("db-credentials")
+
+	fakeClient := f.FakeClient()
+	reconciler := &Reconciler{client: fakeClient, dynClient: f.FakeDynClient(), scheme: f.S}
+
+	t.Run("reconcile-using-trigger-starting-with-true", func(t *testing.T) {
+
+		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+		sbrOutput := v1alpha1.ServiceBindingRequest{}
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbrOutput))
+
+		triggertrue := true
+
+		sbrOutput.Spec.TriggerRebinding = &triggertrue
+
+		// set to True and reconcile
+		require.NoError(t, fakeClient.Update(ctx, &sbrOutput))
+
+		res, err := reconciler.Reconcile(reconcileRequest())
+		assert.Nil(t, err)
+		assert.False(t, res.Requeue)
+
+		d := appsv1.Deployment{}
+		require.Nil(t, fakeClient.Get(ctx, namespacedName, &d))
+
+		containers := d.Spec.Template.Spec.Containers
+		assert.Equal(t, reconcilerName, containers[0].EnvFrom[0].SecretRef.Name)
+
+		sbrOutput = v1alpha1.ServiceBindingRequest{}
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbrOutput))
+
+		// If TRUE was set, this will become FALSE
+		require.False(t, *sbrOutput.Spec.TriggerRebinding)
+	})
+
+	t.Run("reconcile-using-trigger-starting-with-false", func(t *testing.T) {
+
+		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+		sbrOutput := v1alpha1.ServiceBindingRequest{}
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbrOutput))
+
+		triggerfalse := false
+
+		sbrOutput.Spec.TriggerRebinding = &triggerfalse
+
+		// set to False and reconcile
+		require.NoError(t, fakeClient.Update(ctx, &sbrOutput))
+
+		res, err := reconciler.Reconcile(reconcileRequest())
+		assert.Nil(t, err)
+		assert.False(t, res.Requeue)
+
+		d := appsv1.Deployment{}
+		require.Nil(t, fakeClient.Get(ctx, namespacedName, &d))
+
+		containers := d.Spec.Template.Spec.Containers
+		assert.Equal(t, reconcilerName, containers[0].EnvFrom[0].SecretRef.Name)
+
+		sbrOutput = v1alpha1.ServiceBindingRequest{}
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbrOutput))
+
+		// If FALSE was set, this will stay FALSE
+		require.False(t, *sbrOutput.Spec.TriggerRebinding)
+	})
+}
+
 func TestReconcilerReconcileUsingVolumes(t *testing.T) {
 	ctx := context.TODO()
 	resourceRef := "test-using-volumes"

--- a/pkg/controller/servicebindingrequest/reconciler_whitebox_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_whitebox_test.go
@@ -1,0 +1,66 @@
+package servicebindingrequest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/test/mocks"
+)
+
+func init() {
+	logf.SetLogger(logf.ZapLogger(true))
+}
+
+func TestSetRetriggerBinding(t *testing.T) {
+	ctx := context.TODO()
+	resourceRef := "test-retrigger"
+	matchLabels := map[string]string{
+		"connects-to": "database",
+		"environment": "reconciler",
+	}
+
+	f := mocks.NewFake(t, reconcilerNs)
+
+	f.AddMockedServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
+	fakeClient := f.FakeClient()
+
+	t.Run("reconcile-using-trigger-binding", func(t *testing.T) {
+		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+		sbr := v1alpha1.ServiceBindingRequest{}
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
+
+		reconciler := &Reconciler{client: fakeClient, dynClient: f.FakeDynClient(), scheme: f.S}
+		reconciler.setTriggerRebindingFlag(ctx, &sbr)
+
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
+
+		// If nothing was set initially, nothing will be set.
+		require.Nil(t, sbr.Spec.TriggerRebinding)
+
+		// lets as True initially and see what happens
+		triggerTrue := true
+		sbr.Spec.TriggerRebinding = &triggerTrue
+		require.NoError(t, fakeClient.Update(ctx, &sbr))
+
+		reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
+		require.False(t, *sbr.Spec.TriggerRebinding)
+
+		// lets as False initially and see what happens
+		triggerFalse := false
+		sbr.Spec.TriggerRebinding = &triggerFalse
+		require.NoError(t, fakeClient.Update(ctx, &sbr))
+
+		reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
+
+		// remains false
+		require.False(t, *sbr.Spec.TriggerRebinding)
+
+	})
+}

--- a/pkg/controller/servicebindingrequest/reconciler_whitebox_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_whitebox_test.go
@@ -35,7 +35,8 @@ func TestSetRetriggerBinding(t *testing.T) {
 		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
 
 		reconciler := &Reconciler{client: fakeClient, dynClient: f.FakeDynClient(), scheme: f.S}
-		reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		err := reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		require.NoError(t, err)
 
 		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
 
@@ -47,7 +48,8 @@ func TestSetRetriggerBinding(t *testing.T) {
 		sbr.Spec.TriggerRebinding = &triggerTrue
 		require.NoError(t, fakeClient.Update(ctx, &sbr))
 
-		reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		err = reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		require.NoError(t, err)
 		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
 		require.False(t, *sbr.Spec.TriggerRebinding)
 
@@ -56,7 +58,8 @@ func TestSetRetriggerBinding(t *testing.T) {
 		sbr.Spec.TriggerRebinding = &triggerFalse
 		require.NoError(t, fakeClient.Update(ctx, &sbr))
 
-		reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		err = reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		require.NoError(t, err)
 		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
 
 		// remains false


### PR DESCRIPTION
- If the user updated the CR to have a `triggerRebinding` to true, a reconcile is triggered where the value is set to`false`. 
- The predicate takes care of rejecting the event if the event was generated because `triggerRebinding` was set from `false` to `true`.

In no scenario, does the controller never set it to `true`.

```
apiVersion: apps.openshift.io/v1alpha1
kind: ServiceBindingRequest
metadata:
  name: binding-request
  namespace: sbose
spec:
  applicationSelector:
    matchLabels:
      connects-to: postgres
      environment: demo
    group: apps.openshift.io
    version: v1
    resource: deploymentconfigs
  triggerRebinding: true
  backingServiceSelector:
    group: postgresql.baiju.dev
    kind: Database
    version: v1alpha1
    resourceRef: demo-database
```

This would come handy when custom resources not owned by the operator are watched.