### PR TITLE
Alter the Makefile commons output to be more readable

### DIFF
--- a/examples/commons.mk
+++ b/examples/commons.mk
@@ -80,7 +80,7 @@ help: ## Credit: https://gist.github.com/prwhite/8168133#gistcomment-2749866
 
 ## -- Common Cluster Admin Targets --
 
-# === Service Bidining Operator ===
+## --- Service Binding Operator ---
 
 .PHONY: install-service-binding-operator-source
 ## Install the Service Binding Operator Source
@@ -110,7 +110,7 @@ uninstall-service-binding-operator-subscription:
 ## Uninstall the Service Binding Operator
 uninstall-service-binding-operator: uninstall-service-binding-operator-source uninstall-service-binding-operator-subscription
 
-# === Backing Service DB (PostgreSQL) Operator ===
+## --- Backing Service DB (PostgreSQL) Operator ---
 
 .PHONY: install-backing-db-operator-source
 ## Install the Backing Service DB Operator Source
@@ -140,7 +140,7 @@ uninstall-backing-db-operator-subscription:
 ## Uninstall the Backing Service DB Operator
 uninstall-backing-db-operator: uninstall-backing-db-operator-source uninstall-backing-db-operator-subscription
 
-# === Serverless Operator ===
+## --- Serverless Operator ---
 
 .PHONY: install-serverless-operator-subscription
 ## Install the Serverless Operator Subscription
@@ -160,7 +160,7 @@ uninstall-serverless-operator-subscription:
 ## Uninstall the Serverless Operator
 uninstall-serverless-operator: uninstall-serverless-operator-subscription
 
-# === Service Mesh Operator ===
+## --- Service Mesh Operator ---
 
 .PHONY: install-service-mesh-operator-subscription
 ## Install the Service Mesh Operator Subscription
@@ -180,7 +180,7 @@ uninstall-service-mesh-operator-subscription:
 ## Uninstall the Service Mesh Operator
 uninstall-service-mesh-operator: uninstall-service-mesh-operator-subscription
 
-# === Knative Serving (Serverless UI) ===
+## --- Knative Serving (Serverless UI) 
 
 .PHONY: install-knative-serving
 ## Install Knative Serving


### PR DESCRIPTION
Without this change, the 'make' output looks like this - the "Common Cluster Admin Targets" is a solid block of text and difficult to read.


```

make
Usage:
  make <target>
                      -- Cluster Admin Targets --

install-all-operators:  Install all the operators
uninstall-all-operators:  Uninstall all the operators
install-all:          Install all the operators, Knative Serving and the Quarkus native s2i builder image

                      -- Application Developer targets --

set-labels-on-knative-app:  Set binding labels on the knative application
create-service-binding-request:  Create the Service Binding Request

                      -- Commmon Utility targets --

help                  Print help message for all Makefile targets
                      Run `make` or `make help` to see the help

                      -- Common Cluster Admin Targets --

install-service-binding-operator-source:  Install the Service Binding Operator Source
install-service-binding-operator-subscription:  Install the Service Binding Operator Subscription
install-service-binding-operator:  Install the Service Binding Operator
uninstall-service-binding-operator-source:  Uninstall the Service Binding Operator Source
uninstall-service-binding-operator-subscription:  Uninstall the Service Binding Operator Subscription
uninstall-service-binding-operator:  Uninstall the Service Binding Operator
install-backing-db-operator-source:  Install the Backing Service DB Operator Source
install-backing-db-operator-subscription:  Install the Backing Service DB Operator Subscription
install-backing-db-operator:  Install the Backing Service DB Operator
uninstall-backing-db-operator-source:  Uninstall the Backing Service DB Operator Source
uninstall-backing-db-operator-subscription:  Uninstall the Backing Service DB Operator Subscription
uninstall-backing-db-operator:  Uninstall the Backing Service DB Operator
install-serverless-operator-subscription:  Install the Serverless Operator Subscription
install-serverless-operator:  Install the Serverless Operator
uninstall-serverless-operator-subscription:  Uninstall the Serverless Operator Subscription
uninstall-serverless-operator:  Uninstall the Serverless Operator
install-service-mesh-operator-subscription:  Install the Service Mesh Operator Subscription
install-service-mesh-operator:  Install the Service Mesh Operator
uninstall-service-mesh-operator-subscription:  Uninstall the Service Mesh Operator Subscription
uninstall-service-mesh-operator:  Uninstall the Service Mesh Operator
install-knative-serving:  Install Knative Serving
uninstall-knative-serving:  Uninstall Knative Serving
install-quarkus-native-s2i-builder:  Install ubi-quarkus-native-s2i builder

                      -- Common Application Developer Targets --

create-project:       Create the OpenShift project/namespace
delete-project:       Delete the OpenShift project/namespace
create-backing-db-instance:  Create the Backing Service DB Operator

```