### PR TITLE
Updated reference to deployed app in example README

### DIFF
--- a/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/README.md
+++ b/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/README.md
@@ -142,7 +142,7 @@ The labels are:
 * `environment=demo` - indicates the demo environment - it narrows the search
 
 ``` bash
- kubectl patch dc nodejs-app -p '{"metadata": {"labels": {"connects-to": "postgres", "environment":"demo"}}}'
+ kubectl patch dc nodejs-rest-http-crud -p '{"metadata": {"labels": {"connects-to": "postgres", "environment":"demo"}}}'
 ```
 
 ### Express an intent to bind the DB and the application


### PR DESCRIPTION
README update must have been missed when we changed the app name.