### PR TITLE
Catch All Controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ tags
 .vscode/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+### Intellij
+.idea

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -47,8 +47,10 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - ""
+  - "*"
   resources:
   - "*"
   verbs:
     - "get"
+    - "list"
+    - "watch"

--- a/pkg/controller/add_catchall.go
+++ b/pkg/controller/add_catchall.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/redhat-developer/service-binding-operator/pkg/controller/catchall"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, catchall.Add)
+}

--- a/pkg/controller/catchall/controller.go
+++ b/pkg/controller/catchall/controller.go
@@ -25,6 +25,8 @@ func add(mgr manager.Manager, r *CatchAllReconciler) error {
 		return err
 	}
 
+	// FIXME: create a predicate to make sure we only allow reconciliation of objects that are having
+	// service-binding-operator annotations.
 	for _, gvk := range getGVKs() {
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(gvk)
@@ -54,6 +56,7 @@ func newReconciler(mgr manager.Manager) (*CatchAllReconciler, error) {
 // TODO: this list should be fetched from K8S API-Server, and later apply a blacklist;
 func getGVKs() []schema.GroupVersionKind {
 	return []schema.GroupVersionKind{
-		{Group: "apps.openshift.io", Version: "v1alpha1", Kind: "ServiceBindingRequest"},
+		// {Group: "apps.openshift.io", Version: "v1alpha1", Kind: "ServiceBindingRequest"},
+		{Group: "", Version: "v1", Kind: "Secret"},
 	}
 }

--- a/pkg/controller/catchall/controller.go
+++ b/pkg/controller/catchall/controller.go
@@ -1,0 +1,78 @@
+package catchall
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	"time"
+)
+
+func Add(mgr manager.Manager) error {
+	r, err := newReconciler(mgr)
+	if err != nil {
+		return err
+	}
+	return add(mgr, r)
+}
+
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	c, err := controller.New("catchall-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	var listFunc cache.ListFunc
+	var watchFunc cache.WatchFunc
+
+	switch v := r.(type) {
+	// TODO: Check why CatchAllReconciler doesn't implement the right interface.
+	case CatchAllReconciler:
+		gvr := schema.GroupVersionResource{}
+		listFunc = asUnstructuredLister(v.DynClient.Resource(gvr).Namespace("").List)
+		watchFunc = asUnstructuredWatcher(v.DynClient.Resource(gvr).Namespace("").Watch)
+	default:
+		panic("WIP, r is not a CatchAllReconciler")
+	}
+
+	lw := &cache.ListWatch{
+		ListFunc:  listFunc,
+		WatchFunc: watchFunc,
+	}
+
+	resyncPeriod := 5 * time.Minute
+
+	informer := cache.NewSharedIndexInformer(
+		lw,
+		&unstructured.Unstructured{},
+		resyncPeriod,
+		nil,
+	)
+
+	err = c.Watch(
+		&source.Informer{Informer: informer},
+		nil,
+		nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
+	dynClient, err := dynamic.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	return &CatchAllReconciler{
+		Client:    mgr.GetClient(),
+		DynClient: dynClient,
+		Scheme:    mgr.GetScheme(),
+	}, nil
+}

--- a/pkg/controller/catchall/controller.go
+++ b/pkg/controller/catchall/controller.go
@@ -30,8 +30,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	var watchFunc cache.WatchFunc
 
 	switch v := r.(type) {
-	// TODO: Check why CatchAllReconciler doesn't implement the right interface.
-	case CatchAllReconciler:
+	case *CatchAllReconciler:
 		gvr := schema.GroupVersionResource{}
 		listFunc = asUnstructuredLister(v.DynClient.Resource(gvr).Namespace("").List)
 		watchFunc = asUnstructuredWatcher(v.DynClient.Resource(gvr).Namespace("").Watch)

--- a/pkg/controller/catchall/controller.go
+++ b/pkg/controller/catchall/controller.go
@@ -41,10 +41,7 @@ func add(mgr manager.Manager, r *CatchAllReconciler) error {
 			nil,
 		)
 
-		err = c.Watch(
-			&source.Informer{Informer: informer},
-			nil,
-			nil)
+		err = c.Watch(&source.Informer{Informer: informer}, &EnqueueRequestForUnstructured{})
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/catchall/eventhandler.go
+++ b/pkg/controller/catchall/eventhandler.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -15,11 +16,11 @@ type EnqueueRequestForUnstructured struct{}
 
 // TODO: Better name for this request
 type UnstructuredRequest struct {
-	NamespacedName                types.NamespacedName
+	reconcile.Request
 	ServiceBindingRequestSelector int
 }
 
-func getServiceBindingRequestSelector(object runtime.Object) (int, error) {
+func getServiceBindingRequestSelector(_ runtime.Object) (int, error) {
 	// TODO: Should figure out data structure to keep for the worker.
 	panic("implement me")
 }
@@ -38,9 +39,11 @@ func (e EnqueueRequestForUnstructured) Create(evt event.CreateEvent, q workqueue
 
 	q.Add(UnstructuredRequest{
 		ServiceBindingRequestSelector: sbrSelector,
-		NamespacedName: types.NamespacedName{
-			Name:      evt.Meta.GetName(),
-			Namespace: evt.Meta.GetNamespace(),
+		Request: reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      evt.Meta.GetName(),
+				Namespace: evt.Meta.GetNamespace(),
+			},
 		},
 	})
 }
@@ -55,9 +58,11 @@ func (e EnqueueRequestForUnstructured) Update(evt event.UpdateEvent, q workqueue
 	if evt.MetaOld != nil {
 		q.Add(UnstructuredRequest{
 			ServiceBindingRequestSelector: sbrSelector,
-			NamespacedName: types.NamespacedName{
-				Name:      evt.MetaOld.GetName(),
-				Namespace: evt.MetaOld.GetNamespace(),
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      evt.MetaOld.GetName(),
+					Namespace: evt.MetaOld.GetNamespace(),
+				},
 			},
 		})
 	} else {
@@ -67,9 +72,11 @@ func (e EnqueueRequestForUnstructured) Update(evt event.UpdateEvent, q workqueue
 	if evt.MetaNew != nil {
 		q.Add(UnstructuredRequest{
 			ServiceBindingRequestSelector: sbrSelector,
-			NamespacedName: types.NamespacedName{
-				Name:      evt.MetaNew.GetName(),
-				Namespace: evt.MetaNew.GetNamespace(),
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      evt.MetaNew.GetName(),
+					Namespace: evt.MetaNew.GetNamespace(),
+				},
 			},
 		})
 	} else {
@@ -91,9 +98,11 @@ func (e EnqueueRequestForUnstructured) Delete(evt event.DeleteEvent, q workqueue
 
 	q.Add(UnstructuredRequest{
 		ServiceBindingRequestSelector: sbrSelector,
-		NamespacedName: types.NamespacedName{
-			Name:      evt.Meta.GetName(),
-			Namespace: evt.Meta.GetNamespace(),
+		Request: reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      evt.Meta.GetName(),
+				Namespace: evt.Meta.GetNamespace(),
+			},
 		},
 	})
 }
@@ -112,9 +121,11 @@ func (e EnqueueRequestForUnstructured) Generic(evt event.GenericEvent, q workque
 
 	q.Add(UnstructuredRequest{
 		ServiceBindingRequestSelector: sbrSelector,
-		NamespacedName: types.NamespacedName{
-			Name:      evt.Meta.GetName(),
-			Namespace: evt.Meta.GetNamespace(),
+		Request: reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      evt.Meta.GetName(),
+				Namespace: evt.Meta.GetNamespace(),
+			},
 		},
 	})
 }

--- a/pkg/controller/catchall/eventhandler.go
+++ b/pkg/controller/catchall/eventhandler.go
@@ -2,6 +2,7 @@ package catchall
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -17,7 +18,8 @@ type EnqueueRequestForUnstructured struct{}
 
 func getServiceBindingRequestSelector(_ runtime.Object) (int, error) {
 	// TODO: Should figure out data structure to keep for the worker.
-	panic("implement me")
+	// panic("implement me")
+	return 1, nil
 }
 
 func composeNameWithSelector(name string, sbrSelector int) string {

--- a/pkg/controller/catchall/eventhandler.go
+++ b/pkg/controller/catchall/eventhandler.go
@@ -1,6 +1,7 @@
 package catchall
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -14,15 +15,17 @@ var enqueueLog = logf.KBLog.WithName("eventhandler").WithName("EnqueueRequestFor
 
 type EnqueueRequestForUnstructured struct{}
 
-// TODO: Better name for this request
-type UnstructuredRequest struct {
-	reconcile.Request
-	ServiceBindingRequestSelector int
-}
-
 func getServiceBindingRequestSelector(_ runtime.Object) (int, error) {
 	// TODO: Should figure out data structure to keep for the worker.
 	panic("implement me")
+}
+
+func composeNameWithSelector(name string, sbrSelector int) string {
+	return fmt.Sprintf("%s!%v", name, sbrSelector)
+}
+
+func getSelectorFromName(name string) int {
+	return 1
 }
 
 func (e EnqueueRequestForUnstructured) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
@@ -37,13 +40,10 @@ func (e EnqueueRequestForUnstructured) Create(evt event.CreateEvent, q workqueue
 		return
 	}
 
-	q.Add(UnstructuredRequest{
-		ServiceBindingRequestSelector: sbrSelector,
-		Request: reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      evt.Meta.GetName(),
-				Namespace: evt.Meta.GetNamespace(),
-			},
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      composeNameWithSelector(evt.Meta.GetName(), sbrSelector),
+			Namespace: evt.Meta.GetNamespace(),
 		},
 	})
 }
@@ -56,13 +56,10 @@ func (e EnqueueRequestForUnstructured) Update(evt event.UpdateEvent, q workqueue
 	}
 
 	if evt.MetaOld != nil {
-		q.Add(UnstructuredRequest{
-			ServiceBindingRequestSelector: sbrSelector,
-			Request: reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      evt.MetaOld.GetName(),
-					Namespace: evt.MetaOld.GetNamespace(),
-				},
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      composeNameWithSelector(evt.MetaOld.GetName(), sbrSelector),
+				Namespace: evt.MetaOld.GetNamespace(),
 			},
 		})
 	} else {
@@ -70,13 +67,10 @@ func (e EnqueueRequestForUnstructured) Update(evt event.UpdateEvent, q workqueue
 	}
 
 	if evt.MetaNew != nil {
-		q.Add(UnstructuredRequest{
-			ServiceBindingRequestSelector: sbrSelector,
-			Request: reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      evt.MetaNew.GetName(),
-					Namespace: evt.MetaNew.GetNamespace(),
-				},
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      composeNameWithSelector(evt.MetaNew.GetName(), sbrSelector),
+				Namespace: evt.MetaNew.GetNamespace(),
 			},
 		})
 	} else {
@@ -96,13 +90,10 @@ func (e EnqueueRequestForUnstructured) Delete(evt event.DeleteEvent, q workqueue
 		return
 	}
 
-	q.Add(UnstructuredRequest{
-		ServiceBindingRequestSelector: sbrSelector,
-		Request: reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      evt.Meta.GetName(),
-				Namespace: evt.Meta.GetNamespace(),
-			},
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      composeNameWithSelector(evt.Meta.GetName(), sbrSelector),
+			Namespace: evt.Meta.GetNamespace(),
 		},
 	})
 }
