### PR TITLE
Ensure lastbound env key is not added multiple times

### DIFF
--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -191,10 +191,24 @@ func (b *Binder) updateContainers(
 }
 
 func (b *Binder) appendEnvVar(envList []corev1.EnvVar, envParam string, envValue string) []corev1.EnvVar {
-	return append(envList, corev1.EnvVar{
-		Name:  envParam,
-		Value: envValue,
-	})
+	var updatedEnvList []corev1.EnvVar
+
+	alreadyPresent := false
+	for _, env := range envList {
+		if env.Name == envParam {
+			env.Value = envValue
+			alreadyPresent = true
+		}
+		updatedEnvList = append(updatedEnvList, env)
+	}
+
+	if !alreadyPresent {
+		updatedEnvList = append(updatedEnvList, corev1.EnvVar{
+			Name:  envParam,
+			Value: envValue,
+		})
+	}
+	return updatedEnvList
 }
 
 // appendEnvFrom based on secret name and list of EnvFromSource instances, making sure secret is

--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -91,6 +91,25 @@ func TestBinderNew(t *testing.T) {
 	})
 }
 
+func TestAppendEnvVar(t *testing.T) {
+	envName := "lastbound"
+	envList := []corev1.EnvVar{
+		corev1.EnvVar{
+			Name:  envName,
+			Value: "lastboundvalue",
+		},
+	}
+
+	binder := &Binder{}
+	updatedEnvVarList := binder.appendEnvVar(envList, envName, "someothervalue")
+
+	// validate that no new key is added.
+	// the existing key should be overwritten with the new value.
+
+	require.Len(t, updatedEnvVarList, 1)
+	require.Equal(t, updatedEnvVarList[0].Value, "someothervalue")
+}
+
 func TestBinderApplicationName(t *testing.T) {
 	ns := "binder"
 	name := "service-binding-request"


### PR DESCRIPTION
Ensure the following is added only once, but updated on subsequent reconciles.

```
 spec:
      containers:
        - resources: {}
          terminationMessagePath: /dev/termination-log
          name: app2
          env:
            - name: lastbound
              value: '2019-09-19T19:57:06-04:00'
```