### PR TITLE
Watch Resources to Trigger Rebinding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ tags
 .vscode/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+### Intellij
+.idea

--- a/deploy/crds/apps_v1alpha1_servicebindingrequest_crd.yaml
+++ b/deploy/crds/apps_v1alpha1_servicebindingrequest_crd.yaml
@@ -72,6 +72,10 @@ spec:
             mountPathPrefix:
               description: MountPathPrefix is the prefix for volume mount
               type: string
+            triggerRebinding:
+              description: TriggerRebinding forcefully triggers a binding operation
+                if the event for the same was missed for some reason
+              type: boolean
           required:
           - backingServiceSelector
           - applicationSelector

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -47,8 +47,10 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - ""
+  - "*"
   resources:
   - "*"
   verbs:
     - "get"
+    - "list"
+    - "watch"

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -26,6 +26,10 @@ type ServiceBindingRequestSpec struct {
 	// ApplicationSelector is used to identify the application connecting to the
 	// backing service operator.
 	ApplicationSelector ApplicationSelector `json:"applicationSelector"`
+
+	// TriggerRebinding forcefully triggers a binding operation if the event
+	// for the same was missed for some reason
+	TriggerRebinding *bool `json:"triggerRebinding,omitempty"`
 }
 
 // ServiceBindingRequestStatus defines the observed state of ServiceBindingRequest

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -113,6 +113,11 @@ func (in *ServiceBindingRequestSpec) DeepCopyInto(out *ServiceBindingRequestSpec
 	*out = *in
 	out.BackingServiceSelector = in.BackingServiceSelector
 	in.ApplicationSelector.DeepCopyInto(&out.ApplicationSelector)
+	if in.TriggerRebinding != nil {
+		in, out := &in.TriggerRebinding, &out.TriggerRebinding
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
@@ -177,6 +177,13 @@ func schema_pkg_apis_apps_v1alpha1_ServiceBindingRequestSpec(ref common.Referenc
 							Ref:         ref("./pkg/apis/apps/v1alpha1.ApplicationSelector"),
 						},
 					},
+					"triggerRebinding": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TriggerRebinding forcefully triggers a binding operation if the event for the same was missed for some reason",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"backingServiceSelector", "applicationSelector"},
 			},

--- a/pkg/controller/servicebindingrequest/annotations.go
+++ b/pkg/controller/servicebindingrequest/annotations.go
@@ -1,0 +1,116 @@
+package servicebindingrequest
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+)
+
+const (
+	sbrNamespaceAnnotation = "service-binding-operator.apps.openshift.io/binding-namespace"
+	sbrNameAnnotation      = "service-binding-operator.apps.openshift.io/binding-name"
+)
+
+// extractNamespacedName returns a types.NamespacedName if the required service binding request keys
+// are present in the given data
+func extractNamespacedName(data map[string]string) types.NamespacedName {
+	namespacedName := types.NamespacedName{}
+	ns, exists := data[sbrNamespaceAnnotation]
+	if !exists {
+		return namespacedName
+	}
+	name, exists := data[sbrNameAnnotation]
+	if !exists {
+		return namespacedName
+	}
+	namespacedName.Namespace = ns
+	namespacedName.Name = name
+	return namespacedName
+}
+
+// GetSBRNamespacedNameFromObject returns a types.NamespacedName if the required service binding
+// request annotations are present in the given runtime.Object, empty otherwise. When annotations are
+// not present, it checks if the object is an actual SBR, returning the details when positive. An
+// error can be returned in the case the object can't be decoded.
+func GetSBRNamespacedNameFromObject(obj runtime.Object) (types.NamespacedName, error) {
+	namespacedName := types.NamespacedName{}
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return namespacedName, err
+	}
+
+	u := &unstructured.Unstructured{Object: data}
+
+	namespacedName = extractNamespacedName(u.GetAnnotations())
+	logger := log.WithValues(
+		"Resource.GVK", u.GroupVersionKind(),
+		"Resource.Namespace", u.GetNamespace(),
+		"Resource.Name", u.GetName(),
+		"Extracted.NamespacedName", namespacedName.String(),
+	)
+	if !IsSBRNamespacedNameEmpty(namespacedName) {
+		logger.Info("Not able to define SBR namespaced-name based on annotations!")
+		return namespacedName, nil
+	}
+
+	if u.GroupVersionKind() != v1alpha1.SchemeGroupVersion.WithKind("ServiceBindingRequest") {
+		logger.Info("Object is also not a SBR resource type.")
+		return namespacedName, nil
+	}
+
+	logger.Info("Creating namespaced-name for a actual SBR object.")
+	namespacedName.Namespace = u.GetNamespace()
+	namespacedName.Name = u.GetName()
+	return namespacedName, nil
+}
+
+// IsSBRNamespacedNameEmpty returns true if any of the fields from the given namespacedName is empty.
+func IsSBRNamespacedNameEmpty(namespacedName types.NamespacedName) bool {
+	return namespacedName.Namespace == "" || namespacedName.Name == ""
+}
+
+// SetSBRAnnotations update existing annotations to include operator's. The annotations added are
+// referring to a existing SBR namespaced name.
+func SetSBRAnnotations(
+	ctx context.Context,
+	client dynamic.Interface,
+	namespacedName types.NamespacedName,
+	objs []*unstructured.Unstructured,
+) error {
+	for _, obj := range objs {
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+
+		annotations[sbrNamespaceAnnotation] = namespacedName.Namespace
+		annotations[sbrNameAnnotation] = namespacedName.Name
+		obj.SetAnnotations(annotations)
+
+		gvk := obj.GroupVersionKind()
+		gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+		opts := metav1.UpdateOptions{}
+
+		logger := log.WithValues(
+			"SBR.Namespace", namespacedName.Namespace,
+			"SBR.Name", namespacedName.Name,
+			"Resource.GVK", gvk,
+			"Resource.Namespace", obj.GetNamespace(),
+			"Resource.Name", obj.GetName(),
+		)
+		logger.Info("Updating resource annotations...")
+		_, err := client.Resource(gvr).Namespace(obj.GetNamespace()).Update(obj, opts)
+		if err != nil {
+			logger.Error(err, "unable to set/update annotations in object")
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/servicebindingrequest/annotations_test.go
+++ b/pkg/controller/servicebindingrequest/annotations_test.go
@@ -1,0 +1,57 @@
+package servicebindingrequest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+)
+
+func TestAnnotationsExtractNamespacedName(t *testing.T) {
+	assert.Equal(t, types.NamespacedName{}, extractNamespacedName(map[string]string{}))
+
+	data := map[string]string{sbrNamespaceAnnotation: "ns", sbrNameAnnotation: "name"}
+	assert.Equal(t, types.NamespacedName{Namespace: "ns", Name: "name"}, extractNamespacedName(data))
+}
+
+func TestAnnotationsGetSBRNamespacedNameFromObject(t *testing.T) {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
+
+	// not containing annotations, should return empty
+	t.Run("returns-empty", func(t *testing.T) {
+		namespacedName, err := GetSBRNamespacedNameFromObject(u.DeepCopyObject())
+		assert.Nil(t, err)
+		assert.Equal(t, types.NamespacedName{}, namespacedName)
+	})
+
+	// with annotations in place it should return the actual values
+	t.Run("from-annotations", func(t *testing.T) {
+		u.SetAnnotations(map[string]string{sbrNamespaceAnnotation: "ns", sbrNameAnnotation: "name"})
+		namespacedName, err := GetSBRNamespacedNameFromObject(u.DeepCopyObject())
+		assert.Nil(t, err)
+		assert.Equal(t, types.NamespacedName{Namespace: "ns", Name: "name"}, namespacedName)
+	})
+
+	// it should also understand a actual SBR as well, so return not empty
+	t.Run("actual-sbr-object", func(t *testing.T) {
+		sbr := &unstructured.Unstructured{}
+		sbr.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind("ServiceBindingRequest"))
+		sbr.SetNamespace("ns")
+		sbr.SetName("name")
+		namespacedName, err := GetSBRNamespacedNameFromObject(sbr.DeepCopyObject())
+		assert.Nil(t, err)
+		assert.Equal(t, types.NamespacedName{Namespace: "ns", Name: "name"}, namespacedName)
+	})
+}
+
+func TestAnnotationsIsSBRNamespacedNameEmpty(t *testing.T) {
+	assert.True(t, IsSBRNamespacedNameEmpty(types.NamespacedName{}))
+	assert.True(t, IsSBRNamespacedNameEmpty(types.NamespacedName{Namespace: "ns"}))
+	assert.True(t, IsSBRNamespacedNameEmpty(types.NamespacedName{Name: "name"}))
+	assert.False(t, IsSBRNamespacedNameEmpty(types.NamespacedName{Namespace: "ns", Name: "name"}))
+}

--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -3,9 +3,13 @@ package servicebindingrequest
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	ustrv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
@@ -50,5 +54,39 @@ func TestBinderNew(t *testing.T) {
 
 		assert.Equal(t, 1, len(list))
 		assert.Equal(t, secretName, list[0].SecretRef.Name)
+	})
+
+	t.Run("appendEnv", func(t *testing.T) {
+		d := mocks.DeploymentMock("binder", "binder", map[string]string{})
+		list := binder.appendEnvVar(d.Spec.Template.Spec.Containers[0].Env, "name", "value")
+		assert.Equal(t, 1, len(list))
+		assert.Equal(t, "name", list[0].Name)
+		assert.Equal(t, "value", list[0].Value)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		list, err := binder.search()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(list.Items))
+
+		updatedObjects, err := binder.update(list)
+		assert.NoError(t, err)
+		assert.Len(t, updatedObjects, 1)
+
+		containersPath := []string{"spec", "template", "spec", "containers"}
+		containers, found, err := ustrv1.NestedSlice(list.Items[0].Object, containersPath...)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Len(t, containers, 1)
+
+		c := corev1.Container{}
+		u := containers[0].(map[string]interface{})
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(u, &c)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, c.Env[0].Value)
+
+		parsedTime, err := time.Parse(time.RFC3339, c.Env[0].Value)
+		assert.NoError(t, err)
+		assert.True(t, parsedTime.Before(time.Now()))
 	})
 }

