### PR TITLE
tiny typo

### DIFF
--- a/examples/nodejs_postgresql/README.md
+++ b/examples/nodejs_postgresql/README.md
@@ -145,6 +145,7 @@ spec:
   imageName: postgres
   dbName: db-demo
 EOS
+```
 
 Alternatively, you can perform the same task with this make command:
 ``` bash


### PR DESCRIPTION
Finishing up `yaml` indentation block in Markdown file.