@@ -119,13 +110,10 @@ func (e EnqueueRequestForUnstructured) Generic(evt event.GenericEvent, q workque
 		return
 	}
 
-	q.Add(UnstructuredRequest{
-		ServiceBindingRequestSelector: sbrSelector,
-		Request: reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      evt.Meta.GetName(),
-				Namespace: evt.Meta.GetNamespace(),
-			},
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      composeNameWithSelector(evt.Meta.GetName(), sbrSelector),
+			Namespace: evt.Meta.GetNamespace(),
 		},
 	})
 }

--- a/pkg/controller/catchall/eventhandler.go
+++ b/pkg/controller/catchall/eventhandler.go
@@ -1,121 +1,66 @@
 package catchall
 
 import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/controller/common"
 )
 
-// TODO: Use the same log infrastructure as others
-var enqueueLog = logf.KBLog.WithName("eventhandler").WithName("EnqueueRequestForObject")
+var log = logf.KBLog.WithName("eventhandler").WithName("EnqueueRequestForObject")
 
 type EnqueueRequestForUnstructured struct{}
 
-func getServiceBindingRequestSelector(_ runtime.Object) (int, error) {
-	// TODO: Should figure out data structure to keep for the worker.
-	// panic("implement me")
-	return 1, nil
-}
-
-func composeNameWithSelector(name string, sbrSelector int) string {
-	return fmt.Sprintf("%s!%v", name, sbrSelector)
-}
-
-func getSelectorFromName(name string) int {
-	return 1
-}
-
 func (e EnqueueRequestForUnstructured) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