--- a/pkg/controller/servicebindingrequest/common.go
+++ b/pkg/controller/servicebindingrequest/common.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	log = logf.Log.WithName("servicebindingrequest")
+	log = logf.ZapLogger(true).WithName("servicebindingrequest")
 )
 
 // ServiceBindingRequestKind defines the name of the CRD Kind.

--- a/pkg/controller/servicebindingrequest/common.go
+++ b/pkg/controller/servicebindingrequest/common.go
@@ -5,7 +5,15 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var (
+	log = logf.Log.WithName("servicebindingrequest")
+)
+
+// ServiceBindingRequestKind defines the name of the CRD Kind.
+const ServiceBindingRequestKind = "ServiceBindingRequest"
 
 // RequeueOnNotFound inspect error, if not-found then returns Requeue, otherwise expose the error.
 func RequeueOnNotFound(err error, requeueAfter int64) (reconcile.Result, error) {

--- a/pkg/controller/servicebindingrequest/controller.go
+++ b/pkg/controller/servicebindingrequest/controller.go
@@ -48,6 +48,21 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	pred := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldKind := e.ObjectOld.DeepCopyObject().GetObjectKind().GroupVersionKind().Kind
+			if oldKind == ServiceBindingRequestKind {
+				oldSBR := e.ObjectOld.(*v1alpha1.ServiceBindingRequest)
+				newSBR := e.ObjectNew.(*v1alpha1.ServiceBindingRequest)
+
+				// if event was triggered as part of resetting TriggerRebinding True to False,
+				// we shall ignore it to avoid an infinite loop.
+				if newSBR.Spec.TriggerRebinding != nil &&
+					oldSBR.Spec.TriggerRebinding != nil &&
+					!*newSBR.Spec.TriggerRebinding &&
+					*oldSBR.Spec.TriggerRebinding {
+					return false
+				}
+			}
+
 			// ignore updates to CR status in which case metadata.Generation does not change
 			return e.MetaOld.GetGeneration() != e.MetaNew.GetGeneration()
 		},

