### PR TITLE
update README

### DIFF
--- a/examples/nodejs_postgresql/README.md
+++ b/examples/nodejs_postgresql/README.md
@@ -118,7 +118,7 @@ In the OpenShift Console switch to the Developer perspective. (Make sure you hav
 * `Git Repo URL` = `https://github.com/pmacik/nodejs-rest-http-crud`
 * `Project` = `service-binding-demo`
 * `Application`->`Create New Application` = `NodeJSApp`
-* `Name` = `nodejs-app`
+* `Name` = `nodejs-rest-http-crud`
 * `Builder Image` = `Node.js`
 * `Create a route to the application` = checked
 


### PR DESCRIPTION
The name of the nodejs application should be `nodejs-rest-http-crud` otherwise we get error:

```
➜  nodejs_postgresql git:(master) make set-labels-on-nodejs-app
oc project service-binding-demo                           
Already on project "service-binding-demo" on server "https://api.olemefer-101.devcluster.openshift.com:6443".
oc patch dc nodejs-rest-http-crud -p '{"metadata": {"labels": {"connects-to": "postgres", "environment": "demo"}}}'
Error from server (NotFound): deploymentconfigs.apps.openshift.io "nodejs-rest-http-crud" not found
make: *** [Makefile:11: set-labels-on-nodejs-app] Error 1  
```