-	if evt.Meta == nil {
-		enqueueLog.Error(nil, "CreateEvent received with no metadata", "event", evt)
-		return
-	}
-
-	sbrSelector, err := getServiceBindingRequestSelector(evt.Object)
+	sbrSelector, err := common.GetSBRSelectorFromObject(evt.Object)
 	if err != nil {
-		enqueueLog.Error(err, "change me")
+		log.Error(err, "error on extracting SBR namespaced-name from annotations")
+		return
+	}
+	if common.IsSBRSelectorEmpty(sbrSelector) {
 		return
 	}
 
-	q.Add(reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      composeNameWithSelector(evt.Meta.GetName(), sbrSelector),
-			Namespace: evt.Meta.GetNamespace(),
-		},
-	})
+	q.Add(reconcile.Request{NamespacedName: sbrSelector})
 }
 
 func (e EnqueueRequestForUnstructured) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	sbrSelector, err := getServiceBindingRequestSelector(evt.ObjectNew)
+	sbrSelector, err := common.GetSBRSelectorFromObject(evt.ObjectNew)
 	if err != nil {
-		enqueueLog.Error(err, "change me")
+		log.Error(err, "error on extracting SBR namespaced-name from annotations")
+		return
+	}
+	if common.IsSBRSelectorEmpty(sbrSelector) {
 		return
 	}
 
