### PR TITLE
Object Updates as Last Reconciliation Step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ OPERATOR_IMAGE ?= quay.io/${OPERATOR_GROUP}/${GO_PACKAGE_REPO_NAME}
 OPERATOR_TAG_SHORT ?= $(OPERATOR_VERSION)
 OPERATOR_TAG_LONG ?= $(OPERATOR_VERSION)-$(GIT_COMMIT_ID)
 OPERATOR_IMAGE_BUILDER ?= buildah
+OPERATOR_SDK_EXTRA_ARGS ?= ""
 
 QUAY_TOKEN ?= ""
 
@@ -190,7 +191,8 @@ test-e2e: e2e-setup
 			--debug \
 			--namespace $(TEST_NAMESPACE) \
 			--up-local \
-			--go-test-flags "-timeout=15m"
+			--go-test-flags "-timeout=15m" \
+			$(OPERATOR_SDK_EXTRA_ARGS)
 
 .PHONY: test-unit
 ## Runs the unit tests without code coverage
@@ -222,7 +224,10 @@ test-e2e-olm-ci:
 	$(Q)kubectl apply -f ./test/operator-hub/subscription.yaml
 	$(eval DEPLOYED_NAMESPACE := openshift-operators)
 	$(Q)./hack/check-crds.sh
-	$(Q)operator-sdk --verbose test local ./test/e2e --no-setup --go-test-flags "-timeout=15m"
+	$(Q)operator-sdk --verbose test local ./test/e2e \
+			--no-setup \
+			--go-test-flags "-timeout=15m" \
+			$(OPERATOR_SDK_EXTRA_ARGS)
 
 ## -- Build Go binary and OCI image targets --
 

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ OPERATOR_IMAGE ?= quay.io/${OPERATOR_GROUP}/${GO_PACKAGE_REPO_NAME}
 OPERATOR_TAG_SHORT ?= $(OPERATOR_VERSION)
 OPERATOR_TAG_LONG ?= $(OPERATOR_VERSION)-$(GIT_COMMIT_ID)
 OPERATOR_IMAGE_BUILDER ?= buildah
-OPERATOR_SDK_EXTRA_ARGS ?= ""
+OPERATOR_SDK_EXTRA_ARGS ?= "--debug"
 
 QUAY_TOKEN ?= ""
 
@@ -188,7 +188,6 @@ test-e2e: e2e-setup
 	$(info Running E2E test: $@)
 	$(Q)GO111MODULE=$(GO111MODULE) GOCACHE=$(GOCACHE) SERVICE_BINDING_OPERATOR_DISABLE_ELECTION=true \
 		operator-sdk --verbose test local ./test/e2e \
-			--debug \
 			--namespace $(TEST_NAMESPACE) \
 			--up-local \
 			--go-test-flags "-timeout=15m" \

