### PR TITLE
Add go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ replace (
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde
 )
+
+go 1.13


### PR DESCRIPTION

After upgrading to go 1.13 from 1.12, the go version is added to go.mod.
It seems that this is ignored in 1.12, so everything should work fine.