-	if evt.MetaOld != nil {
-		q.Add(reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      composeNameWithSelector(evt.MetaOld.GetName(), sbrSelector),
-				Namespace: evt.MetaOld.GetNamespace(),
-			},
-		})
-	} else {
-		enqueueLog.Error(nil, "UpdateEvent received with no old metadata", "event", evt)
-	}
-
-	if evt.MetaNew != nil {
-		q.Add(reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      composeNameWithSelector(evt.MetaNew.GetName(), sbrSelector),
-				Namespace: evt.MetaNew.GetNamespace(),
-			},
-		})
-	} else {
-		enqueueLog.Error(nil, "UpdateEvent received with no new metadata", "event", evt)
-	}
+	q.Add(reconcile.Request{NamespacedName: sbrSelector})
 }
 
 func (e EnqueueRequestForUnstructured) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
-	sbrSelector, err := getServiceBindingRequestSelector(evt.Object)
+	sbrSelector, err := common.GetSBRSelectorFromObject(evt.Object)
 	if err != nil {
-		enqueueLog.Error(err, "change me")
+		log.Error(err, "error on extracting SBR namespaced-name from annotations")
+		return
+	}
+	if common.IsSBRSelectorEmpty(sbrSelector) {
 		return
 	}
 
-	if evt.Meta == nil {
-		enqueueLog.Error(nil, "DeleteEvent received with no metadata", "event", evt)
-		return
-	}
-
-	q.Add(reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      composeNameWithSelector(evt.Meta.GetName(), sbrSelector),
-			Namespace: evt.Meta.GetNamespace(),
-		},
-	})
+	q.Add(reconcile.Request{sbrSelector})
 }
 
 func (e EnqueueRequestForUnstructured) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
-	sbrSelector, err := getServiceBindingRequestSelector(evt.Object)
+	sbrSelector, err := common.GetSBRSelectorFromObject(evt.Object)
 	if err != nil {
-		enqueueLog.Error(err, "change me")
+		log.Error(err, "error on extracting SBR namespaced-name from annotations")
+		return
+	}
+	if common.IsSBRSelectorEmpty(sbrSelector) {
 		return
 	}
 
