### PR TITLE
Define a Collector interface to be consumed by Retriever

### DIFF
--- a/pkg/controller/servicebindingrequest/collectors/collector.go
+++ b/pkg/controller/servicebindingrequest/collectors/collector.go
@@ -1,0 +1,14 @@
+package collectors
+
+type Collector interface {
+	Collect() (BindableMetadata, error)
+}
+
+type BindableMetadata struct {
+	BindableSecrets
+	BindableVolumePaths
+}
+
+type BindableSecrets map[string][]byte
+
+type BindableVolumePaths []string

--- a/pkg/controller/servicebindingrequest/collectors/cr.go
+++ b/pkg/controller/servicebindingrequest/collectors/cr.go
@@ -1,0 +1,1 @@
+package collectors

--- a/pkg/controller/servicebindingrequest/collectors/cr.go
+++ b/pkg/controller/servicebindingrequest/collectors/cr.go
@@ -1,1 +1,22 @@
 package collectors
+
+// CrCollector reads all data referred in plan instance
+type CrCollector struct {
+	ctx           context.Context // request context
+	client        client.Client   // Kubernetes API client
+}
+
+// NewCSVCollector creates a new CSVCollector
+func NewCrCollector(ctx context.Context, client client.Client) CrCollector {
+	return CrCollector{
+		ctx:           ctx,
+		client:        client,
+}
+
+// Collect returns all bindable metadata
+func (c *CrCollector) Collect() (*BindableMetadata, error) {
+	/*
+		Read from the CR JSON path
+	*/
+	return nil, nil
+}

--- a/pkg/controller/servicebindingrequest/collectors/csv.go
+++ b/pkg/controller/servicebindingrequest/collectors/csv.go
@@ -1,0 +1,164 @@
+package collectors
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/controller/servicebindingrequest/plan"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	basePrefix              = "binding:env:object"
+	secretPrefix            = basePrefix + ":secret"
+	configMapPrefix         = basePrefix + ":configmap"
+	attributePrefix         = "binding:env:attribute"
+	volumeMountSecretPrefix = "binding:volumemount:secret"
+)
+
+// CSVCollector reads all data referred in plan instance
+type CSVCollector struct {
+	ctx           context.Context // request context
+	client        client.Client   // Kubernetes API client
+	plan          plan.Plan       // plan instance
+	secretData    map[string][]byte
+	volumeData    []string
+	bindingPrefix string
+}
+
+// NewCSVCollector creates a new CSVCollector
+func NewCSVCollector(ctx context.Context, client client.Client, plan plan.Plan, bindingPrefix string) CSVCollector {
+	return CSVCollector{
+		ctx:           ctx,
+		client:        client,
+		plan:          plan.Plan,
+		bindingPrefix: bindingPrefix,
+	}
+}
+
+// Collect returns all bindable metadata
+func (c *CSVCollector) Collect() (*BindableMetadata, error) {
+
+	for _, specDescriptor := range c.plan.CRDDescription.SpecDescriptors {
+		if err := c.read("spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
+			return nil, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *CSVCollector) read(place, path string, xDescriptors []string) error {
+
+	// holds the secret name and items
+	secrets := make(map[string][]string)
+
+	// holds the configMap name and items
+	configMaps := make(map[string][]string)
+	for _, xDescriptor := range xDescriptors {
+		pathValue, err := c.getCRKey(place, path)
+		if err != nil {
+			return err
+		}
+
+		if strings.HasPrefix(xDescriptor, secretPrefix) {
+			secrets[pathValue] = append(secrets[pathValue], c.extractSecretItemName(xDescriptor))
+		} else if strings.HasPrefix(xDescriptor, configMapPrefix) {
+			configMaps[pathValue] = append(configMaps[pathValue], c.extractConfigMapItemName(xDescriptor))
+		} else if strings.HasPrefix(xDescriptor, volumeMountSecretPrefix) {
+			secrets[pathValue] = append(secrets[pathValue], c.extractSecretItemName(xDescriptor))
+			c.volumeData = append(c.volumeData, pathValue)
+		} else if strings.HasPrefix(xDescriptor, attributePrefix) {
+			c.store(path, []byte(pathValue))
+		}
+	}
+
+	for name, items := range secrets {
+		// loading secret items all-at-once
+		err := c.readSecret(name, items)
+		if err != nil {
+			return err
+		}
+	}
+	/* FIXIT
+
+	for name, items := range configMaps {
+		// add the function readConfigMap
+		err := c.readConfigMap(name, items)
+		if err != nil {
+			return err
+		}
+	}
+	*/
+	return nil
+}
+
+func (c *CSVCollector) readSecret(name string, items []string) error {
+	secretObj := corev1.Secret{}
+	err := c.client.Get(c.ctx, types.NamespacedName{Namespace: c.plan.Ns, Name: name}, &secretObj)
+	if err != nil {
+		return err
+	}
+	for key, value := range secretObj.Data {
+		c.store(fmt.Sprintf("secret_%s", key), value)
+	}
+	return nil
+}
+
+// getCRKey retrieve key in section from CR object, part of the "plan" instance.
+func (c *CSVCollector) getCRKey(section string, key string) (string, error) {
+	obj := c.plan.CR.Object
+	objName := c.plan.CR.GetName()
+
+	sectionMap, exists := obj[section]
+	if !exists {
+		return "", fmt.Errorf("Can't find '%s' section in CR named '%s'", section, objName)
+	}
+
+	return c.getNestedValue(key, sectionMap)
+}
+
+// getNestedValue retrieve value from dotted key path
+func (c *CSVCollector) getNestedValue(key string, sectionMap interface{}) (string, error) {
+	if !strings.Contains(key, ".") {
+		value, exists := sectionMap.(map[string]interface{})[key]
+		if !exists {
+			return "", fmt.Errorf("Can't find key '%s'", key)
+		}
+		return fmt.Sprintf("%v", value), nil
+	}
+	attrs := strings.SplitN(key, ".", 2)
+	newSectionMap, exists := sectionMap.(map[string]interface{})[attrs[0]]
+	if !exists {
+		return "", fmt.Errorf("Can't find '%v' section in CR", attrs)
+	}
+	return c.getNestedValue(attrs[1], newSectionMap.(map[string]interface{}))
+}
+
+// store stores key and value, formatting key to look like an environment variable.
+func (c *CSVCollector) store(key string, value []byte) {
+	key = strings.ReplaceAll(key, ":", "_")
+	key = strings.ReplaceAll(key, ".", "_")
+	if c.bindingPrefix == "" {
+		key = fmt.Sprintf("%s_%s", c.plan.CR.GetKind(), key)
+	} else {
+		key = fmt.Sprintf("%s_%s_%s", c.bindingPrefix, c.plan.CR.GetKind(), key)
+	}
+	key = strings.ToUpper(key)
+	c.secretData[key] = value
+}
+
+// extractSecretItemName based in x-descriptor entry, removing prefix in order to keep only the
+// secret item name.
+func (c *CSVCollector) extractSecretItemName(xDescriptor string) string {
+	return strings.ReplaceAll(xDescriptor, fmt.Sprintf("%s:", secretPrefix), "")
+}
+
+// extractConfigMapItemName based in x-descriptor entry, removing prefix in order to keep only the
+// configMap item name.
+func (c *CSVCollector) extractConfigMapItemName(xDescriptor string) string {
+	return strings.ReplaceAll(xDescriptor, fmt.Sprintf("%s:", configMapPrefix), "")
+}

--- a/pkg/controller/servicebindingrequest/plan/planner.go
+++ b/pkg/controller/servicebindingrequest/plan/planner.go
@@ -1,4 +1,4 @@
-package servicebindingrequest
+package plan
 
 import (
 	"context"

--- a/pkg/controller/servicebindingrequest/plan/planner_test.go
+++ b/pkg/controller/servicebindingrequest/plan/planner_test.go
@@ -1,4 +1,4 @@
-package servicebindingrequest
+package plan_test
 
 import (
 	"context"

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -10,6 +10,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/pkg/controller/servicebindingrequest/collectors"
+
 )
 
 // Reconciler reconciles a ServiceBindingRequest object
@@ -135,6 +137,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	logger.Info("Retrieving data to create intermediate secret.")
 	retriever := NewRetriever(ctx, r.client, plan, instance.Spec.EnvVarPrefix)
+	retriever.RegisterCollector(collectors.NewCSVCollector(ctx, r.client, plan, instance.Spec.EnvVarPrefix))
 	if err = retriever.Retrieve(); err != nil {
 		_ = r.setStatus(ctx, instance, bindingFail)
 		logger.Error(err, "On retrieving binding data.")

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -2,23 +2,23 @@ package servicebindingrequest
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"github.com/redhat-developer/service-binding-operator/pkg/controller/servicebindingrequest/plan"
+
 )
 
 // Retriever reads all data referred in plan instance, and store in a secret.
 type Retriever struct {
-	ctx           context.Context   // request context
-	client        client.Client     // Kubernetes API client
-	plan          *Plan             // plan instance
+	ctx           context.Context // request context
+	client        client.Client   // Kubernetes API client
+	collectors    []Collector
+	plan          *plan.Plan             // plan instance
 	logger        logr.Logger       // logger instance
 	data          map[string][]byte // data retrieved
 	volumeKeys    []string
@@ -33,156 +33,9 @@ const (
 	volumeMountSecretPrefix = "binding:volumemount:secret"
 )
 
-// getNestedValue retrieve value from dotted key path
-func (r *Retriever) getNestedValue(key string, sectionMap interface{}) (string, error) {
-	if !strings.Contains(key, ".") {
-		value, exists := sectionMap.(map[string]interface{})[key]
-		if !exists {
-			return "", fmt.Errorf("Can't find key '%s'", key)
-		}
-		return fmt.Sprintf("%v", value), nil
-	}
-	attrs := strings.SplitN(key, ".", 2)
-	newSectionMap, exists := sectionMap.(map[string]interface{})[attrs[0]]
-	if !exists {
-		return "", fmt.Errorf("Can't find '%v' section in CR", attrs)
-	}
-	return r.getNestedValue(attrs[1], newSectionMap.(map[string]interface{}))
-}
-
-// getCRKey retrieve key in section from CR object, part of the "plan" instance.
-func (r *Retriever) getCRKey(section string, key string) (string, error) {
-	obj := r.plan.CR.Object
-	objName := r.plan.CR.GetName()
-	logger := r.logger.WithValues("CR.Name", objName, "CR.section", section, "CR.key", key)
-	logger.Info("Reading CR attributes...")
-
-	sectionMap, exists := obj[section]
-	if !exists {
-		return "", fmt.Errorf("Can't find '%s' section in CR named '%s'", section, objName)
-	}
-
-	return r.getNestedValue(key, sectionMap)
-}
-
-// read attributes from CR, where place means which top level key name contains the "path" actual
-// value, and parsing x-descriptors in order to either directly read CR data, or read items from
-// a secret.
-func (r *Retriever) read(place, path string, xDescriptors []string) error {
-	logger := r.logger.WithValues(
-		"CR.Section", place,
-		"CRDDescription.Path", path,
-		"CRDDescription.XDescriptors", xDescriptors,
-	)
-	logger.Info("Reading CRDDescription attributes...")
-
-	// holds the secret name and items
-	secrets := make(map[string][]string)
-
-	// holds the configMap name and items
-	configMaps := make(map[string][]string)
-	for _, xDescriptor := range xDescriptors {
-		logger = logger.WithValues("CRDDescription.xDescriptor", xDescriptor)
-		logger.Info("Inspecting xDescriptor...")
-		pathValue, err := r.getCRKey(place, path)
-		if err != nil {
-			return err
-		}
-
-		if strings.HasPrefix(xDescriptor, secretPrefix) {
-			secrets[pathValue] = append(secrets[pathValue], r.extractSecretItemName(xDescriptor))
-		} else if strings.HasPrefix(xDescriptor, configMapPrefix) {
-			configMaps[pathValue] = append(configMaps[pathValue], r.extractConfigMapItemName(xDescriptor))
-		} else if strings.HasPrefix(xDescriptor, volumeMountSecretPrefix) {
-			secrets[pathValue] = append(secrets[pathValue], r.extractSecretItemName(xDescriptor))
-			r.volumeKeys = append(r.volumeKeys, pathValue)
-		} else if strings.HasPrefix(xDescriptor, attributePrefix) {
-			r.store(path, []byte(pathValue))
-		}
-	}
-
-	for name, items := range secrets {
-		// loading secret items all-at-once
-		err := r.readSecret(name, items)
-		if err != nil {
-			return err
-		}
-	}
-	for name, items := range configMaps {
-		// add the function readConfigMap
-		err := r.readConfigMap(name, items)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// extractSecretItemName based in x-descriptor entry, removing prefix in order to keep only the
-// secret item name.
-func (r *Retriever) extractSecretItemName(xDescriptor string) string {
-	return strings.ReplaceAll(xDescriptor, fmt.Sprintf("%s:", secretPrefix), "")
-}
-
-// extractConfigMapItemName based in x-descriptor entry, removing prefix in order to keep only the
-// configMap item name.
-func (r *Retriever) extractConfigMapItemName(xDescriptor string) string {
-	return strings.ReplaceAll(xDescriptor, fmt.Sprintf("%s:", configMapPrefix), "")
-}
-
-// readSecret based in secret name and list of items, read a secret from the same namespace informed
-// in plan instance.
-func (r *Retriever) readSecret(name string, items []string) error {
-	logger := r.logger.WithValues("Secret.Name", name, "Secret.Items", items)
-	logger.Info("Reading secret items...")
-	secretObj := corev1.Secret{}
-	err := r.client.Get(r.ctx, types.NamespacedName{Namespace: r.plan.Ns, Name: name}, &secretObj)
-	if err != nil {
-		return err
-	}
-	logger.Info("Inspecting secret data...")
-	for key, value := range secretObj.Data {
-		logger.WithValues("Secret.Key.Name", key, "Secret.Key.Length", len(value)).
-			Info("Inspecting secret key...")
-		// making sure key name has a secret reference
-		r.store(fmt.Sprintf("secret_%s", key), value)
-	}
-	return nil
-}
-
-// readConfigMap based in configMap name and list of items, read a configMap from the same namespace informed
-// in plan instance.
-func (r *Retriever) readConfigMap(name string, items []string) error {
-	logger := r.logger.WithValues("ConfigMap.Name", name, "ConfigMap.Items", items)
-	logger.Info("Reading ConfigMap items...")
-	configMapObj := corev1.ConfigMap{}
-	err := r.client.Get(r.ctx, types.NamespacedName{Namespace: r.plan.Ns, Name: name}, &configMapObj)
-	if err != nil {
-		return err
-	}
-	logger.Info("Inspecting configMap data...")
-	for key, value := range configMapObj.Data {
-		logger.WithValues("configMap.Key.Name", key, "configMap.Key.Length", len(value)).
-			Info("Inspecting configMap key...")
-		// making sure key name has a configMap reference
-		// string to byte
-		r.store(fmt.Sprintf("configMap_%s", key), []byte(value))
-	}
-
-	return nil
-}
-
-// store key and value, formatting key to look like an environment variable.
-func (r *Retriever) store(key string, value []byte) {
-	key = strings.ReplaceAll(key, ":", "_")
-	key = strings.ReplaceAll(key, ".", "_")
-	if r.bindingPrefix == "" {
-		key = fmt.Sprintf("%s_%s", r.plan.CR.GetKind(), key)
-	} else {
-		key = fmt.Sprintf("%s_%s_%s", r.bindingPrefix, r.plan.CR.GetKind(), key)
-	}
-	key = strings.ToUpper(key)
-	r.data[key] = value
+// RegisterCollector registers a collector.
+func (r *Retriever) RegisterCollector(c Collector) {
+	r.collectors = append(r.collectors, c)
 }
 
 // saveDataOnSecret create or update secret that will store the data collected.
@@ -209,27 +62,17 @@ func (r *Retriever) saveDataOnSecret() error {
 
 // Retrieve loop and read data pointed by the references in plan instance.
 func (r *Retriever) Retrieve() error {
-	var err error
 
-	r.logger.Info("Looking for spec-descriptors in 'spec'...")
-	for _, specDescriptor := range r.plan.CRDDescription.SpecDescriptors {
-		if err = r.read("spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
-			return err
-		}
-	}
-
-	r.logger.Info("Looking for status-descriptors in 'status'...")
-	for _, statusDescriptor := range r.plan.CRDDescription.StatusDescriptors {
-		if err = r.read("status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
-			return err
-		}
+	for _, c := range r.collectors {
+		c.Collect()
+		// c.Collect() returns BindableMetadata, use it to populate data structures in Retriever.
 	}
 
 	return r.saveDataOnSecret()
 }
 
 // NewRetriever instantiate a new retriever instance.
-func NewRetriever(ctx context.Context, client client.Client, plan *Plan, bindingPrefix string) *Retriever {
+func NewRetriever(ctx context.Context, client client.Client, plan *plan.Plan, bindingPrefix string) *Retriever {
 	return &Retriever{
 		ctx:           ctx,
 		client:        client,


### PR DESCRIPTION
For https://github.com/redhat-developer/service-binding-operator/issues/154

### Why
`Retriever` today does a lot of things. 
- figures out which configmap keys and secret keys to read
- figures out how to construct environment environment variables and volume paths
- creates the secret(s).

I would like to separate out (1) figuring out which cms and secrets ,  (2) creation of resources.


### Issues
While it is an excellent design to start with, the moment we have different ways to collect the "what to bind", it doesn't scale.
1. reading from a CSV and use env var prefix
2. reading from a CR json paths and use custom env variables.
3. In future, reading from CRD OpenAPI Validation spec

### What
Introducing the `Collector` Interface which makes implementations implement a `Collect()` , it is hard to scale the design when there are multiple ways to find out what is to be bound:

In this PR, I've demonstrated how to implement the existing collector with the new interface.
- CSVCollector - handles the logic to parse the CSV and get env vars out of it.
- CRCollector - handles the logic to parse random CR jsonpaths and get env vars

```
type CSVCollector struct {

}

// Collect returns all bindable metadata by finding the same from CSVs
func (c *CSVCollector) Collect() (*BindableMetadata, error) {

    // business logic to collect all bindable metadata

}
```

All collectors get called in Retrieve(..)


```
// Retrieve loop and read data pointed by the references in plan instance.
func (r *Retriever) Retrieve() error {

	for _, c := range r.collectors {
		c.Collect()
		// c.Collect() returns BindableMetadata, use it to populate data structures in Retriever.
	}

	return r.saveDataOnSecret()
}
```

### How to add a new `Collector`

1. Create an implementation of the `Collector` interface, ie, implement a new structure which has a `Collect()` method.
2. Modify Reconcile(..) to register a new collector

```
retriever.RegisterCollector(collectors.NewCSVCollector(ctx, r.client, plan, instance.Spec.EnvVarPrefix))
```

And that's it. No code changes needed in retriever.go! 