--- a/pkg/controller/servicebindingrequest/controller.go
+++ b/pkg/controller/servicebindingrequest/controller.go
@@ -48,20 +48,24 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	pred := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldKind := e.ObjectOld.DeepCopyObject().GetObjectKind().GroupVersionKind().Kind
-			if oldKind == ServiceBindingRequestKind {
-				oldSBR := e.ObjectOld.(*v1alpha1.ServiceBindingRequest)
-				newSBR := e.ObjectNew.(*v1alpha1.ServiceBindingRequest)
+			// FIXME: support unstructured.Unstructured types. This block is currently causing a
+			// panic with the assertion error.
+			/*
+				oldKind := e.ObjectOld.DeepCopyObject().GetObjectKind().GroupVersionKind().Kind
+				if oldKind == ServiceBindingRequestKind {
+					oldSBR := e.ObjectOld.(*v1alpha1.ServiceBindingRequest)
+					newSBR := e.ObjectNew.(*v1alpha1.ServiceBindingRequest)
 
-				// if event was triggered as part of resetting TriggerRebinding True to False,
-				// we shall ignore it to avoid an infinite loop.
-				if newSBR.Spec.TriggerRebinding != nil &&
-					oldSBR.Spec.TriggerRebinding != nil &&
-					!*newSBR.Spec.TriggerRebinding &&
-					*oldSBR.Spec.TriggerRebinding {
-					return false
+					// if event was triggered as part of resetting TriggerRebinding True to False,
+					// we shall ignore it to avoid an infinite loop.
+					if newSBR.Spec.TriggerRebinding != nil &&
+						oldSBR.Spec.TriggerRebinding != nil &&
+						!*newSBR.Spec.TriggerRebinding &&
+						*oldSBR.Spec.TriggerRebinding {
+						return false
+					}
 				}
-			}
+			*/
 
 			// ignore updates to CR status in which case metadata.Generation does not change
 			return e.MetaOld.GetGeneration() != e.MetaNew.GetGeneration()

--- a/pkg/controller/servicebindingrequest/mapper.go
+++ b/pkg/controller/servicebindingrequest/mapper.go
@@ -1,0 +1,28 @@
+package servicebindingrequest
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// SBRRequestMapper is the handler.SBRRequestMapper interface implementation. It should influence the
+// enqueue process considering the resources informed.
+type SBRRequestMapper struct{}
+
+// Map execute the mapping of a resource with the requests it would produce. Here we inspect the
+// given object trying to identify if this object is part of a SBR, or a actual SBR resource.
+func (m *SBRRequestMapper) Map(obj handler.MapObject) []reconcile.Request {
+	toReconcile := []reconcile.Request{}
+
+	sbrNamespacedName, err := GetSBRNamespacedNameFromObject(obj.Object)
+	if err != nil {
+		log.Error(err, "on inspecting object for annotations for SBR object")
+		return toReconcile
+	}
+	if IsSBRNamespacedNameEmpty(sbrNamespacedName) {
+		log.Error(nil, "not able to extract SBR namespaced-name")
+		return toReconcile
+	}
+
+	return append(toReconcile, reconcile.Request{NamespacedName: sbrNamespacedName})
+}

--- a/pkg/controller/servicebindingrequest/mapper.go
+++ b/pkg/controller/servicebindingrequest/mapper.go
@@ -12,15 +12,19 @@ type SBRRequestMapper struct{}
 // Map execute the mapping of a resource with the requests it would produce. Here we inspect the
 // given object trying to identify if this object is part of a SBR, or a actual SBR resource.
 func (m *SBRRequestMapper) Map(obj handler.MapObject) []reconcile.Request {
+	logger := log.WithValues(
+		"Object.Namespace", obj.Meta.GetNamespace(),
+		"Object.Name", obj.Meta.GetName(),
+	)
 	toReconcile := []reconcile.Request{}
 
 	sbrNamespacedName, err := GetSBRNamespacedNameFromObject(obj.Object)
 	if err != nil {
-		log.Error(err, "on inspecting object for annotations for SBR object")
+		logger.Error(err, "on inspecting object for annotations for SBR object")
 		return toReconcile
 	}
 	if IsSBRNamespacedNameEmpty(sbrNamespacedName) {
-		log.Error(nil, "not able to extract SBR namespaced-name")
+		log.Info("not able to extract SBR namespaced-name")
 		return toReconcile
 	}
 

--- a/pkg/controller/servicebindingrequest/mapper_test.go
+++ b/pkg/controller/servicebindingrequest/mapper_test.go
@@ -1,0 +1,45 @@
+package servicebindingrequest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+)
+
+func TestSBRRequestMapperMap(t *testing.T) {
+	mapper := &SBRRequestMapper{}
+
+	// not containing annotations, should return empty
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
+	mapObj := handler.MapObject{Object: u.DeepCopyObject()}
+	mappedRequests := mapper.Map(mapObj)
+	require.Equal(t, 0, len(mappedRequests))
+
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "name"}}
+
+	// with annotations in place it should return the actual values
+	u.SetAnnotations(map[string]string{sbrNamespaceAnnotation: "ns", sbrNameAnnotation: "name"})
+	mapObj = handler.MapObject{Object: u.DeepCopyObject()}
+	mappedRequests = mapper.Map(mapObj)
+	require.Equal(t, 1, len(mappedRequests))
+	assert.Equal(t, request, mappedRequests[0])
+
+	// it should also understand a actual SBR as well, so return not empty
+	sbr := &unstructured.Unstructured{}
+	sbr.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind("ServiceBindingRequest"))
+	sbr.SetNamespace("ns")
+	sbr.SetName("name")
+	mapObj = handler.MapObject{Object: sbr.DeepCopyObject()}
+	mappedRequests = mapper.Map(mapObj)
+	require.Equal(t, 1, len(mappedRequests))
+	assert.Equal(t, request, mappedRequests[0])
+}

