### PR TITLE
Watch all registered CRDs on startup and reboot if needed

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -47,8 +47,10 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - ""
+  - "*"
   resources:
   - "*"
   verbs:
     - "get"
+    - "list"
+    - "watch"

--- a/pkg/controller/servicebindingrequest/controller.go
+++ b/pkg/controller/servicebindingrequest/controller.go
@@ -1,7 +1,19 @@
 package servicebindingrequest
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	scheme "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -13,6 +25,8 @@ import (
 	v1alpha1 "github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 )
 
+var watchedOperators []string
+
 // Add creates a new ServiceBindingRequest Controller and adds it to the Manager. The Manager will
 // set fields on the Controller and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -20,11 +34,11 @@ func Add(mgr manager.Manager) error {
 	if err != nil {
 		return err
 	}
-	return add(mgr, r)
+	return add(mgr, r, r.handleCRDChange, r.handleCSVChange)
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
+func newReconciler(mgr manager.Manager) (*Reconciler, error) {
 	dynClient, err := dynamic.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		return nil, err
@@ -33,7 +47,7 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, r reconcile.Reconciler, crdHandler handler.ToRequestsFunc, csvHandler handler.ToRequestsFunc) error {
 	// Create a new controller
 	c, err := controller.New("servicebindingrequest-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -57,7 +71,173 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	err = addWatchesToKnownCRDs(mgr, r, crdHandler, c)
+	if err != nil {
+		return err
+	}
+
+	err = addWatchToCSVList(mgr, r, csvHandler, c)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func addWatchToCSVList(mgr manager.Manager, r reconcile.Reconciler, crdHandler handler.ToRequestsFunc, c controller.Controller) error {
+
+	predicateForFilteringCSV := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+	}
+
+	olmGVR := schema.GroupVersionKind{
+		Group:   olmv1alpha1.GroupName,
+		Version: olmv1alpha1.GroupVersion,
+		Kind:    "ClusterServiceVersion",
+	}
+
+	objRuntime, _ := scheme.NewUnstructuredCreator().New(olmGVR)
+	handlerCRD := &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: crdHandler,
+	}
+	fmt.Println("Adding a watch on " + olmGVR.String())
+	return c.Watch(&source.Kind{Type: objRuntime}, handlerCRD, predicateForFilteringCSV)
+
+}
+
+func addWatchesToKnownCRDs(mgr manager.Manager, r reconcile.Reconciler, crdHandler handler.ToRequestsFunc, c controller.Controller) error {
+
+	olmGVR := schema.GroupVersionResource{
+		Group:    olmv1alpha1.GroupName,
+		Version:  olmv1alpha1.GroupVersion,
+		Resource: "clusterserviceversions",
+	}
+
+	// Create a dynamic client to fetch all CSVs
+	dynClient, err := dynamic.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return err
+	}
+
+	// Get all CSVs into an Unstructured List
+	allCSV, err := dynClient.Resource(olmGVR).Namespace("").List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, csv := range allCSV.Items {
+
+		// Convert each Unstructured item into a CSV
+		typedCSV := olmv1alpha1.ClusterServiceVersion{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(csv.Object, &typedCSV)
+		if err != nil {
+			return err
+		}
+
+		if !isOperatorCRDsBeingWatched(typedCSV.GetName()) {
+			watchedOperators = append(watchedOperators, typedCSV.Name)
+
+			// For each CSV, iterate through all OWNED CRDs
+			for _, crd := range typedCSV.Spec.CustomResourceDefinitions.Owned {
+
+				err = watchCRD(crd, crdHandler, c)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
 	return nil
+}
+
+func watchCRD(crd olmv1alpha1.CRDDescription, crdHandler handler.ToRequestsFunc, c controller.Controller) error {
+
+	// a bit messy, needs cleanup
+	rsrc := strings.Split(crd.Name, ".")[0]
+
+	grp := strings.Split(crd.Name, rsrc+".")
+	fmt.Println(grp[1])
+
+	gvk := schema.GroupVersionKind{
+		Group:   grp[1],
+		Version: crd.Version,
+		Kind:    crd.Kind,
+	}
+
+	objRuntime, _ := scheme.NewUnstructuredCreator().New(gvk)
+	handlerCRD := &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: crdHandler,
+	}
+	fmt.Println("Adding a watch on " + gvk.String())
+	return c.Watch(&source.Kind{Type: objRuntime}, handlerCRD)
+}
+
+func isOperatorCRDsBeingWatched(i string) bool {
+
+	present := false
+	for _, ele := range watchedOperators {
+		if ele == i {
+			present = true
+		}
+	}
+	return present
+
+}
+
+func (r *Reconciler) handleCRDChange(o handler.MapObject) []reconcile.Request {
+	var result []reconcile.Request
+
+	sbr := &v1alpha1.ServiceBindingRequestList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceBindingRequest",
+			APIVersion: "apps.openshift.io/v1alpha1",
+		},
+	}
+
+	// Get all ServiceBindingRequests
+	currentNamespace := &client.ListOptions{Namespace: o.Meta.GetNamespace()}
+	if err := r.client.List(context.TODO(), currentNamespace, sbr); err != nil {
+		return result
+	}
+
+	// If any of the SBRs consume this CR, then we need
+	// to trigger reconcile for that SBR.
+	for _, sbr := range sbr.Items {
+
+		if sbr.Spec.BackingServiceSelector.ResourceRef == o.Meta.GetName() &&
+			sbr.Spec.BackingServiceSelector.Kind == o.Object.GetObjectKind().GroupVersionKind().Kind {
+			// could check group and version as well.
+
+			result = append(result, reconcile.Request{
+				NamespacedName: client.ObjectKey{Namespace: sbr.Namespace, Name: sbr.Name}})
+		}
+	}
+	return result
+
+}
+
+func (r *Reconciler) handleCSVChange(o handler.MapObject) []reconcile.Request {
+	var result []reconcile.Request
+
+	// A new CSV doesn't necessarily imply that a new operator has been installed.
+	// When a new namespace is created, CVSs are copied over to the new
+	// namespace.
+	if isOperatorCRDsBeingWatched(o.Meta.GetName()) {
+		// This operator's CRDs are already being watched, Do nothing.
+		return result
+	}
+	// Control comes here if there's a new operator - so kill the container
+	// The Pod controller will create a new one anyway.
+	os.Exit(0)
+	return result
 }
 
 // blank assignment to verify that ReconcileServiceBindingRequest implements reconcile.Reconciler

