### PR TITLE
Use @otaviof's hack script to get operator log from e2e tests.

### DIFF
--- a/hack/e2e-log-parser.sh
+++ b/hack/e2e-log-parser.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Based on the input extracted from operator-sdk running end-to-end tests, parse and print out
+# regular log lines.
+#
+
+set -e
+
+grep 'msg="Local operator stderr' $1 \
+    |sed 's/^time.*err: //g' \
+    |eval 'in=$(cat); echo -en "$in"'


### PR DESCRIPTION
This hack script replaces the `sed` pipeline in the main `Makefile` by a simpler hack script provided by @otaviof 