--- a/pkg/controller/servicebindingrequest/mapper_test.go
+++ b/pkg/controller/servicebindingrequest/mapper_test.go
@@ -17,10 +17,13 @@ import (
 func TestSBRRequestMapperMap(t *testing.T) {
 	mapper := &SBRRequestMapper{}
 
-	// not containing annotations, should return empty
 	u := &unstructured.Unstructured{}
+	u.SetNamespace("mapper-unit")
+	u.SetName("mapper-unit")
 	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
-	mapObj := handler.MapObject{Object: u.DeepCopyObject()}
+
+	// not containing annotations, should return empty
+	mapObj := handler.MapObject{Meta: u, Object: u.DeepCopyObject()}
 	mappedRequests := mapper.Map(mapObj)
 	require.Equal(t, 0, len(mappedRequests))
 
@@ -28,7 +31,7 @@ func TestSBRRequestMapperMap(t *testing.T) {
 
 	// with annotations in place it should return the actual values
 	u.SetAnnotations(map[string]string{sbrNamespaceAnnotation: "ns", sbrNameAnnotation: "name"})
-	mapObj = handler.MapObject{Object: u.DeepCopyObject()}
+	mapObj = handler.MapObject{Meta: u, Object: u.DeepCopyObject()}
 	mappedRequests = mapper.Map(mapObj)
 	require.Equal(t, 1, len(mappedRequests))
 	assert.Equal(t, request, mappedRequests[0])
@@ -38,7 +41,7 @@ func TestSBRRequestMapperMap(t *testing.T) {
 	sbr.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind("ServiceBindingRequest"))
 	sbr.SetNamespace("ns")
 	sbr.SetName("name")
-	mapObj = handler.MapObject{Object: sbr.DeepCopyObject()}
+	mapObj = handler.MapObject{Meta: u, Object: sbr.DeepCopyObject()}
 	mappedRequests = mapper.Map(mapObj)
 	require.Equal(t, 1, len(mappedRequests))
 	assert.Equal(t, request, mappedRequests[0])

--- a/pkg/controller/servicebindingrequest/planner_test.go
+++ b/pkg/controller/servicebindingrequest/planner_test.go
@@ -29,7 +29,7 @@ func TestPlannerNew(t *testing.T) {
 	f := mocks.NewFake(t, ns)
 	sbr := f.AddMockedServiceBindingRequest(name, resourceRef, matchLabels)
 	f.AddMockedUnstructuredCSV("cluster-service-version")
-	f.AddMockedDatabaseCRList(resourceRef)
+	f.AddMockedDatabaseCR(resourceRef)
 
 	planner = NewPlanner(context.TODO(), f.FakeDynClient(), sbr)
 	require.NotNil(t, planner)

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -2,8 +2,11 @@ package servicebindingrequest
 
 import (
 	"context"
+	"fmt"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -52,15 +55,34 @@ func (r *Reconciler) setStatus(
 	return r.client.Status().Update(ctx, instance)
 }
 
+// setStatus always updates the TriggerRebindingFlag field to False, if present
+func (r *Reconciler) setTriggerRebindingFlag(
+	ctx context.Context,
+	instance *v1alpha1.ServiceBindingRequest,
+) error {
+	if instance.Spec.TriggerRebinding != nil && *instance.Spec.TriggerRebinding {
+		newValue := false
+		instance.Spec.TriggerRebinding = &newValue
+		return r.client.Update(ctx, instance)
+	}
+	return nil
+}
+
 // setApplicationObjects set the ApplicationObject status field, and also set the overall status as
 // success, since it was able to bind applications.
 func (r *Reconciler) setApplicationObjects(
 	ctx context.Context,
 	instance *v1alpha1.ServiceBindingRequest,
-	objs []string,
+	objs []*unstructured.Unstructured,
 ) error {
+	names := []string{}
+	for _, obj := range objs {
+		names = append(names, fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName()))
+	}
+
 	instance.Status.BindingStatus = bindingSuccess
-	instance.Status.ApplicationObjects = objs
+	instance.Status.ApplicationObjects = names
+
 	return r.client.Status().Update(ctx, instance)
 }
 
@@ -75,6 +97,7 @@ func (r *Reconciler) setApplicationObjects(
 //    Deployment (and other kinds) will be updated in "spec" level.
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := context.TODO()
+	objectsToAnnotate := []*unstructured.Unstructured{}
 	logger := logf.Log.WithValues(
 		"Request.Namespace", request.Namespace,
 		"Request.Name", request.Name,
@@ -86,7 +109,13 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	err := r.client.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
 		logger.Error(err, "On retrieving service-binding-request instance.")
-		return RequeueOnNotFound(err, 0)
+		return RequeueOnNotFound(err, 5)
+	}
+
+	// As long the request was handled, we update the TriggerRebind
+	err = r.setTriggerRebindingFlag(ctx, instance)
+	if err != nil {
+		return RequeueError(err)
 	}
 
 	logger = logger.WithValues("ServiceBindingRequest.Name", instance.Name)
@@ -110,13 +139,17 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return RequeueOnNotFound(err, requeueAfter)
 	}
 
+	// storing CR in objects to annotate
+	objectsToAnnotate = append(objectsToAnnotate, plan.CR)
+
 	//
 	// Retrieving data
 	//
 
 	logger.Info("Retrieving data to create intermediate secret.")
-	retriever := NewRetriever(ctx, r.client, plan, instance.Spec.EnvVarPrefix)
-	if err = retriever.Retrieve(); err != nil {
+	retriever := NewRetriever(ctx, r.dynClient, plan, instance.Spec.EnvVarPrefix)
+	retrievedObjects, err := retriever.Retrieve()
+	if err != nil {
 		_ = r.setStatus(ctx, instance, bindingFail)
 		logger.Error(err, "On retrieving binding data.")
 		return RequeueOnNotFound(err, requeueAfter)
@@ -127,18 +160,38 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return RequeueError(err)
 	}
 
+	// storing objects used in Retriever
+	objectsToAnnotate = append(objectsToAnnotate, retrievedObjects...)
+
 	//
 	// Updating applications to use intermediary secret
 	//
 
 	logger.Info("Binding applications with intermediary secret.")
 	binder := NewBinder(ctx, r.client, r.dynClient, instance, retriever.volumeKeys)
-	if updatedObjectNames, err := binder.Bind(); err != nil {
+	updatedObjects, err := binder.Bind()
+	if err != nil {
 		_ = r.setStatus(ctx, instance, bindingFail)
 		logger.Error(err, "On binding application.")
 		return RequeueOnNotFound(err, requeueAfter)
-	} else if err = r.setApplicationObjects(ctx, instance, updatedObjectNames); err != nil {
+	} else if err = r.setApplicationObjects(ctx, instance, updatedObjects); err != nil {
 		logger.Error(err, "On updating application objects status field.")
+		return RequeueError(err)
+	}
+
+	// storing objects used in Binder
+	objectsToAnnotate = append(objectsToAnnotate, updatedObjects...)
+
+	//
+	// Annotating objects related to binding
+	//
+
+	sbrNamespacedName := types.NamespacedName{
+		Namespace: instance.GetNamespace(),
+		Name:      instance.GetName(),
+	}
+	if err = SetSBRAnnotations(ctx, r.dynClient, sbrNamespacedName, objectsToAnnotate); err != nil {
+		logger.Error(err, "On setting annotations in related objects.")
 		return RequeueError(err)
 	}
 

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -109,7 +109,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	err := r.client.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
 		logger.Error(err, "On retrieving service-binding-request instance.")
-		return RequeueOnNotFound(err, 5)
+		return RequeueError(err)
 	}
 
 	// As long the request was handled, we update the TriggerRebind

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -95,7 +95,7 @@ func TestReconcilerForForcedTriggeringOfBinding(t *testing.T) {
 	f.AddMockedServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
 
 	f.AddMockedUnstructuredCSV("cluster-service-version-list-forced-trigger")
-	f.AddMockedDatabaseCRList(resourceRef)
+	f.AddMockedDatabaseCR(resourceRef)
 	f.AddMockedUnstructuredDeployment(reconcilerName, matchLabels)
 	f.AddMockedSecret("db-credentials")
 

--- a/pkg/controller/servicebindingrequest/reconciler_whitebox_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_whitebox_test.go
@@ -1,0 +1,69 @@
+package servicebindingrequest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/test/mocks"
+)
+
+func init() {
+	logf.SetLogger(logf.ZapLogger(true))
+}
+
+func TestSetRetriggerBinding(t *testing.T) {
+	ctx := context.TODO()
+	resourceRef := "test-retrigger"
+	matchLabels := map[string]string{
+		"connects-to": "database",
+		"environment": "reconciler",
+	}
+
+	f := mocks.NewFake(t, reconcilerNs)
+
+	f.AddMockedServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
+	fakeClient := f.FakeClient()
+
+	t.Run("reconcile-using-trigger-binding", func(t *testing.T) {
+		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+		sbr := v1alpha1.ServiceBindingRequest{}
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
+
+		reconciler := &Reconciler{client: fakeClient, dynClient: f.FakeDynClient(), scheme: f.S}
+		err := reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		require.NoError(t, err)
+
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
+
+		// If nothing was set initially, nothing will be set.
+		require.Nil(t, sbr.Spec.TriggerRebinding)
+
+		// lets as True initially and see what happens
+		triggerTrue := true
+		sbr.Spec.TriggerRebinding = &triggerTrue
+		require.NoError(t, fakeClient.Update(ctx, &sbr))
+
+		err = reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		require.NoError(t, err)
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
+		require.False(t, *sbr.Spec.TriggerRebinding)
+
+		// lets as False initially and see what happens
+		triggerFalse := false
+		sbr.Spec.TriggerRebinding = &triggerFalse
+		require.NoError(t, fakeClient.Update(ctx, &sbr))
+
+		err = reconciler.setTriggerRebindingFlag(ctx, &sbr)
+		require.NoError(t, err)
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &sbr))
+
+		// remains false
+		require.False(t, *sbr.Spec.TriggerRebinding)
+
+	})
+}

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -2,27 +2,32 @@ package servicebindingrequest
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 // Retriever reads all data referred in plan instance, and store in a secret.
 type Retriever struct {
-	ctx           context.Context   // request context
-	client        client.Client     // Kubernetes API client
-	plan          *Plan             // plan instance
-	logger        logr.Logger       // logger instance
-	data          map[string][]byte // data retrieved
-	volumeKeys    []string
-	bindingPrefix string
+	logger        logr.Logger                  // logger instance
+	data          map[string][]byte            // data retrieved
+	objects       []*unstructured.Unstructured // list of objects employed
+	ctx           context.Context              // request context
+	client        dynamic.Interface            // Kubernetes API client
+	plan          *Plan                        // plan instance
+	volumeKeys    []string                     // list of keys found
+	bindingPrefix string                       // prefix for variable names
 }
 
 const (
@@ -135,18 +140,35 @@ func (r *Retriever) extractConfigMapItemName(xDescriptor string) string {
 func (r *Retriever) readSecret(name string, items []string) error {
 	logger := r.logger.WithValues("Secret.Name", name, "Secret.Items", items)
 	logger.Info("Reading secret items...")
-	secretObj := corev1.Secret{}
-	err := r.client.Get(r.ctx, types.NamespacedName{Namespace: r.plan.Ns, Name: name}, &secretObj)
+
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	u, err := r.client.Resource(gvr).Namespace(r.plan.Ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	logger.Info("Inspecting secret data...")
-	for key, value := range secretObj.Data {
-		logger.WithValues("Secret.Key.Name", key, "Secret.Key.Length", len(value)).
-			Info("Inspecting secret key...")
-		// making sure key name has a secret reference
-		r.store(fmt.Sprintf("secret_%s", key), value)
+
+	data, exists, err := unstructured.NestedMap(u.Object, []string{"data"}...)
+	if err != nil {
+		return err
 	}
+	if !exists {
+		return fmt.Errorf("could not find 'data' in secret")
+	}
+
+	for k, v := range data {
+		value := v.(string)
+		data, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return err
+		}
+		logger.WithValues("Secret.Key.Name", k, "Secret.Key.Length", len(data)).
+			Info("Inspecting secret key...")
+
+		// making sure key name has a secret reference
+		r.store(fmt.Sprintf("secret_%s", k), data)
+	}
+
+	r.objects = append(r.objects, u)
 	return nil
 }
 
@@ -155,20 +177,31 @@ func (r *Retriever) readSecret(name string, items []string) error {
 func (r *Retriever) readConfigMap(name string, items []string) error {
 	logger := r.logger.WithValues("ConfigMap.Name", name, "ConfigMap.Items", items)
 	logger.Info("Reading ConfigMap items...")
-	configMapObj := corev1.ConfigMap{}
-	err := r.client.Get(r.ctx, types.NamespacedName{Namespace: r.plan.Ns, Name: name}, &configMapObj)
+
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	u, err := r.client.Resource(gvr).Namespace(r.plan.Ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	logger.Info("Inspecting configMap data...")
-	for key, value := range configMapObj.Data {
-		logger.WithValues("configMap.Key.Name", key, "configMap.Key.Length", len(value)).
-			Info("Inspecting configMap key...")
-		// making sure key name has a configMap reference
-		// string to byte
-		r.store(fmt.Sprintf("configMap_%s", key), []byte(value))
+
+	data, exists, err := unstructured.NestedMap(u.Object, []string{"data"}...)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("could not find 'data' in secret")
 	}
 
+	logger.Info("Inspecting configMap data...")
+	for k, v := range data {
+		value := v.(string)
+		logger.WithValues("configMap.Key.Name", k, "configMap.Key.Length", len(value)).
+			Info("Inspecting configMap key...")
+		// making sure key name has a configMap reference
+		r.store(fmt.Sprintf("configMap_%s", k), []byte(value))
+	}
+
+	r.objects = append(r.objects, u)
 	return nil
 }
 
@@ -187,55 +220,116 @@ func (r *Retriever) store(key string, value []byte) {
 
 // saveDataOnSecret create or update secret that will store the data collected.
 func (r *Retriever) saveDataOnSecret() error {
-	secretObj := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.plan.Name,
-			Namespace: r.plan.Ns,
-		},
-		Data: r.data,
-	}
+	gvk := schema.GroupVersion{Group: "", Version: "v1"}.WithKind("Secret")
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	resourceClient := r.client.Resource(gvr).Namespace(r.plan.Ns)
+	logger := r.logger.WithValues(
+		"Secret.GVK", gvk.String(),
+		"Secret.Namespace", r.plan.Ns,
+		"Secret.Name", r.plan.Name,
+	)
 
-	err := r.client.Create(r.ctx, secretObj)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	logger.Info("Retrieving intermediary secret...")
+	u, err := resourceClient.Get(r.plan.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		logger.Error(err, "on retrieving intermediary secret")
 		return err
 	}
 
-	return r.client.Update(r.ctx, secretObj)
+	secretObj := &corev1.Secret{}
+	if u != nil {
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, secretObj)
+		if err != nil {
+			return err
+		}
+
+		generation := secretObj.GetGeneration()
+		logger.WithValues("Generation", generation).
+			Info("Updating intermediary secret object.")
+
+		generation++
+		secretObj.SetGeneration(generation)
+		secretObj.Data = r.data
+	} else {
+		logger.Info("Creating intermediary secret.")
+		secretObj = &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      r.plan.Name,
+				Namespace: r.plan.Ns,
+			},
+			Data: r.data,
+		}
+	}
+
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secretObj)
+	if err != nil {
+		r.logger.Error(err, "Converting secret to unstructured")
+		return err
+	}
+
+	logger.Info("Commiting object to the cluster...")
+	if u == nil {
+		u = &unstructured.Unstructured{Object: data}
+		u.SetGroupVersionKind(gvk)
+		_, err = resourceClient.Create(u, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	} else {
+		u.Object = data
+		if _, err = resourceClient.Update(u, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+
+	r.objects = append(r.objects, u)
+	return nil
 }
 
-// Retrieve loop and read data pointed by the references in plan instance.
-func (r *Retriever) Retrieve() error {
+// Retrieve loop and read data pointed by the references in plan instance. It returns a slice of
+// Unstructured refering the objects in use by the Retriever, and error when issues reading fields.
+func (r *Retriever) Retrieve() ([]*unstructured.Unstructured, error) {
 	var err error
 
 	r.logger.Info("Looking for spec-descriptors in 'spec'...")
 	for _, specDescriptor := range r.plan.CRDDescription.SpecDescriptors {
 		if err = r.read("spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	r.logger.Info("Looking for status-descriptors in 'status'...")
 	for _, statusDescriptor := range r.plan.CRDDescription.StatusDescriptors {
 		if err = r.read("status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return r.saveDataOnSecret()
+	r.logger.Info("Saving data on intermediary secret...")
+	if err = r.saveDataOnSecret(); err != nil {
+		return nil, err
+	}
+	return r.objects, nil
 }
 
 // NewRetriever instantiate a new retriever instance.
-func NewRetriever(ctx context.Context, client client.Client, plan *Plan, bindingPrefix string) *Retriever {
+func NewRetriever(
+	ctx context.Context,
+	client dynamic.Interface,
+	plan *Plan,
+	bindingPrefix string,
+) *Retriever {
 	return &Retriever{
+		logger:        logf.Log.WithName("retriever"),
+		data:          make(map[string][]byte),
+		objects:       []*unstructured.Unstructured{},
 		ctx:           ctx,
 		client:        client,
-		logger:        logf.Log.WithName("retriever"),
 		plan:          plan,
-		data:          make(map[string][]byte),
 		volumeKeys:    []string{},
 		bindingPrefix: bindingPrefix,
 	}

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -108,7 +108,7 @@ func TestRetriever(t *testing.T) {
 	})
 }
 
-func TestRetrieverNestedCRDKey(t *testing.T) {
+func TestRetrieverWithNestedCRKey(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	var retriever *Retriever
 
@@ -149,7 +149,7 @@ func TestRetrieverNestedCRDKey(t *testing.T) {
 
 }
 
-func TestConfigMapRetriever(t *testing.T) {
+func TestRetrieverWithConfigMap(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	var retriever *Retriever
 
@@ -162,7 +162,7 @@ func TestConfigMapRetriever(t *testing.T) {
 
 	crdDescription := mocks.CRDDescriptionConfigMapMock()
 
-	cr, err := mocks.UnstructuredDatabaseConfigMapMock(ns, crName)
+	cr, err := mocks.UnstructuredDatabaseConfigMapMock(ns, crName, crName)
 	require.Nil(t, err)
 
 	plan := &Plan{Ns: ns, Name: "retriever", CRDDescription: &crdDescription, CR: cr}
@@ -193,7 +193,7 @@ func TestConfigMapRetriever(t *testing.T) {
 	t.Run("readConfigMap", func(t *testing.T) {
 		retriever.data = make(map[string][]byte)
 
-		err := retriever.readConfigMap("db-configmap", []string{"user", "password"})
+		err := retriever.readConfigMap(crName, []string{"user", "password"})
 		assert.Nil(t, err)
 
 		assert.Contains(t, retriever.data, ("SERVICE_BINDING_DATABASE_CONFIGMAP_USER"))

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -6,9 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	ustrv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
@@ -21,30 +18,26 @@ func TestRetriever(t *testing.T) {
 	ns := "testing"
 	crName := "db-testing"
 
-	crdDescription := mocks.CRDDescriptionMock()
-	cr := mocks.DatabaseCRMock(ns, crName)
+	f := mocks.NewFake(t, ns)
+	f.AddMockedUnstructuredCSV("csv")
+	f.AddMockedSecret("db-credentials")
 
-	genericCR, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&cr)
+	crdDescription := mocks.CRDDescriptionMock()
+	cr, err := mocks.UnstructuredDatabaseCRMock(ns, crName)
 	require.Nil(t, err)
 
-	plan := &Plan{
-		Ns:             ns,
-		Name:           "retriever",
-		CRDDescription: &crdDescription,
-		CR:             &ustrv1.Unstructured{Object: genericCR},
-	}
+	plan := &Plan{Ns: ns, Name: "retriever", CRDDescription: &crdDescription, CR: cr}
 
-	dbSecret := mocks.SecretMock(ns, "db-credentials")
-	objs := []runtime.Object{dbSecret}
-	fakeClient := fake.NewFakeClient(objs...)
+	fakeDynClient := f.FakeDynClient()
 
-	retriever = NewRetriever(context.TODO(), fakeClient, plan, "SERVICE_BINDING")
+	retriever = NewRetriever(context.TODO(), fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
 
 	t.Run("retrive", func(t *testing.T) {
-		err := retriever.Retrieve()
+		objs, err := retriever.Retrieve()
 		assert.Nil(t, err)
 		assert.NotEmpty(t, retriever.data)
+		assert.True(t, len(objs) > 0)
 	})
 
 	t.Run("getCRKey", func(t *testing.T) {
@@ -103,7 +96,7 @@ func TestRetriever(t *testing.T) {
 	})
 
 	t.Run("empty prefix", func(t *testing.T) {
-		retriever = NewRetriever(context.TODO(), fakeClient, plan, "")
+		retriever = NewRetriever(context.TODO(), fakeDynClient, plan, "")
 		require.NotNil(t, retriever)
 		retriever.data = make(map[string][]byte)
 
@@ -122,24 +115,19 @@ func TestRetrieverNestedCRDKey(t *testing.T) {
 	ns := "testing"
 	crName := "db-testing"
 
-	crdDescription := mocks.CRDDescriptionMock()
-	cr := mocks.NestedDatabaseCRMock(ns, crName)
+	f := mocks.NewFake(t, ns)
+	f.AddMockedUnstructuredCSV("csv")
+	f.AddMockedSecret("db-credentials")
 
-	genericCR, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&cr)
+	crdDescription := mocks.CRDDescriptionMock()
+	cr, err := mocks.UnstructuredNestedDatabaseCRMock(ns, crName)
 	require.Nil(t, err)
 
-	plan := &Plan{
-		Ns:             ns,
-		Name:           "retriever",
-		CRDDescription: &crdDescription,
-		CR:             &ustrv1.Unstructured{Object: genericCR},
-	}
+	plan := &Plan{Ns: ns, Name: "retriever", CRDDescription: &crdDescription, CR: cr}
 
-	dbSecret := mocks.SecretMock(ns, "db-credentials")
-	objs := []runtime.Object{dbSecret}
-	fakeClient := fake.NewFakeClient(objs...)
+	fakeDynClient := f.FakeDynClient()
 
-	retriever = NewRetriever(context.TODO(), fakeClient, plan, "SERVICE_BINDING")
+	retriever = NewRetriever(context.TODO(), fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
 
 	t.Run("Second level", func(t *testing.T) {
@@ -168,29 +156,23 @@ func TestConfigMapRetriever(t *testing.T) {
 	ns := "testing"
 	crName := "db-testing"
 
+	f := mocks.NewFake(t, ns)
+	f.AddMockedUnstructuredCSV("csv")
+	f.AddMockedConfigMap(crName)
+
 	crdDescription := mocks.CRDDescriptionConfigMapMock()
 
-	cr := mocks.DatabaseConfigMapMock(ns, crName)
-
-	genericCR, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
+	cr, err := mocks.UnstructuredDatabaseConfigMapMock(ns, crName)
 	require.Nil(t, err)
 
-	plan := &Plan{
-		Ns:             ns,
-		Name:           "retriever",
-		CRDDescription: &crdDescription,
-		CR:             &ustrv1.Unstructured{Object: genericCR},
-	}
+	plan := &Plan{Ns: ns, Name: "retriever", CRDDescription: &crdDescription, CR: cr}
 
-	dbConfigMap := mocks.ConfigMapMock(ns, "db-configmap")
-	objs := []runtime.Object{&dbConfigMap}
-	fakeClient := fake.NewFakeClient(objs...)
+	fakeDynClient := f.FakeDynClient()
 
-	retriever = NewRetriever(context.TODO(), fakeClient, plan, "SERVICE_BINDING")
+	retriever = NewRetriever(context.TODO(), fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
 
 	t.Run("read", func(t *testing.T) {
-
 		// reading from configMap, from status attribute
 		err = retriever.read("spec", "dbConfigMap", []string{
 			"binding:env:object:configmap:user",

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -157,7 +157,7 @@ func serviceBindingRequestTest(t *testing.T, ctx *framework.TestCtx, f *framewor
 		if generation > 1 {
 			break
 		}
-		time.Sleep(time.Second * 3)
+		time.Sleep(time.Second * 6)
 	}
 
 	// making sure envFrom is added to the container
@@ -189,6 +189,7 @@ func serviceBindingRequestTest(t *testing.T, ctx *framework.TestCtx, f *framewor
 		}
 		time.Sleep(time.Second * 8)
 	}
+	t.Logf("Intermediary secret geranetion: '%d'", sbrSecret.GetGeneration())
 
 	// inspecting secret contents again, expect to be original
 	_ = inspectSBRSecret(t, todoCtx, f, intermediarySecretNamespacedName)
@@ -233,7 +234,7 @@ func updateSecret(
 	generation := sbrSecret.GetGeneration()
 	t.Logf("Secret generation: '%d'", generation)
 
-	// FIXME: intentionally bumping the object generation, so the operator will reconcile;
+	// intentionally bumping the object generation, so the operator will reconcile;
 	generation++
 	sbrSecret.SetGeneration(generation)
 

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -67,11 +67,11 @@ func (f *Fake) AddMockedUnstructuredCSVWithVolumeMount(name string) {
 	f.objs = append(f.objs, csv)
 }
 
-// AddMockedDatabaseCRList add mocked object from DatabaseCRListMock.
-func (f *Fake) AddMockedDatabaseCRList(ref string) {
+// AddMockedDatabaseCR add mocked object from DatabaseCRMock.
+func (f *Fake) AddMockedDatabaseCR(ref string) {
 	require.Nil(f.t, pgapis.AddToScheme(f.S))
 	f.S.AddKnownTypes(pgv1alpha1.SchemeGroupVersion, &pgv1alpha1.Database{})
-	f.objs = append(f.objs, DatabaseCRListMock(f.ns, ref))
+	f.objs = append(f.objs, DatabaseCRMock(f.ns, ref))
 }
 
 // AddMockedUnstructuredDeployment add mocked object from UnstructuredDeploymentMock.
@@ -86,6 +86,11 @@ func (f *Fake) AddMockedUnstructuredDeployment(name string, matchLabels map[stri
 // AddMockedSecret add mocked object from SecretMock.
 func (f *Fake) AddMockedSecret(name string) {
 	f.objs = append(f.objs, SecretMock(f.ns, name))
+}
+
+// AddMockedConfigMap add mocked object from ConfigMapMock.
+func (f *Fake) AddMockedConfigMap(name string) {
+	f.objs = append(f.objs, ConfigMapMock(f.ns, name))
 }
 
 // FakeClient returns fake structured api client.

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -417,7 +417,7 @@ type ConfigMapDatabase struct {
 }
 
 // DatabaseConfigMapMock returns a local ConfigMapDatabase object.
-func DatabaseConfigMapMock(ns, name string) *ConfigMapDatabase {
+func DatabaseConfigMapMock(ns, name, configMapName string) *ConfigMapDatabase {
 	return &ConfigMapDatabase{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       CRDKind,
@@ -428,14 +428,14 @@ func DatabaseConfigMapMock(ns, name string) *ConfigMapDatabase {
 			Name:      name,
 		},
 		Spec: ConfigMapDatabaseSpec{
-			DBConfigMap: "db-configmap",
+			DBConfigMap: configMapName,
 		},
 	}
 }
 
 // UnstructuredDatabaseConfigMapMock returns a unstructured version of DatabaseConfigMapMock.
-func UnstructuredDatabaseConfigMapMock(ns, name string) (*unstructured.Unstructured, error) {
-	db := DatabaseConfigMapMock(ns, name)
+func UnstructuredDatabaseConfigMapMock(ns, name, configMapName string) (*unstructured.Unstructured, error) {
+	db := DatabaseConfigMapMock(ns, name, configMapName)
 	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&db)
 	return &ustrv1.Unstructured{Object: data}, err
 }

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -10,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ustrv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -70,6 +71,13 @@ var (
 		},
 	}
 )
+
+//
+// Usage of TypeMeta in Mocks
+//
+// 	Usually TypeMeta should not be explicitly defined in mocked objects, however, on using
+//  it via *unstructured.Unstructured it could not find this CR without it.
+//
 
 // crdDescriptionMock based for mocked objects.
 func crdDescriptionMock(
@@ -167,8 +175,7 @@ func ClusterServiceVersionMock(ns, name string) olmv1alpha1.ClusterServiceVersio
 func UnstructuredClusterServiceVersionMock(ns, name string) (*ustrv1.Unstructured, error) {
 	csv := ClusterServiceVersionMock(ns, name)
 	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&csv)
-	u := ustrv1.Unstructured{Object: data}
-	return &u, err
+	return &ustrv1.Unstructured{Object: data}, err
 }
 
 // ClusterServiceVersionVolumeMountMock based on PostgreSQL operator.
@@ -184,8 +191,7 @@ func UnstructuredClusterServiceVersionVolumeMountMock(
 ) (*ustrv1.Unstructured, error) {
 	csv := ClusterServiceVersionVolumeMountMock(ns, name)
 	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&csv)
-	u := ustrv1.Unstructured{Object: data}
-	return &u, err
+	return &ustrv1.Unstructured{Object: data}, err
 }
 
 // ClusterServiceVersionListVolumeMountMock returns a list with a single CSV object inside, reusing mock.
@@ -196,10 +202,8 @@ func ClusterServiceVersionListVolumeMountMock(ns, name string) *olmv1alpha1.Clus
 }
 
 // DatabaseCRMock based on PostgreSQL operator, returning a instantiated object.
-func DatabaseCRMock(ns, name string) pgv1alpha1.Database {
-	return pgv1alpha1.Database{
-		// usually TypeMeta should not be explicitly defined in mocked objects, however, on using
-		// it via *unstructured.Unstructured it could not find this CR without it.
+func DatabaseCRMock(ns, name string) *pgv1alpha1.Database {
+	return &pgv1alpha1.Database{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       CRDKind,
 			APIVersion: fmt.Sprintf("%s/%s", CRDName, CRDVersion),
@@ -218,16 +222,20 @@ func DatabaseCRMock(ns, name string) pgv1alpha1.Database {
 	}
 }
 
-// DatabaseCRListMock returns a list with a single database CR inside, reusing existing mock.
-func DatabaseCRListMock(ns, name string) *pgv1alpha1.DatabaseList {
-	return &pgv1alpha1.DatabaseList{
-		Items: []pgv1alpha1.Database{DatabaseCRMock(ns, name)},
-	}
+// UnstructuredDatabaseCRMock returns a unstructured version of DatabaseCRMock.
+func UnstructuredDatabaseCRMock(ns, name string) (*unstructured.Unstructured, error) {
+	db := DatabaseCRMock(ns, name)
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(db)
+	return &unstructured.Unstructured{Object: data}, err
 }
 
 // SecretMock returns a Secret based on PostgreSQL operator usage.
 func SecretMock(ns, name string) *corev1.Secret {
 	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
@@ -240,8 +248,12 @@ func SecretMock(ns, name string) *corev1.Secret {
 }
 
 // ConfigMapMock returns a dummy config-map object.
-func ConfigMapMock(ns, name string) corev1.ConfigMap {
-	return corev1.ConfigMap{
+func ConfigMapMock(ns, name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
@@ -299,8 +311,7 @@ func UnstructuredDeploymentMock(
 ) (*ustrv1.Unstructured, error) {
 	d := DeploymentMock(ns, name, matchLabels)
 	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&d)
-	u := ustrv1.Unstructured{Object: data}
-	return &u, err
+	return &ustrv1.Unstructured{Object: data}, err
 }
 
 // DeploymentMock creates a mocked Deployment object of busybox.
@@ -385,6 +396,13 @@ func NestedDatabaseCRMock(ns, name string) NestedDatabase {
 	}
 }
 
+// UnstructuredNestedDatabaseCRMock returns a unstructured object from NestedDatabaseCRMock.
+func UnstructuredNestedDatabaseCRMock(ns, name string) (*unstructured.Unstructured, error) {
+	db := NestedDatabaseCRMock(ns, name)
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&db)
+	return &ustrv1.Unstructured{Object: data}, err
+}
+
 // ConfigMapDatabaseSpec ...
 type ConfigMapDatabaseSpec struct {
 	DBConfigMap string `json:"dbConfigMap"`
@@ -398,7 +416,7 @@ type ConfigMapDatabase struct {
 	Spec ConfigMapDatabaseSpec `json:"spec,omitempty"`
 }
 
-// DatabaseConfigMapMock ...
+// DatabaseConfigMapMock returns a local ConfigMapDatabase object.
 func DatabaseConfigMapMock(ns, name string) *ConfigMapDatabase {
 	return &ConfigMapDatabase{
 		TypeMeta: metav1.TypeMeta{
@@ -413,4 +431,11 @@ func DatabaseConfigMapMock(ns, name string) *ConfigMapDatabase {
 			DBConfigMap: "db-configmap",
 		},
 	}
+}
+
+// UnstructuredDatabaseConfigMapMock returns a unstructured version of DatabaseConfigMapMock.
+func UnstructuredDatabaseConfigMapMock(ns, name string) (*unstructured.Unstructured, error) {
+	db := DatabaseConfigMapMock(ns, name)
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&db)
+	return &ustrv1.Unstructured{Object: data}, err
 }


### PR DESCRIPTION
This PR will create a workflow where the controller watches for all "interesting" types of GVKs, and using `EnqueueRequestsFromMapFunc` (`controller-runtime/handler`) to always extract a `ServiceBindingRequest` request from those.

To identify the namespaced-name of an `ServiceBindingRequest`, this PR rely in annotations, and also checks if the given resource is actually a SBR. At the end of a binding workflow, after actions are executed successfully, related resources are annotated to identify from which `ServiceBindingRequest` instance it belongs to.

#### TODOs

- [ ] Review controller predicate, do we want to reconcile when annotations are found, or when generation has changed (default behavior);
- [ ] Improve getWatchingGVKs` to allow more GVKs, review the logic we would like to apply;

#### Fixes

- #147 
- #148 

### Collateral Effects

During coding some components were refactored to use a dynamic client, since during testing the objects were not visible by "static" and dynamic clients at the same time. Since they do not share the same cache.