--- a/pkg/controller/servicebindingrequest/controller.go
+++ b/pkg/controller/servicebindingrequest/controller.go
@@ -164,7 +164,6 @@ func watchCRD(crd olmv1alpha1.CRDDescription, crdHandler handler.ToRequestsFunc,
 	rsrc := strings.Split(crd.Name, ".")[0]
 
 	grp := strings.Split(crd.Name, rsrc+".")
-	fmt.Println(grp[1])
 
 	gvk := schema.GroupVersionKind{
 		Group:   grp[1],

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme/scheme.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme/scheme.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstructuredscheme
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+// NewUnstructuredNegotiatedSerializer returns a simple, negotiated serializer
+func NewUnstructuredNegotiatedSerializer() runtime.NegotiatedSerializer {
+	return unstructuredNegotiatedSerializer{
+		scheme:  scheme,
+		typer:   NewUnstructuredObjectTyper(),
+		creator: NewUnstructuredCreator(),
+	}
+}
+
+type unstructuredNegotiatedSerializer struct {
+	scheme  *runtime.Scheme
+	typer   runtime.ObjectTyper
+	creator runtime.ObjectCreater
+}
+
+func (s unstructuredNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, s.creator, s.typer, false),
+			PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, s.creator, s.typer, true),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, s.creator, s.typer, false),
+				Framer:        json.Framer,
+			},
+		},
+		{
+			MediaType:     "application/yaml",
+			EncodesAsText: true,
+			Serializer:    json.NewYAMLSerializer(json.DefaultMetaFactory, s.creator, s.typer),
+		},
+	}
+}
+
+func (s unstructuredNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(s.scheme, encoder, nil, gv, nil)
+}
+
+func (s unstructuredNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(s.scheme, nil, decoder, nil, gv)
+}
+
+type unstructuredObjectTyper struct {
+}
+
+// NewUnstructuredObjectTyper returns an object typer that can deal with unstructured things
+func NewUnstructuredObjectTyper() runtime.ObjectTyper {
+	return unstructuredObjectTyper{}
+}
+
+func (t unstructuredObjectTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	// Delegate for things other than Unstructured.
+	if _, ok := obj.(runtime.Unstructured); !ok {
+		return nil, false, fmt.Errorf("cannot type %T", obj)
+	}
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if len(gvk.Kind) == 0 {
+		return nil, false, runtime.NewMissingKindErr("object has no kind field ")
+	}
+	if len(gvk.Version) == 0 {
+		return nil, false, runtime.NewMissingVersionErr("object has no apiVersion field")
+	}
+
+	return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
+}
+
+func (t unstructuredObjectTyper) Recognizes(gvk schema.GroupVersionKind) bool {
+	return true
+}
+
+type unstructuredCreator struct{}
+
+// NewUnstructuredCreator returns a simple object creator that always returns an unstructured
+func NewUnstructuredCreator() runtime.ObjectCreater {
+	return unstructuredCreator{}
+}
+
+func (c unstructuredCreator) New(kind schema.GroupVersionKind) (runtime.Object, error) {
+	ret := &unstructured.Unstructured{}
+	ret.SetGroupVersionKind(kind)
+	return ret, nil
+}
+
+type unstructuredDefaulter struct {
+}
+
+// NewUnstructuredDefaulter returns defaulter suitable for unstructured types that doesn't default anything
+func NewUnstructuredDefaulter() runtime.ObjectDefaulter {
+	return unstructuredDefaulter{}
+}
+
+func (d unstructuredDefaulter) Default(in runtime.Object) {
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -370,6 +370,7 @@ k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
+k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/runtime/serializer
@@ -390,8 +391,8 @@ k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/apis/meta/v1beta1
-k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/runtime/serializer/versioning
+k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/service-binding-operator/issues/142


1. On Controller load, `watch`es are added for all existing operators/CRDs.

```
{"level":"info","ts":1566446390.970348,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"servicebindingrequest-controller","source":"kind source: /, Kind="}
app.lightbend.com
Adding a watch on app.lightbend.com/v1alpha1, Kind=AkkaCluster
{"level":"info","ts":1566446392.7945302,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"servicebindingrequest-controller","source":"kind source: app.lightbend.com/v1alpha1, Kind=AkkaCluster"}
atlasmap.io
Adding a watch on atlasmap.io/v1alpha1, Kind=AtlasMap
{"level":"info","ts":1566446392.7970872,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"servicebindingrequest-controller","source":"kind source: atlasmap.io/v1alpha1, Kind=AtlasMap"}
couchbase.com
Adding a watch on couchbase.com/v1, Kind=CouchbaseCluster
crunchydata.com
Adding a watch on crunchydata.com/v1, Kind=Pgcluster
crunchydata.com
Adding a watch on crunchydata.com/v1, Kind=Pgreplica
{"level":"info","ts":1566446392.7993212,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"servicebindingrequest-controller","source":"kind source: crunchydata.com/v1, Kind=Pgcluster"}
{"level":"info","ts":1566446392.799452,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"servicebindingrequest-controller","source":"kind source: crunchydata.com/v1, Kind=Pgreplica"}
crunchydata.com
Adding a watch on crunchydata.com/v1, Kind=Pgpolicy
crunchydata.com
Adding a watch on crunchydata.com/v1, Kind=Pgtask
crunchydata.com
Adding a watch on crunchydata.com/v1, Kind=Pgbackup
{"level":"info","ts":1566446392.7996802,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"servicebindingrequest-controller","source":"kind source: crunchydata.com/v1, Kind=Pgpolicy"}
{"level":"info","ts":1566446392.7998037,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"servicebindingrequest-controller","source":"kind source: crunchydata.com/v1, Kind=Pgtask"}
{"level":"info","ts":1566446392.7999172,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"servicebindingrequest-controller","source":"kind source: crunchydata.com/v1, Kind=Pgbackup"}
postgresql.baiju.dev
Adding a watch on postgresql.baiju.dev/v1alpha1, Kind=Database
{"level":"info","ts":1566446392.800366,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"servicebindingrequest-controller","source":"kind source: postgresql.baiju.dev/v1alpha1, Kind=Database"}
apps.3scale.net
```

2. Create a Database CR "db-demo" - event is received because a watch on Kind:Database was added on startup - but creation of "db-demo" doesn't trigger reconcile because there's no associated ServiceBindingRequest with it. 

3. Create a ServiceBindingRequest and watch a reconcile being triggered ✅ 

4. Modify the Database CR and viola! there's a reconcile triggered because in (3) we had created an SBR which referred to it. ✅ ( and in (1) a `watch` on `Kind:Database` was added.

5. Start tailing the logs by doing a `kubectl logs -f service-binding-operator-546967955b-wtf6w` 

6. Install a new operator from OperatorHub.

7. Notice that the log tailing terminates automatically - this is because on `watch`ing creation of a new clusterserviceversion ( aka operator ), the container quits `os.Exit(0)`, and automatically gets restarted.✅ 

8. On restart, the controller refreshes the list of operator/CRDs it was watching. Do a `kubectl logs -f service-binding-operator-546967955b-wtf6w` and see that the logs say that a `watch` for the new operator/CRD has been added. ✅ 