### PR TITLE
Minor changes to improve feedback to users when running examples

### DIFF
--- a/hack/examples-commons.sh
+++ b/hack/examples-commons.sh
@@ -69,6 +69,7 @@ function wait_for_packagemanifest {
     PACKAGE_NAME=$1
     i=1
     while [[ -z "$(oc get packagemanifest | grep $PACKAGE_NAME)" ]] && [ $i -le 5 ]; do
+        echo "Waiting for package install to complete..."
         sleep 5
         i=$(($i+1))
     done
@@ -201,9 +202,9 @@ function uninstall_service_mesh_operator_subscription {
 function install_knative_serving {
     echo " ==   -  STEP 1/5 -   ==  "
     echo "  -  Cleanup process  -  "
-    oc delete -f $HACK_YAMLS/service-mesh-control-plane.yaml
-    oc delete -f $HACK_YAMLS/service-mesh-member-roll.yaml
-    oc delete -f $HACK_YAMLS/knative-serving.yaml
+    oc delete -f $HACK_YAMLS/service-mesh-control-plane.yaml --ignore-not-found=true
+    oc delete -f $HACK_YAMLS/service-mesh-member-roll.yaml --ignore-not-found=true
+    oc delete -f $HACK_YAMLS/knative-serving.yaml --ignore-not-found=true
     sleep 5
     echo " ==   -  STEP 2/5 -   == "
     echo "  - SETTING ENVIRONMENT NAMESPACE CONTROLLERS  - "


### PR DESCRIPTION
This pull request eliminates this feedback to users - which might cause confusion for new users:

```
 ==   -  STEP 1/5 -   ==  
  -  Cleanup process  -  
error: unable to recognize "../../hack/yamls/service-mesh-control-plane.yaml": no matches for kind "ServiceMeshControlPlane" in version "maistra.io/v1"
error: unable to recognize "../../hack/yamls/service-mesh-member-roll.yaml": no matches for kind "ServiceMeshMemberRoll" in version "maistra.io/v1"
Error from server (NotFound): error when deleting "../../hack/yamls/knative-serving.yaml": namespaces "knative-serving" not found
unable to recognize "../../hack/yamls/knative-serving.yaml": no matches for kind "KnativeServing" in version "serving.knative.dev/v1alpha1"
```