### PR TITLE
Extract local operator log from e2e tests in a readable form into a file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ tags
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Intellij
 .idea
+### Logs
+**/*.log

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,19 @@ test-e2e: e2e-setup
 			--up-local \
 			--go-test-flags "-timeout=15m" \
 			--local-operator-flags "$(ZAP_FLAGS)" \
-			$(OPERATOR_SDK_EXTRA_ARGS)
+			$(OPERATOR_SDK_EXTRA_ARGS) \
+			| tee test-e2e.log
+	$(Q)cat test-e2e.log | grep 'Local operator stderr:' | sed -e 's,.*Local operator stderr: \(.*\)}\\n",\1,g' \
+		| sed -e 's,\\a,\a,g' \
+		| sed -e 's,\\b,\b,g' \
+		| sed -e 's,\\\\,\\,g' \
+		| sed -e 's,\\t,\t,g' \
+		| sed -e 's,\\n,\n,g' \
+		| sed -e 's,\\f,\f,g' \
+		| sed -e 's,\\r,\r,g' \
+		| sed -e 's,\\v,\v,g' \
+		| sed -e 's,\\",\",g' \
+		> test-e2e-local-operator.log
 
 .PHONY: test-unit
 ## Runs the unit tests without code coverage

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -151,15 +151,19 @@ func assertSBRSecret(
 	if _, contains := sbrSecret.Data["DATABASE_SECRET_USER"]; !contains {
 		return nil, fmt.Errorf("can't find DATABASE_SECRET_USER in data")
 	}
-	if !bytes.Equal([]byte("user"), sbrSecret.Data["DATABASE_SECRET_USER"]) {
-		return nil, fmt.Errorf("key DATABASE_SECRET_USER is different than expected")
+	actualUser := sbrSecret.Data["DATABASE_SECRET_USER"]
+	expectedUser := []byte("user")
+	if !bytes.Equal(expectedUser, actualUser) {
+		return nil, fmt.Errorf("key DATABASE_SECRET_USER (%s) is different than expected (%s)", actualUser, expectedUser)
 	}
 
 	if _, contains := sbrSecret.Data["DATABASE_SECRET_PASSWORD"]; !contains {
 		return nil, fmt.Errorf("can't find DATABASE_SECRET_PASSWORD in data")
 	}
-	if !bytes.Equal([]byte("password"), sbrSecret.Data["DATABASE_SECRET_PASSWORD"]) {
-		return nil, fmt.Errorf("key DATABASE_SECRET_PASSWORD is different than expected")
+	actualPassword := sbrSecret.Data["DATABASE_SECRET_PASSWORD"]
+	expectedPassword := []byte("password")
+	if !bytes.Equal(expectedPassword, actualPassword) {
+		return nil, fmt.Errorf("key DATABASE_SECRET_PASSWORD (%s) is different than expected (%s)", actualPassword, expectedPassword)
 	}
 
 	return sbrSecret, nil
@@ -275,7 +279,7 @@ func serviceBindingRequestTest(t *testing.T, ctx *framework.TestCtx, f *framewor
 	// checking intermediary secret contents, right after deployment the secrets must be in place
 	intermediarySecretNamespacedName := types.NamespacedName{Namespace: ns, Name: name}
 	sbrSecret, err := assertSBRSecret(todoCtx, f, intermediarySecretNamespacedName)
-	assert.NoError(t, err)
+	assert.NoError(t, err, "Intermediary secret contents are invalid: %v", sbrSecret)
 
 	// editing intermediary secret in order to trigger update event
 	t.Logf("Updating intermediary secret to have bogus data: '%s'", intermediarySecretNamespacedName)
@@ -380,7 +384,7 @@ func preCreateServiceBindingRequestTest(t *testing.T, ctx *framework.TestCtx, f 
 	// checking intermediary secret contents, right after deployment the secrets must be in place
 	intermediarySecretNamespacedName := types.NamespacedName{Namespace: ns, Name: name}
 	sbrSecret, err := assertSBRSecret(todoCtx, f, intermediarySecretNamespacedName)
-	assert.NoError(t, err)
+	assert.NoError(t, err, "Intermediary secret contents are invalid: %v", sbrSecret)
 
 	// editing intermediary secret in order to trigger update event
 	t.Logf("Updating intermediary secret to have bogus data: '%s'", intermediarySecretNamespacedName)


### PR DESCRIPTION
The current e2e tests output the local operator log in a single line including all the interesting characters (such as end-of-line, tab,...) escaped which makes the logs unreadable, such as:
```
time="2019-10-21T12:06:40+02:00" level=info msg="Local operator stdout: "
time="2019-10-21T12:06:40+02:00" level=info msg="Local operator stderr: 2019-10-21T12:03:43.044+0200\tINFO\tmain\tGo Version: go1.13\n2019-10-21T12:03:43.044+0200\tINFO\tmain\tGo OS/Arch: linux/amd64\n2019-10-21T12:03:43.044+0200\tINFO\tmain\tVersion of operator-sdk: v0.10.0\n2019-10-21T12:03:43.045+0200\tINFO\tmain\tWARNING: Leader election is disabled\n2019-10-21T12:03:52.482+0200\tINFO\tmain\tRegistering Components.\n2019-10-21T12:03:52.482+0200\tINFO\tkubebuilder.controller\tStarting EventSource\t{\"controller\": \"servicebindingrequest-controller\", \"source\": \"kind source: apps.openshift.io/v1alpha1, Kind=ServiceBindingRequest\"}\n2019-10-21T12:03:52.483+0200\tDEBUG\tsbrcontroller\tWatch added for ServiceBindingRequest\t{\"GKV\": \"apps.openshift.io/v1alpha1, Kind=ServiceBindingRequest\"}\n2019-10-21T12:03:52.611+0200\tDEBUG\tsbrcontroller\tAmount of GVK founds in CSV objects.\t{\"CSVOwnedGVK.Amount\": 0}\n2019-10-21T12:03:52.611+0200\tDEBUG\tsbrcontroller\tAdding watch for whitelisted GVK...\t{\"GVK\": \"/v1, Kind=Secret\"}\n2019-10-21T12:03:52.611+0200\tDEBUG\tsbrcontroller\tAdding watch for GVK...\t{\"GVK\": \"/v1, Kind=Secret\"}\n2019-10-21T12:03:52.611+0200\tDEBUG\tsbrcontroller\tCreating watch on GVK\t{\"GVK\": \"/v1, Kind=Secret\"}\n2019-10-21T12:03:52.611+0200\tINFO\tkubebuilder.controller\tStarting EventSource\t{\"controller\": \"servicebindingrequest-controller\", \"source\": \"kind source: /v1, Kind=Secret\"}\n2019-10-21T12:03:52.611+0200\tDEBUG\tsbrcontroller\tAdding watch for whitelisted GVK...\t{\"GVK\": \"/v1, Kind=ConfigMap\"}\n2019-10-21T12:03:52.611+0200\tDEBUG\tsbrcontroller\tAdding watch for GVK...\t{\"GVK\": \"/v1, Kind=ConfigMap\"}\n2019-10-21T12:03:52.611+0200\tDEBUG\tsbrcontroller\tCreating watch on GVK\t{\"GVK\": \"/v1, Kind=ConfigMap\"}\n2019-10-21T12:03:52.611+0200\tINFO\tkubebuilder.controller\tStarting EventSource\t{\"controller\": \"servicebindingrequest-controller\", \"source\": \"kind source: /v1, Kind=ConfigMap\"}\n2019-10-21T12:03:52.611+0200\tINFO\tkubebuilder.controller\tStarting EventSource\t{\"controller\": \"servicebindingrequest-controller\", \"source\": \"kind source: operators.coreos.com/v1alpha1, Kind=ClusterServiceVersion\"}\n2019-10-21T12:03:52.612+0200\tDEBUG\tsbrcontroller\tWatch added for ClusterServiceVersion\t{\"GVK\": \"operators.coreos.com/v1alpha1, Kind=ClusterServiceVersion\"}\n2019-10-21T12:03:52.612+0200\tINFO\tmain\tCould not generate and serve custom resource metrics\t{\"error\": \"operator run mode forced to local\"}\n2019-10-21T12:04:01.624+0200\tINFO\tmain\tCould not create metrics Service\t{\"error\": \"failed to initialize service object for metrics:
...
```
This PR:
* Extracts the operator logs into a file called `test-e2e-local-operator.log` and with all the escape sequences rendered
* Adds all `*.log` files into the `.gitignore`