--- a/pkg/controller/servicebindingrequest/annotations.go
+++ b/pkg/controller/servicebindingrequest/annotations.go
@@ -1,8 +1,6 @@
 package servicebindingrequest
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -79,7 +77,6 @@ func IsSBRNamespacedNameEmpty(namespacedName types.NamespacedName) bool {
 // SetSBRAnnotations update existing annotations to include operator's. The annotations added are
 // referring to a existing SBR namespaced name.
 func SetSBRAnnotations(
-	ctx context.Context,
 	client dynamic.Interface,
 	namespacedName types.NamespacedName,
 	objs []*unstructured.Unstructured,

--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -254,34 +254,34 @@ func (b *Binder) update(objs *unstructured.UnstructuredList) ([]*unstructured.Un
 		logger := b.logger.WithValues("Obj.Name", name, "Obj.Kind", obj.GetKind())
 		logger.Info("Inspecting object...")
 
-		modifiedObj, err := b.updateSpecContainers(logger, &obj)
+		updatedObj, err := b.updateSpecContainers(logger, &obj)
 		if err != nil {
 			return nil, err
 		}
 
 		if len(b.volumeKeys) > 0 {
-			modifiedObj, err = b.updateSpecVolumes(logger, &obj)
+			updatedObj, err = b.updateSpecVolumes(logger, &obj)
 			if err != nil {
 				return nil, err
 			}
 		}
 
 		logger.Info("Updating object...")
-		if err := b.client.Update(b.ctx, modifiedObj); err != nil {
+		if err := b.client.Update(b.ctx, updatedObj); err != nil {
 			return nil, err
 		}
 
 		logger.Info("Reading back updated object...")
 		// reading object back again, to comply with possible modifications
 		namespacedName := types.NamespacedName{
-			Namespace: modifiedObj.GetNamespace(),
-			Name:      modifiedObj.GetName(),
+			Namespace: updatedObj.GetNamespace(),
+			Name:      updatedObj.GetName(),
 		}
-		if err = b.client.Get(b.ctx, namespacedName, modifiedObj); err != nil {
+		if err = b.client.Get(b.ctx, namespacedName, updatedObj); err != nil {
 			return nil, err
 		}
 
-		updatedObjs = append(updatedObjs, modifiedObj)
+		updatedObjs = append(updatedObjs, updatedObj)
 	}
 
 	return updatedObjs, nil

--- a/pkg/controller/servicebindingrequest/common.go
+++ b/pkg/controller/servicebindingrequest/common.go
@@ -18,6 +18,9 @@ const ServiceBindingRequestKind = "ServiceBindingRequest"
 // DeploymentConfigKind defines the name of DeploymentConfig kind.
 const DeploymentConfigKind = "DeploymentConfig"
 
+// ServiceBindingRequestResource the name of ServiceBindingRequest resource.
+const ServiceBindingRequestResource = "servicebindingrequests"
+
 // RequeueOnNotFound inspect error, if not-found then returns Requeue, otherwise expose the error.
 func RequeueOnNotFound(err error, requeueAfter int64) (reconcile.Result, error) {
 	if errors.IsNotFound(err) {

--- a/pkg/controller/servicebindingrequest/olm.go
+++ b/pkg/controller/servicebindingrequest/olm.go
@@ -1,6 +1,7 @@
 package servicebindingrequest
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -115,7 +116,7 @@ func (o *OLM) SelectCRDByGVK(gvk schema.GroupVersionKind) (*olmv1alpha1.CRDDescr
 
 	if len(crds) == 0 {
 		logger.Info("No CRD could be found for GVK.")
-		return nil, nil
+		return nil, fmt.Errorf("no crd could be found for gvk")
 	}
 	return crds[0], nil
 }

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,43 +35,88 @@ const (
 )
 
 // setSecretName update the CR status field to "in progress", and setting secret name.
-func (r *Reconciler) setSecretName(
-	ctx context.Context,
-	instance *v1alpha1.ServiceBindingRequest,
-	name string,
-) error {
-	instance.Status.BindingStatus = bindingInProgress
-	instance.Status.Secret = name
-	return r.client.Status().Update(ctx, instance)
-
+func (r *Reconciler) setSecretName(sbrStatus *v1alpha1.ServiceBindingRequestStatus, name string) {
+	sbrStatus.BindingStatus = bindingInProgress
+	sbrStatus.Secret = name
 }
 
 // setStatus update the CR status field.
-func (r *Reconciler) setStatus(
-	ctx context.Context,
-	instance *v1alpha1.ServiceBindingRequest,
-	status string,
-) error {
-	instance.Status.BindingStatus = status
-	return r.client.Status().Update(ctx, instance)
+func (r *Reconciler) setStatus(sbrStatus *v1alpha1.ServiceBindingRequestStatus, status string) {
+	sbrStatus.BindingStatus = status
 }
 
 // setApplicationObjects set the ApplicationObject status field, and also set the overall status as
 // success, since it was able to bind applications.
 func (r *Reconciler) setApplicationObjects(
-	ctx context.Context,
-	instance *v1alpha1.ServiceBindingRequest,
+	sbrStatus *v1alpha1.ServiceBindingRequestStatus,
 	objs []*unstructured.Unstructured,
-) error {
+) {
 	names := []string{}
 	for _, obj := range objs {
 		names = append(names, fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName()))
 	}
+	sbrStatus.BindingStatus = bindingSuccess
+	sbrStatus.ApplicationObjects = names
+}
 
-	instance.Status.BindingStatus = bindingSuccess
-	instance.Status.ApplicationObjects = names
+// getServiceBindingRequest retrieve the SBR object based on namespaced-name.
+func (r *Reconciler) getServiceBindingRequest(
+	namespacedName types.NamespacedName,
+) (*v1alpha1.ServiceBindingRequest, error) {
+	gr := v1alpha1.SchemeGroupVersion.WithResource(ServiceBindingRequestResource)
+	resourceClient := r.dynClient.Resource(gr).Namespace(namespacedName.Namespace)
+	u, err := resourceClient.Get(namespacedName.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	sbr := &v1alpha1.ServiceBindingRequest{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, sbr)
+	if err != nil {
+		return nil, err
+	}
+	return sbr, nil
+}
 
-	return r.client.Status().Update(ctx, instance)
+// updateStatusServiceBindingRequest update the status field of a ServiceBindingRequest.
+func (r *Reconciler) updateStatusServiceBindingRequest(
+	sbr *v1alpha1.ServiceBindingRequest,
+	sbrStatus *v1alpha1.ServiceBindingRequestStatus,
+) error {
+	// coping status over informed object
+	sbr.Status = *sbrStatus
+
+	// converting object into unstructured
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sbr)
+	if err != nil {
+		return err
+	}
+	u := &unstructured.Unstructured{Object: data}
+
+	gr := v1alpha1.SchemeGroupVersion.WithResource(ServiceBindingRequestResource)
+	resourceClient := r.dynClient.Resource(gr).Namespace(sbr.GetNamespace())
+	_, err = resourceClient.UpdateStatus(u, metav1.UpdateOptions{})
+	return err
+}
+
+// onError comprise the update of ServiceBindingRequest status to set error flag, and inspect
+// informed error to apply a different behavior for not-founds.
+func (r *Reconciler) onError(
+	err error,
+	sbr *v1alpha1.ServiceBindingRequest,
+	sbrStatus *v1alpha1.ServiceBindingRequestStatus,
+	objs []*unstructured.Unstructured,
+) (reconcile.Result, error) {
+	// settting overall status to failed
+	r.setStatus(sbrStatus, bindingFail)
+	//
+	if objs != nil {
+		r.setApplicationObjects(sbrStatus, objs)
+	}
+	errStatus := r.updateStatusServiceBindingRequest(sbr, sbrStatus)
+	if errStatus != nil {
+		return RequeueError(errStatus)
+	}
+	return RequeueOnNotFound(err, requeueAfter)
 }
 
 // Reconcile a ServiceBindingRequest by the following steps:
@@ -85,6 +131,7 @@ func (r *Reconciler) setApplicationObjects(
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := context.TODO()
 	objectsToAnnotate := []*unstructured.Unstructured{}
+
 	logger := logf.Log.WithValues(
 		"Request.Namespace", request.Namespace,
 		"Request.Name", request.Name,
@@ -92,32 +139,28 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	logger.Info("Reconciling ServiceBindingRequest...")
 
 	// fetch the ServiceBindingRequest instance
-	instance := &v1alpha1.ServiceBindingRequest{}
-	err := r.client.Get(ctx, request.NamespacedName, instance)
+	sbr, err := r.getServiceBindingRequest(request.NamespacedName)
 	if err != nil {
 		logger.Error(err, "On retrieving service-binding-request instance.")
 		return RequeueError(err)
 	}
 
-	logger = logger.WithValues("ServiceBindingRequest.Name", instance.Name)
-	logger.Info("Found service binding request to inspect")
+	// splitting instance from it's status
+	sbrStatus := sbr.Status
 
-	if err = r.setStatus(ctx, instance, bindingInProgress); err != nil {
-		logger.Error(err, "On updating service-binding-request status.")
-		return RequeueError(err)
-	}
+	logger = logger.WithValues("ServiceBindingRequest.Name", sbr.Name)
+	logger.Info("Found service binding request to inspect")
 
 	//
 	// Planing changes
 	//
 
 	logger.Info("Creating a plan based on OLM and CRD.")
-	planner := NewPlanner(ctx, r.dynClient, instance)
+	planner := NewPlanner(ctx, r.dynClient, sbr)
 	plan, err := planner.Plan()
 	if err != nil {
-		_ = r.setStatus(ctx, instance, bindingFail)
 		logger.Error(err, "On creating a plan to bind applications.")
-		return RequeueOnNotFound(err, requeueAfter)
+		return r.onError(err, sbr, &sbrStatus, nil)
 	}
 
 	// storing CR in objects to annotate
@@ -128,18 +171,14 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	//
 
 	logger.Info("Retrieving data to create intermediate secret.")
-	retriever := NewRetriever(ctx, r.dynClient, plan, instance.Spec.EnvVarPrefix)
+	retriever := NewRetriever(ctx, r.dynClient, plan, sbr.Spec.EnvVarPrefix)
 	retrievedObjects, err := retriever.Retrieve()
 	if err != nil {
-		_ = r.setStatus(ctx, instance, bindingFail)
 		logger.Error(err, "On retrieving binding data.")
-		return RequeueOnNotFound(err, requeueAfter)
+		return r.onError(err, sbr, &sbrStatus, nil)
 	}
 
-	if err = r.setSecretName(ctx, instance, plan.Name); err != nil {
-		logger.Error(err, "On updating service-binding-request status.")
-		return RequeueError(err)
-	}
+	r.setSecretName(&sbrStatus, plan.Name)
 
 	// storing objects used in Retriever
 	objectsToAnnotate = append(objectsToAnnotate, retrievedObjects...)
@@ -149,17 +188,15 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	//
 
 	logger.Info("Binding applications with intermediary secret.")
-	binder := NewBinder(ctx, r.client, r.dynClient, instance, retriever.volumeKeys)
+	binder := NewBinder(ctx, r.client, r.dynClient, sbr, retriever.volumeKeys)
 	updatedObjects, err := binder.Bind()
 	if err != nil {
-		_ = r.setStatus(ctx, instance, bindingFail)
 		logger.Error(err, "On binding application.")
-		return RequeueOnNotFound(err, requeueAfter)
-	} else if err = r.setApplicationObjects(ctx, instance, updatedObjects); err != nil {
-		logger.Error(err, "On updating application objects status field.")
-		return RequeueError(err)
+		return r.onError(err, sbr, &sbrStatus, updatedObjects)
 	}
 
+	// saving on status the list of objects that have been touched
+	r.setApplicationObjects(&sbrStatus, updatedObjects)
 	// storing objects used in Binder
 	objectsToAnnotate = append(objectsToAnnotate, updatedObjects...)
 
@@ -167,12 +204,14 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Annotating objects related to binding
 	//
 
-	sbrNamespacedName := types.NamespacedName{
-		Namespace: instance.GetNamespace(),
-		Name:      instance.GetName(),
-	}
-	if err = SetSBRAnnotations(ctx, r.dynClient, sbrNamespacedName, objectsToAnnotate); err != nil {
+	if err = SetSBRAnnotations(r.dynClient, request.NamespacedName, objectsToAnnotate); err != nil {
 		logger.Error(err, "On setting annotations in related objects.")
+		return r.onError(err, sbr, &sbrStatus, updatedObjects)
+	}
+
+	// updating status of request instance
+	if err = r.updateStatusServiceBindingRequest(sbr, &sbrStatus); err != nil {
+		logger.Error(err, "On updating status of ServiceBindingRequest.")
 		return RequeueError(err)
 	}
 

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -171,7 +171,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	//
 
 	logger.Info("Retrieving data to create intermediate secret.")
-	retriever := NewRetriever(ctx, r.dynClient, plan, sbr.Spec.EnvVarPrefix)
+	retriever := NewRetriever(r.dynClient, plan, sbr.Spec.EnvVarPrefix)
 	retrievedObjects, err := retriever.Retrieve()
 	if err != nil {
 		logger.Error(err, "On retrieving binding data.")

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
@@ -46,14 +50,15 @@ func TestReconcilerReconcileUsingSecret(t *testing.T) {
 	}
 
 	f := mocks.NewFake(t, reconcilerNs)
-	f.AddMockedServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
+	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
 	f.AddMockedUnstructuredCSV("cluster-service-version-list")
-	f.AddMockedDatabaseCR(resourceRef)
+	f.AddMockedUnstructuredDatabaseCR(resourceRef)
 	f.AddMockedUnstructuredDeployment(reconcilerName, matchLabels)
 	f.AddMockedSecret("db-credentials")
 
 	fakeClient := f.FakeClient()
-	reconciler := &Reconciler{client: fakeClient, dynClient: f.FakeDynClient(), scheme: f.S}
+	fakeDynClient := f.FakeDynClient()
+	reconciler := &Reconciler{client: fakeClient, dynClient: fakeDynClient, scheme: f.S}
 
 	t.Run("reconcile-using-secret", func(t *testing.T) {
 		res, err := reconciler.Reconcile(reconcileRequest())
@@ -70,14 +75,105 @@ func TestReconcilerReconcileUsingSecret(t *testing.T) {
 		assert.NotNil(t, containers[0].EnvFrom[0].SecretRef)
 		assert.Equal(t, reconcilerName, containers[0].EnvFrom[0].SecretRef.Name)
 
-		sbrOutput := v1alpha1.ServiceBindingRequest{}
-		require.Nil(t, fakeClient.Get(ctx, namespacedName, &sbrOutput))
+		namespacedName = types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+		sbrOutput, err := reconciler.getServiceBindingRequest(namespacedName)
+		require.NoError(t, err)
+
 		require.Equal(t, "Success", sbrOutput.Status.BindingStatus)
 		require.Equal(t, reconcilerName, sbrOutput.Status.Secret)
 
 		require.Equal(t, 1, len(sbrOutput.Status.ApplicationObjects))
 		expectedStatus := fmt.Sprintf("%s/%s", reconcilerNs, reconcilerName)
 		assert.Equal(t, expectedStatus, sbrOutput.Status.ApplicationObjects[0])
+	})
+}
+
+func updateSBR(t *testing.T, client dynamic.Interface, sbr *v1alpha1.ServiceBindingRequest) {
+	namespacedName := types.NamespacedName{Namespace: sbr.GetNamespace(), Name: sbr.GetName()}
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sbr)
+	require.NoError(t, err)
+	u := &unstructured.Unstructured{Object: data}
+
+	gr := v1alpha1.SchemeGroupVersion.WithResource(ServiceBindingRequestResource)
+	resourceClient := client.Resource(gr).Namespace(namespacedName.Namespace)
+	_, err = resourceClient.Update(u, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+// TestReconcilerForForcedTriggeringOfBinding test the reconciliation process using a secret,
+// and using TriggerRebind = true, false
+func TestReconcilerForForcedTriggeringOfBinding(t *testing.T) {
+	ctx := context.TODO()
+	resourceRef := "test-for-forced-trigger"
+	matchLabels := map[string]string{
+		"connects-to": "database",
+		"environment": "reconciler",
+	}
+
+	f := mocks.NewFake(t, reconcilerNs)
+	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
+	f.AddMockedUnstructuredCSV("cluster-service-version-list-forced-trigger")
+	f.AddMockedUnstructuredDatabaseCR(resourceRef)
+	f.AddMockedUnstructuredDeployment(reconcilerName, matchLabels)
+	f.AddMockedSecret("db-credentials")
+
+	fakeClient := f.FakeClient()
+	fakeDynClient := f.FakeDynClient()
+	reconciler := &Reconciler{client: fakeClient, dynClient: fakeDynClient, scheme: f.S}
+
+	t.Run("reconcile-using-trigger-starting-with-true", func(t *testing.T) {
+		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+		sbrOutput, err := reconciler.getServiceBindingRequest(namespacedName)
+		require.NoError(t, err)
+
+		// set to True and reconcile
+		triggertrue := true
+		sbrOutput.Spec.TriggerRebinding = &triggertrue
+
+		updateSBR(t, fakeDynClient, sbrOutput)
+
+		res, err := reconciler.Reconcile(reconcileRequest())
+		assert.Nil(t, err)
+		assert.False(t, res.Requeue, "should not requeue")
+
+		d := appsv1.Deployment{}
+		require.Nil(t, fakeClient.Get(ctx, namespacedName, &d))
+
+		containers := d.Spec.Template.Spec.Containers
+		assert.Equal(t, reconcilerName, containers[0].EnvFrom[0].SecretRef.Name)
+
+		sbrOutput, err = reconciler.getServiceBindingRequest(namespacedName)
+		require.NoError(t, err)
+
+		// If TRUE was set, this will become FALSE
+		require.False(t, *sbrOutput.Spec.TriggerRebinding)
+	})
+
+	t.Run("reconcile-using-trigger-starting-with-false", func(t *testing.T) {
+		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+		sbrOutput := &v1alpha1.ServiceBindingRequest{}
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, sbrOutput))
+
+		triggerfalse := false
+		sbrOutput.Spec.TriggerRebinding = &triggerfalse
+
+		updateSBR(t, fakeDynClient, sbrOutput)
+
+		res, err := reconciler.Reconcile(reconcileRequest())
+		assert.Nil(t, err)
+		assert.False(t, res.Requeue)
+
+		d := appsv1.Deployment{}
+		require.Nil(t, fakeClient.Get(ctx, namespacedName, &d))
+
+		containers := d.Spec.Template.Spec.Containers
+		assert.Equal(t, reconcilerName, containers[0].EnvFrom[0].SecretRef.Name)
+
+		sbrOutput, err = reconciler.getServiceBindingRequest(namespacedName)
+		require.NoError(t, err)
+
+		// If FALSE was set, this will stay FALSE
+		require.False(t, *sbrOutput.Spec.TriggerRebinding)
 	})
 }
 
@@ -90,9 +186,9 @@ func TestReconcilerReconcileUsingVolumes(t *testing.T) {
 	}
 
 	f := mocks.NewFake(t, reconcilerNs)
-	f.AddMockedServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
+	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
 	f.AddMockedUnstructuredCSVWithVolumeMount("cluster-service-version-list")
-	f.AddMockedDatabaseCR(resourceRef)
+	f.AddMockedUnstructuredDatabaseCR(resourceRef)
 	f.AddMockedUnstructuredDeployment(reconcilerName, matchLabels)
 	f.AddMockedSecret("db-credentials")
 

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -34,6 +34,25 @@ func reconcileRequest() reconcile.Request {
 	}
 }
 
+func TestReconcilerReconcileError(t *testing.T) {
+	resourceRef := "test-using-secret"
+	matchLabels := map[string]string{
+		"connects-to": "database",
+		"environment": "reconciler",
+	}
+
+	f := mocks.NewFake(t, reconcilerNs)
+	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, resourceRef, matchLabels)
+
+	fakeClient := f.FakeClient()
+	fakeDynClient := f.FakeDynClient()
+	reconciler := &Reconciler{client: fakeClient, dynClient: fakeDynClient, scheme: f.S}
+
+	res, err := reconciler.Reconcile(reconcileRequest())
+	assert.Error(t, err)
+	assert.True(t, res.Requeue)
+}
+
 // TestReconcilerReconcileUsingSecret test the reconciliation process using a secret, expected to be
 // the regular approach.
 func TestReconcilerReconcileUsingSecret(t *testing.T) {

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -1,7 +1,6 @@
 package servicebindingrequest
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -22,7 +21,6 @@ type Retriever struct {
 	logger        logr.Logger                  // logger instance
 	data          map[string][]byte            // data retrieved
 	objects       []*unstructured.Unstructured // list of objects employed
-	ctx           context.Context              // request context
 	client        dynamic.Interface            // Kubernetes API client
 	plan          *Plan                        // plan instance
 	volumeKeys    []string                     // list of keys found
@@ -294,17 +292,11 @@ func (r *Retriever) Retrieve() ([]*unstructured.Unstructured, error) {
 }
 
 // NewRetriever instantiate a new retriever instance.
-func NewRetriever(
-	ctx context.Context,
-	client dynamic.Interface,
-	plan *Plan,
-	bindingPrefix string,
-) *Retriever {
+func NewRetriever(client dynamic.Interface, plan *Plan, bindingPrefix string) *Retriever {
 	return &Retriever{
 		logger:        logf.Log.WithName("retriever"),
 		data:          make(map[string][]byte),
 		objects:       []*unstructured.Unstructured{},
-		ctx:           ctx,
 		client:        client,
 		plan:          plan,
 		volumeKeys:    []string{},

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -1,7 +1,6 @@
 package servicebindingrequest
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +29,7 @@ func TestRetriever(t *testing.T) {
 
 	fakeDynClient := f.FakeDynClient()
 
-	retriever = NewRetriever(context.TODO(), fakeDynClient, plan, "SERVICE_BINDING")
+	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
 
 	t.Run("retrive", func(t *testing.T) {
@@ -96,7 +95,7 @@ func TestRetriever(t *testing.T) {
 	})
 
 	t.Run("empty prefix", func(t *testing.T) {
-		retriever = NewRetriever(context.TODO(), fakeDynClient, plan, "")
+		retriever = NewRetriever(fakeDynClient, plan, "")
 		require.NotNil(t, retriever)
 		retriever.data = make(map[string][]byte)
 
@@ -127,7 +126,7 @@ func TestRetrieverWithNestedCRKey(t *testing.T) {
 
 	fakeDynClient := f.FakeDynClient()
 
-	retriever = NewRetriever(context.TODO(), fakeDynClient, plan, "SERVICE_BINDING")
+	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
 
 	t.Run("Second level", func(t *testing.T) {
@@ -169,7 +168,7 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 
 	fakeDynClient := f.FakeDynClient()
 
-	retriever = NewRetriever(context.TODO(), fakeDynClient, plan, "SERVICE_BINDING")
+	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
 
 	t.Run("read", func(t *testing.T) {

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -8,6 +8,7 @@ import (
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
@@ -27,9 +28,25 @@ type Fake struct {
 }
 
 // AddMockedServiceBindingRequest add mocked object from ServiceBindingRequestMock.
-func (f *Fake) AddMockedServiceBindingRequest(name, ref string, matchLabels map[string]string) *v1alpha1.ServiceBindingRequest {
+func (f *Fake) AddMockedServiceBindingRequest(
+	name string,
+	ref string,
+	matchLabels map[string]string,
+) *v1alpha1.ServiceBindingRequest {
 	f.S.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.ServiceBindingRequest{})
 	sbr := ServiceBindingRequestMock(f.ns, name, ref, matchLabels)
+	f.objs = append(f.objs, sbr)
+	return sbr
+}
+
+func (f *Fake) AddMockedUnstructuredServiceBindingRequest(
+	name string,
+	ref string,
+	matchLabels map[string]string,
+) *unstructured.Unstructured {
+	f.S.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.ServiceBindingRequest{})
+	sbr, err := UnstructuredServiceBindingRequestMock(f.ns, name, ref, matchLabels)
+	require.Nil(f.t, err)
 	f.objs = append(f.objs, sbr)
 	return sbr
 }
@@ -72,6 +89,13 @@ func (f *Fake) AddMockedDatabaseCR(ref string) {
 	require.Nil(f.t, pgapis.AddToScheme(f.S))
 	f.S.AddKnownTypes(pgv1alpha1.SchemeGroupVersion, &pgv1alpha1.Database{})
 	f.objs = append(f.objs, DatabaseCRMock(f.ns, ref))
+}
+
+func (f *Fake) AddMockedUnstructuredDatabaseCR(ref string) {
+	require.Nil(f.t, pgapis.AddToScheme(f.S))
+	d, err := UnstructuredDatabaseCRMock(f.ns, ref)
+	require.Nil(f.t, err)
+	f.objs = append(f.objs, d)
 }
 
 // AddMockedUnstructuredDeployment add mocked object from UnstructuredDeploymentMock.

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -268,7 +268,10 @@ func ConfigMapMock(ns, name string) *corev1.ConfigMap {
 
 // ServiceBindingRequestMock return a binding-request mock of informed name and match labels.
 func ServiceBindingRequestMock(
-	ns, name, resourceRef string, matchLabels map[string]string,
+	ns string,
+	name string,
+	resourceRef string,
+	matchLabels map[string]string,
 ) *v1alpha1.ServiceBindingRequest {
 	return &v1alpha1.ServiceBindingRequest{
 		ObjectMeta: metav1.ObjectMeta{
@@ -291,6 +294,23 @@ func ServiceBindingRequestMock(
 			},
 		},
 	}
+}
+
+// UnstructuredServiceBindingRequestMock returns a unstructured version of SBR.
+func UnstructuredServiceBindingRequestMock(
+	ns string,
+	name string,
+	resourceRef string,
+	matchLabels map[string]string,
+) (*unstructured.Unstructured, error) {
+	sbr := ServiceBindingRequestMock(ns, name, resourceRef, matchLabels)
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&sbr)
+	if err != nil {
+		return nil, err
+	}
+	u := &ustrv1.Unstructured{Object: data}
+	u.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind(OperatorKind))
+	return u, nil
 }
 
 // DeploymentListMock returns a list of DeploymentMock.


### PR DESCRIPTION
Refactoring reconciliation process to only update objects as last step. Status of `ServiceBindingRequest` is kept as a local variable, and updated as the reconciliation process goes, and attempts to update object status will happen in case of error, or at the end of reconciliation.

This PR addresses errors on updating objects that have been modified, and considerably reduces the amount of API calls during reconciliation.

Furthermore, fixing panic triggered on `planner.go:66` due a `nil` variable returned, covering issue scenario with unit-test. The test is asserting the reconciliation processes will return error and cause re-queue in case of expected resources are not found.