### PR TITLE
Skip adding annotations to the Deployment

### DIFF
--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -226,15 +226,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// storing objects used in Binder
 	objectsToAnnotate = append(objectsToAnnotate, updatedObjects...)
 
-	//
-	// Annotating objects related to binding
-	//
-
-	if err = SetSBRAnnotations(r.dynClient, request.NamespacedName, objectsToAnnotate); err != nil {
-		logger.Error(err, "On setting annotations in related objects.")
-		return r.onError(err, sbr, &sbrStatus, updatedObjects)
-	}
-
 	// updating status of request instance
 	if err = r.updateStatusServiceBindingRequest(sbr, &sbrStatus); err != nil {
 		logger.Error(err, "On updating status of ServiceBindingRequest.")

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -224,6 +224,15 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// saving on status the list of objects that have been touched
 	r.setApplicationObjects(&sbrStatus, updatedObjects)
 
+	//
+	// Annotating objects related to binding
+	//
+
+	if err = SetSBRAnnotations(r.dynClient, request.NamespacedName, objectsToAnnotate); err != nil {
+		logger.Error(err, "On setting annotations in related objects.")
+		return r.onError(err, sbr, &sbrStatus, updatedObjects)
+	}
+
 	// updating status of request instance
 	if err = r.updateStatusServiceBindingRequest(sbr, &sbrStatus); err != nil {
 		logger.Error(err, "On updating status of ServiceBindingRequest.")

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -223,8 +223,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	// saving on status the list of objects that have been touched
 	r.setApplicationObjects(&sbrStatus, updatedObjects)
-	// storing objects used in Binder
-	objectsToAnnotate = append(objectsToAnnotate, updatedObjects...)
 
 	// updating status of request instance
 	if err = r.updateStatusServiceBindingRequest(sbr, &sbrStatus); err != nil {


### PR DESCRIPTION
I've noticed infinite reconciles & panics because addition of the annotation on the DC/D keeps failing. This PR safely removes addition of the annotation. 

Since we do not make use of the annotation ( we don't watch DCs/Ds anyway ), not adding the annotation has no adverse impact.