### PR TITLE
Update the original (in-cluster) example to include a Makefile

### DIFF
--- a/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/Makefile
+++ b/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/Makefile
@@ -1,0 +1,115 @@
+# It's necessary to set this because some environments don't link sh -> bash.
+SHELL := /bin/bash
+
+#-----------------------------------------------------------------------------
+# VERBOSE target
+#-----------------------------------------------------------------------------
+
+# When you run make VERBOSE=1 (the default), executed commands will be printed
+# before executed. If you run make VERBOSE=2 verbose flags are turned on and
+# quiet flags are turned off for various commands. Use V_FLAG in places where
+# you can toggle on/off verbosity using -v. Use Q_FLAG in places where you can
+# toggle on/off quiet mode using -q. Use S_FLAG where you want to toggle on/off
+# silence mode using -s...
+VERBOSE ?= 1
+Q = @
+Q_FLAG = -q
+QUIET_FLAG = --quiet
+V_FLAG =
+VERBOSE_FLAG = 
+S_FLAG = -s
+X_FLAG =
+ifeq ($(VERBOSE),1)
+	Q =
+endif
+ifeq ($(VERBOSE),2)
+	Q =
+	Q_FLAG =
+	QUIET_FLAG =
+	S_FLAG =
+	V_FLAG = -v
+	VERBOSE_FLAG = --verbose
+	X_FLAG = -x
+endif
+
+
+.DEFAULT_GOAL := help
+
+## -- Utility targets --
+
+## Print help message for all Makefile targets
+## Run `make` or `make help` to see the help
+.PHONY: help
+help: ## Credit: https://gist.github.com/prwhite/8168133#gistcomment-2749866
+
+	@printf "Usage:\n  make <target>";
+
+	@awk '{ \
+			if ($$0 ~ /^.PHONY: [a-zA-Z\-\_0-9]+$$/) { \
+				helpCommand = substr($$0, index($$0, ":") + 2); \
+				if (helpMessage) { \
+					printf "\033[36m%-20s\033[0m %s\n", \
+						helpCommand, helpMessage; \
+					helpMessage = ""; \
+				} \
+			} else if ($$0 ~ /^[a-zA-Z\-\_0-9.]+:/) { \
+				helpCommand = substr($$0, 0, index($$0, ":")); \
+				if (helpMessage) { \
+					printf "\033[36m%-20s\033[0m %s\n", \
+						helpCommand, helpMessage; \
+					helpMessage = ""; \
+				} \
+			} else if ($$0 ~ /^##/) { \
+				if (helpMessage) { \
+					helpMessage = helpMessage"\n                     "substr($$0, 3); \
+				} else { \
+					helpMessage = substr($$0, 3); \
+				} \
+			} else { \
+				if (helpMessage) { \
+					print "\n                     "helpMessage"\n" \
+				} \
+				helpMessage = ""; \
+			} \
+		}' \
+		$(MAKEFILE_LIST)
+
+## -- Cluster Admin targets --
+
+.PHONY: install-service-binding-operator-source
+## Install the Service Binding Operator
+install-service-binding-operator-source:
+	@oc apply -f service-binding-operator-source.yaml
+
+.PHONY: install-backing-db-operator-source
+## Install the Backing Service DB Operator
+install-backing-db-operator-source:
+	@oc apply -f backing-db-operator-source.yaml 
+
+## -- Application Developer targets --
+
+.PHONY: create-project
+## Create the OpenShift project/namespace
+create-project:
+	@oc new-project service-binding-demo
+
+.PHONY: create-backing-db-instance
+## Create the Backing Service Database
+create-backing-db-instance:
+	@oc apply -f create-db-instance.yaml
+
+.PHONY: create-service-binding-request
+## Create the Service Binding Request
+create-service-binding-request:
+	@oc apply -f service-binding-request.yaml
+
+.PHONY: set-labels-on-nodejs-app
+## Set the binding labels for the NodeJS app
+set-labels-on-nodejs-app:
+	@oc project service-binding-demo
+	@oc patch dc nodejs-rest-http-crud -p '{"metadata": {"labels": {"connects-to": "postgres", "environment": "demo"}}}'
+
+.PHONY: delete-project
+## Delete the OpenShift project/namespace
+delete-project:
+	@-oc delete project service-binding-demo

--- a/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/README.md
+++ b/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/README.md
@@ -43,6 +43,11 @@ spec:
 EOS
 ```
 
+Alternatively, you can perform the same task with this make command:
+``` bash
+make install-service-binding-operator-source
+```
+
 Then navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Other` category select the `Service Bidning Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
@@ -70,6 +75,11 @@ spec:
 EOS
 ```
 
+Alternatively, you can perform the same task with this make command:
+``` bash
+make install-backing-db-operator-source
+```
+
 Then navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Database` category select the `PostgreSQL Database` operator
 
 ![PostgreSQL Database Operator as shown in OperatorHub](../../assets/operator-hub-pgo-screenshot.png)
@@ -92,6 +102,11 @@ apiVersion: v1
 metadata:
   name: service-binding-demo
 EOS
+```
+
+Alternatively, you can perform the same task with this make command:
+``` bash
+make create-project
 ```
 
 ### Import an application
@@ -130,7 +145,12 @@ spec:
   imageName: postgres
   dbName: db-demo
 EOS
+
+Alternatively, you can perform the same task with this make command:
+``` bash
+make create-backing-db-instance
 ```
+
 
 ### Set labels on the application
 
@@ -143,6 +163,11 @@ The labels are:
 
 ``` bash
  kubectl patch dc nodejs-app -p '{"metadata": {"labels": {"connects-to": "postgres", "environment":"demo"}}}'
+```
+
+Alternatively, you can perform the same task with this make command:
+``` bash
+make set-labels-on-nodejs-app
 ```
 
 ### Express an intent to bind the DB and the application
@@ -174,6 +199,11 @@ spec:
     resourceRef: db-demo
   mountPathPrefix: “”
 EOS
+```
+
+Alternatively, you can perform the same task with this make command:
+``` bash
+make create-service-binding-request
 ```
 
 There are 2 parts in the request:

--- a/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/backing-db-operator-source.yaml
+++ b/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/backing-db-operator-source.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorSource
 metadata:

--- a/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/create-db-instance.yaml
+++ b/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/create-db-instance.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: postgresql.baiju.dev/v1alpha1
 kind: Database
 metadata:

--- a/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/namespace.yaml
+++ b/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/namespace.yaml
@@ -1,3 +1,4 @@
+---
 kind: Namespace
 apiVersion: v1
 metadata:

--- a/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/service-binding-operator-source.yaml
+++ b/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/service-binding-operator-source.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorSource
 metadata:

--- a/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/service-binding-request.yaml
+++ b/examples/bind_imported_app_to_incluster_operator_managed_PostgreSQL_db/service-binding-request.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps.openshift.io/v1alpha1
 kind: ServiceBindingRequest
 metadata:


### PR DESCRIPTION
This pull request accomplishes a couple of things:

First, it adds a Makefile (with an updated README) to make it easier for users to perform the steps necessary to load and run the example.

Second, it brings this example into alignment with the RDS off cluster example which also makes use of a Makefile. 