### PR TITLE
[WIP Increase retryInterval to enable e2e tests to pass

### DIFF
--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	retryInterval  = time.Second * 5
+	retryInterval  = time.Second * 10
 	timeout        = time.Second * 120
 	cleanupTimeout = time.Second * 5
 )


### PR DESCRIPTION
A few seconds more are needed to enable deployments to be successful and enable the e2e tests to pass. 