### PR TITLE
Enable the 'update' privilege for the service account so that CRs can be updated.

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -54,6 +54,7 @@ rules:
       - "get"
       - "list"
       - "watch"
+      - "update"
   - verbs:
       - "*"
     apiGroups:

--- a/manifests/service-binding-operator.v0.0.20.clusterserviceversion.yaml
+++ b/manifests/service-binding-operator.v0.0.20.clusterserviceversion.yaml
@@ -111,6 +111,7 @@ spec:
                 - "get"
                 - "list"
                 - "watch"
+                - "update"
             - verbs:
                 - "*"
               apiGroups:


### PR DESCRIPTION
The backing CRs are updated with an SBR annotation at the time of reconcile. This PR adds the service account privilege to enable that.

Fixes 

```
{"level":"info","ts":1571751848.8616478,"logger":"binder","msg":"Reading back updated object...","Obj.Name":"e2e-application","Obj.Kind":"Deployment"}
2019-10-22T13:44:08.865Z    INFO    servicebindingrequest    Updating resource annotations...    {"SBR.Namespace": "test-namespace-527580c4-2b32-46d0-a1f0-a0bd2e0643b8", "SBR.Name": "e2e-service-binding-request", "Resource.GVK": "postgresql.baiju.dev/v1alpha1, Kind=Database", "Resource.Namespace": "test-namespace-527580c4-2b32-46d0-a1f0-a0bd2e0643b8", "Resource.Name": "e2e-db-testing"}
2019-10-22T13:44:09.048Z    ERROR    servicebindingrequest    unable to set/update annotations in object    {"SBR.Namespace": "test-namespace-527580c4-2b32-46d0-a1f0-a0bd2e0643b8", "SBR.Name": "e2e-service-binding-request", "Resource.GVK": "postgresql.baiju.dev/v1alpha1, Kind=Database", "Resource.Namespace": "test-namespace-527580c4-2b32-46d0-a1f0-a0bd2e0643b8", "Resource.Name": "e2e-db-testing", "error": "databases.postgresql.baiju.dev \"e2e-db-testing\" is forbidden: User \"system:serviceaccount:openshift-operators:service-binding-operator\" cannot update resource \"databases\" in API group \"postgresql.baiju.dev\" in the namespace \"test-namespace-527580c4-2b32-46d0-a1f0-a0bd2e0643b8\""}
github.com/redhat-developer/service-binding-operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error
    /tmp/go/src/github.com/redhat-developer/service-binding-operator/vendor/github.com/go-logr/zapr/zapr.go:128
github.com/redhat-developer/service-binding-operator/pkg/controller/servicebindingrequest.SetSBRAnnotations
```