### PR TITLE
Added in sleep statement that is referenced, but is missing

### DIFF
--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -181,6 +181,7 @@ func retry(attempts int, sleep time.Duration, fn func() error) error {
 		if err == nil {
 			break
 		}
+		time.Sleep(sleep)
 	}
 	return err
 }


### PR DESCRIPTION
Adding `time.Sleep` on `retry` method used in end-to-end tests.