### PR TITLE
Read objects incl. DC/D before annotating

### DIFF
--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -3,8 +3,9 @@ package servicebindingrequest
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -54,7 +55,7 @@ func (b *Binder) search() (*unstructured.UnstructuredList, error) {
 	}
 	// Return fake NotFound error explicitly to ensure requeue when objList(^) is empty.
 	if len(objList.Items) == 0 {
-		return nil , errors.NewNotFound(
+		return nil, errors.NewNotFound(
 			gvr.GroupResource(),
 			b.sbr.Spec.ApplicationSelector.Resource,
 		)
@@ -266,6 +267,8 @@ func (b *Binder) update(objs *unstructured.UnstructuredList) ([]*unstructured.Un
 		}
 
 		logger.Info("Updating object in Kube...")
+
+		// updatedObj holds the returned object after it was updated.
 		if err := b.client.Update(b.ctx, updatedObj); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Annotating/updating the DC looks unreliable because right after the binding is done, the `generation`
 changes frequently for a few seconds and hence any update on the object could potentially be an attempt to update a stale  object.

```
2019-09-03T11:03:43.142+0530    ERROR   servicebindingrequest   unable to set/update annotations in object      {"SBR.Namespace": "demo-akash", "SBR.Name": "binding-request", "Resource.GVK": "apps.openshift.io/v1, Kind=DeploymentConfig", "Resource.Namespace": "demo-akash", "Resource.Na
me": "nodejs-rest-http-crud", "error": "Operation cannot be fulfilled on deploymentconfigs.apps.openshift.io \"nodejs-rest-http-crud\": the object has been modified; please apply your changes to the latest version and try again"}
```

In this PR, I have proposed that we `get` the object right before `update`ing the annotation. This only reduces the probability of having a stale object - doesn't eliminate it.

@akashshinde @otaviof  Giving it a second thought, if the update fails the first time and a few reconciles are triggered because of the error in updating the DC, can we let it be that way - as long as it manages to finally find a stable non-frequently-changing DC to update the annotation into?  