-	if evt.Meta == nil {
-		enqueueLog.Error(nil, "GenericEvent received with no metadata", "event", evt)
-		return
-	}
-
-	q.Add(reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      composeNameWithSelector(evt.Meta.GetName(), sbrSelector),
-			Namespace: evt.Meta.GetNamespace(),
-		},
-	})
+	q.Add(reconcile.Request{sbrSelector})
 }

--- a/pkg/controller/catchall/eventhandler.go
+++ b/pkg/controller/catchall/eventhandler.go
@@ -1,0 +1,120 @@
+package catchall
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+// TODO: Use the same log infrastructure as others
+var enqueueLog = logf.KBLog.WithName("eventhandler").WithName("EnqueueRequestForObject")
+
+type EnqueueRequestForUnstructured struct{}
+
+// TODO: Better name for this request
+type UnstructuredRequest struct {
+	NamespacedName                types.NamespacedName
+	ServiceBindingRequestSelector int
+}
+
+func getServiceBindingRequestSelector(object runtime.Object) (int, error) {
+	// TODO: Should figure out data structure to keep for the worker.
+	panic("implement me")
+}
+
+func (e EnqueueRequestForUnstructured) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	if evt.Meta == nil {
+		enqueueLog.Error(nil, "CreateEvent received with no metadata", "event", evt)
+		return
+	}
+
+	sbrSelector, err := getServiceBindingRequestSelector(evt.Object)
+	if err != nil {
+		enqueueLog.Error(err, "change me")
+		return
+	}
+
+	q.Add(UnstructuredRequest{
+		ServiceBindingRequestSelector: sbrSelector,
+		NamespacedName: types.NamespacedName{
+			Name:      evt.Meta.GetName(),
+			Namespace: evt.Meta.GetNamespace(),
+		},
+	})
+}
+
+func (e EnqueueRequestForUnstructured) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	sbrSelector, err := getServiceBindingRequestSelector(evt.ObjectNew)
+	if err != nil {
+		enqueueLog.Error(err, "change me")
+		return
+	}
+
+	if evt.MetaOld != nil {
+		q.Add(UnstructuredRequest{
+			ServiceBindingRequestSelector: sbrSelector,
+			NamespacedName: types.NamespacedName{
+				Name:      evt.MetaOld.GetName(),
+				Namespace: evt.MetaOld.GetNamespace(),
+			},
+		})
+	} else {
+		enqueueLog.Error(nil, "UpdateEvent received with no old metadata", "event", evt)
+	}
+
+	if evt.MetaNew != nil {
+		q.Add(UnstructuredRequest{
+			ServiceBindingRequestSelector: sbrSelector,
+			NamespacedName: types.NamespacedName{
+				Name:      evt.MetaNew.GetName(),
+				Namespace: evt.MetaNew.GetNamespace(),
+			},
+		})
+	} else {
+		enqueueLog.Error(nil, "UpdateEvent received with no new metadata", "event", evt)
+	}
+}
+
+func (e EnqueueRequestForUnstructured) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	sbrSelector, err := getServiceBindingRequestSelector(evt.Object)
+	if err != nil {
+		enqueueLog.Error(err, "change me")
+		return
+	}
+
+	if evt.Meta == nil {
+		enqueueLog.Error(nil, "DeleteEvent received with no metadata", "event", evt)
+		return
+	}
+
+	q.Add(UnstructuredRequest{
+		ServiceBindingRequestSelector: sbrSelector,
+		NamespacedName: types.NamespacedName{
+			Name:      evt.Meta.GetName(),
+			Namespace: evt.Meta.GetNamespace(),
+		},
+	})
+}
+
+func (e EnqueueRequestForUnstructured) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	sbrSelector, err := getServiceBindingRequestSelector(evt.Object)
+	if err != nil {
+		enqueueLog.Error(err, "change me")
+		return
+	}
+
+	if evt.Meta == nil {
+		enqueueLog.Error(nil, "GenericEvent received with no metadata", "event", evt)
+		return
+	}
+
+	q.Add(UnstructuredRequest{
+		ServiceBindingRequestSelector: sbrSelector,
+		NamespacedName: types.NamespacedName{
+			Name:      evt.Meta.GetName(),
+			Namespace: evt.Meta.GetNamespace(),
+		},
+	})
+}

--- a/pkg/controller/catchall/reconciler.go
+++ b/pkg/controller/catchall/reconciler.go
@@ -1,13 +1,15 @@
 package catchall
 
 import (
-	"fmt"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/pkg/controller/common"
 )
 
 type CatchAllReconciler struct {
@@ -16,14 +18,52 @@ type CatchAllReconciler struct {
 	Scheme    *runtime.Scheme
 }
 
+const bindingPending = "pending"
+
+// FIXME: update the SBR object, encoded in the request name, return done if successful to the
+// FIXME: make sure we can update SBR object to trigger re-reconciliation;
 func (r *CatchAllReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	sbrSelector := getSelectorFromName(request.Name)
-	_ = sbrSelector
+	logger := logf.Log.WithName("catchall").WithValues(
+		"Request.Namespace", request.Namespace,
+		"Request.Name", request.Name,
+	)
 
-	logf.Log.WithValues("Reconcile.Request", fmt.Sprintf("%#v", request)).Info("Debug -> Request!")
+	ns := request.Namespace
+	name := request.Name
 
-	// Do something with sbrSelector
-	logf.Log.Info("Inside CatchAllReconciler.Reconcile. Will panic!")
+	gv := v1alpha1.SchemeGroupVersion
+	gvr := gv.WithResource("servicebindingrequests")
+	resourceClient := r.DynClient.Resource(gvr).Namespace(ns)
 
-	panic(fmt.Sprintf("%#v\n", request))
+	logger.Info("Reading SBR resource...")
+	u, err := resourceClient.Get(name, metav1.GetOptions{})
+	if err != nil {
+		logger.Error(err, "On trying to read SBR resource.")
+		return common.RequeueError(err)
+	}
+
+	logger.Info("Converting unstructured object into SBR...")
+	sbr := &v1alpha1.ServiceBindingRequest{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, sbr)
+	if err != nil {
+		logger.Error(err, "On converting unstructured to SBR.")
+		return common.RequeueError(err)
+	}
+
+	logger.Info("Updating SBR status to 'pending'...")
+	sbr.Status.BindingStatus = bindingPending
+	u.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(sbr)
+	if err != nil {
+		logger.Error(err, "On tranforming SBR back to unstructured.")
+		return common.RequeueError(err)
+	}
+
+	_, err = resourceClient.UpdateStatus(u, metav1.UpdateOptions{})
+	if err != nil {
+		logger.Error(err, "On updating the status of SBR resource.")
+		return common.RequeueError(err)
+	}
+
+	logger.Info("SBR resource updated!")
+	return common.Done()
 }

--- a/pkg/controller/catchall/reconciler.go
+++ b/pkg/controller/catchall/reconciler.go
@@ -13,6 +13,6 @@ type CatchAllReconciler struct {
 	Scheme    *runtime.Scheme
 }
 
-func (r *CatchAllReconciler) Reconcile(request UnstructuredRequest) (reconcile.Result, error) {
+func (r *CatchAllReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	panic("implement me")
 }

--- a/pkg/controller/catchall/reconciler.go
+++ b/pkg/controller/catchall/reconciler.go
@@ -13,6 +13,6 @@ type CatchAllReconciler struct {
 	Scheme    *runtime.Scheme
 }
 
-func (r *CatchAllReconciler) Reconcile(reconcile.Request) (reconcile.Result, error) {
+func (r *CatchAllReconciler) Reconcile(request UnstructuredRequest) (reconcile.Result, error) {
 	panic("implement me")
 }

--- a/pkg/controller/catchall/reconciler.go
+++ b/pkg/controller/catchall/reconciler.go
@@ -2,6 +2,7 @@ package catchall
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,12 +17,13 @@ type CatchAllReconciler struct {
 }
 
 func (r *CatchAllReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-
 	sbrSelector := getSelectorFromName(request.Name)
 	_ = sbrSelector
+
+	logf.Log.WithValues("Reconcile.Request", fmt.Sprintf("%#v", request)).Info("Debug -> Request!")
 
 	// Do something with sbrSelector
 	logf.Log.Info("Inside CatchAllReconciler.Reconcile. Will panic!")
 
-	panic(">>>>> Can you see me? <<<<<")
+	panic(fmt.Sprintf("%#v\n", request))
 }

--- a/pkg/controller/catchall/reconciler.go
+++ b/pkg/controller/catchall/reconciler.go
@@ -1,0 +1,18 @@
+package catchall
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type CatchAllReconciler struct {
+	Client    client.Client
+	DynClient dynamic.Interface
+	Scheme    *runtime.Scheme
+}
+
+func (r *CatchAllReconciler) Reconcile(reconcile.Request) (reconcile.Result, error) {
+	panic("implement me")
+}

--- a/pkg/controller/catchall/reconciler.go
+++ b/pkg/controller/catchall/reconciler.go
@@ -1,10 +1,12 @@
 package catchall
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 type CatchAllReconciler struct {
@@ -14,5 +16,12 @@ type CatchAllReconciler struct {
 }
 
 func (r *CatchAllReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	panic("implement me")
+
+	sbrSelector := getSelectorFromName(request.Name)
+	_ = sbrSelector
+
+	// Do something with sbrSelector
+	logf.Log.Info("Inside CatchAllReconciler.Reconcile. Will panic!")
+
+	panic(">>>>> Can you see me? <<<<<")
 }

--- a/pkg/controller/catchall/unstructured.go
+++ b/pkg/controller/catchall/unstructured.go
@@ -1,0 +1,29 @@
+package catchall
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Shamelessly copied from https://github.com/isutton/eventing/blob/a4598653d46752d5ca8ef55f28d8b37cb1fd8e3f/pkg/adapter/apiserver/adapter.go#L144-L160
+
+type unstructuredLister func(metav1.ListOptions) (*unstructured.UnstructuredList, error)
+
+func asUnstructuredLister(ulist unstructuredLister) cache.ListFunc {
+	return func(opts metav1.ListOptions) (runtime.Object, error) {
+		ul, err := ulist(opts)
+		if err != nil {
+			return nil, err
+		}
+		return ul, nil
+	}
+}
+
+func asUnstructuredWatcher(wf cache.WatchFunc) cache.WatchFunc {
+	return func(lo metav1.ListOptions) (watch.Interface, error) {
+		return wf(lo)
+	}
+}

--- a/pkg/controller/common/annotations.go
+++ b/pkg/controller/common/annotations.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	sbrNamespaceAnnotation = "service-binding-operator.apps.openshift.io/binding-namespace"
+	sbrNameAnnotation      = "service-binding-operator.apps.openshift.io/binding-name"
+)
+
+func extractNamespacedName(data map[string]string) types.NamespacedName {
+	ns, exists := data[sbrNamespaceAnnotation]
+	if !exists {
+		return types.NamespacedName{}
+	}
+	name, exists := data[sbrNameAnnotation]
+	if !exists {
+		return types.NamespacedName{}
+	}
+	return types.NamespacedName{Namespace: ns, Name: name}
+}
+
+func GetSBRSelectorFromObject(obj runtime.Object) (types.NamespacedName, error) {
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return types.NamespacedName{}, err
+	}
+
+	u := &unstructured.Unstructured{Object: data}
+	return extractNamespacedName(u.GetAnnotations()), nil
+}
+
+func IsSBRSelectorEmpty(namespacedName types.NamespacedName) bool {
+	return namespacedName.Namespace == "" || namespacedName.Name == ""
+}
+
+func SetSBRSelectorInObject() error {
+	return nil
+}

--- a/pkg/controller/common/common.go
+++ b/pkg/controller/common/common.go
@@ -1,4 +1,4 @@
-package servicebindingrequest
+package common
 
 import (
 	"time"


### PR DESCRIPTION
Adding a new controller (`CatchAll`) to work side by with with `ServiceBindingRequest` controller. The new controller objective is to inspect events in order to know if they are part of a `ServiceBindingRequest` resource, and in this case, call for a reconciliation of that `ServiceBindingRequest` resource.

Tackling issue #142 as a next step.

(cc @isutton)