### PR TITLE
Update the Knative example to be in synch with OpenShift 4.3

### DIFF
--- a/examples/knative_postgresql_customvar/Makefile
+++ b/examples/knative_postgresql_customvar/Makefile
@@ -27,3 +27,9 @@ set-labels-on-knative-app:
 ## Create the Service Binding Request
 create-service-binding-request:
 	${Q}oc apply -f service-binding-request.yaml
+
+.PHONY: install-serverless-ui
+## Create the knative namespace, install knative serving
+install-serverless-ui:
+	${Q}oc apply -f serving.yaml
+

--- a/examples/knative_postgresql_customvar/README.md
+++ b/examples/knative_postgresql_customvar/README.md
@@ -24,24 +24,19 @@ The cluster admin needs to install operators, knative serving and a builder imag
 * Quarkus Native S2i Builder Image
 
 A Backing Service Operator that is "bind-able," in other
-words a Backing Service Operator that exposes binding information in secrets, config maps, status, and/or spec
-attributes. The Backing Service Operator may represent a database or other services required by
-applications. We'll use [postgresql-operator](https://github.com/operator-backing-service-samples/postgresql-operator) to
+words a Backing Service Operator that exposes binding information in secrets,
+config maps, status, and/or spec attributes. The Backing Service Operator
+may represent a database or other services required by applications. We'll
+use [postgresql-operator](https://github.com/operator-backing-service-samples/postgresql-operator) to
 demonstrate a sample use case.
-
-We can install all by running the following make target (note that the command will take up to ten minutes to run):
-
-```shell
-make install-all
-```
-
-or we can install one by one via the following six individual make targets.
 
 #### Install the Service Binding Operator
 
-```shell
-make install-service-binding-operator
-```
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Other` category select the `Service Binding Operator` operator
+
+![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
+
+and install a `stable` version.
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
 
@@ -53,35 +48,28 @@ make install-backing-db-operator
 
 This makes the `Database` custom resource available, that the application developer will use later.
 
-#### Install the Serverless plugin to OpenShift
+#### Install the OpenShift Serverless Operator
 
-The installation process for the Serverless plugin to OpenShift is documented [here](https://docs.openshift.com/container-platform/4.1/serverless/installing-openshift-serverless.html).
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Cloud Provider` category select the `OpenShift Serverless Operator` operator.
 
-However there're several make targets for each step to make it easy for us.
-
-##### Install the Service Mesh Operator
-
-```shell
-make install-service-mesh-operator
-```
-
-This makes the `ServiceMeshControlPlane` and `ServiceMeshMemberRoll` custom resourced available, that the application developer will use later.
-
-##### Install the Serverless Operator
-
-```shell
-make install-serverless-operator
-```
-
-This makes the `KnativeServing` custom resource available, that the application developer will use later to deploy the application.
+Note that installing this operator will automatically install this set of operators:
+* Elasticsearch Operator
+* Jaeger Operator
+* Kiali Operator
+* OpenShift Serverless Operator
+* Red Hat OpenShift Service Mesh
 
 ##### Install Serverless UI
 
 ```shell
-make install-knative-serving
+make install-serverless-ui
 ```
 
-This enables `Serverless` view in the UI. Note that installing the Serverless features will require around seven minutes for the command to run.
+This enables `Serverless` view in the UI. Note that installing the Serverless features will require around seven minutes for the command to run. You can check the status of this install with this command:
+
+```shell
+oc get knativeserving knative-serving -n knative-serving -oyaml
+```
 
 #### Install the `ubi-quarkus-native-s2i` builder image
 
@@ -101,49 +89,6 @@ The application and the DB needs a namespace to live in so let's create one for 
 
 ```shell
 make create-project
-```
-
-This creates a project/namespace called `service-binding-demo`.
-
-#### Import an application
-
-In this example we will import an arbitrary [Quarkus application](https://github.com/sbose78/using-spring-data-jpa-quarkus).
-
-In the OpenShift Console switch to the Developer perspective. (We need to make sure we've selected the `service-binding-demo` project). Navigate to the `+Add` page from the menu and then click on the `[From Git]` button. Fill in the form with the following:
-
-* `Git Repo URL` = `https://github.com/sbose78/using-spring-data-jpa-quarkus`
-* `Builder Image` = `Ubi Quarkus Native S2i`
-* `Application`->`Create Application`
-* `Application Name` = `knative-app`
-* `Name` = `knative-app`
-* `Serverless`->`Enable scaling to zero when idle` = checked
-* `Advanced Options`->`Create a route to the application` = checked
-
-and click on the `[Create]` button.
-
-Notice, that during the import no DB config was mentioned or requestd.
-
-It take several minutes to build the application using the Quarkus native s2i builder image, we can check the running build progress in the Administrator's perspective under `Builds`->`Builds` view until the build status is `Complete`.
-
-After the application is built we can check the `Services` under `Serverless` view to see the deployed application. The application should fail at this point with `Reason` to be the "connection refused" error. That indicates that the application is not connected to the DB.
-
-#### Set labels on the application
-
-Now we need to set arbitrary labels on the application's `Service` in order for the Service Binding Operator to be able to find the application.
-
-The labels are:
-
-* `connects-to=postgres` - indicates that the application needs to connect to a PostgreSQL DB
-* `environment=demo` - indicates the demo environment - it narrows the search
-
-```shell
-oc label services.serving.knative.dev knative-app connects-to=postgres environment=demo --overwrite
-```
-
-Alternatively, we can perform the same task with this make command:
-
-```shell
-make set-labels-on-knative-app
 ```
 
 #### Create a DB instance for the application
@@ -171,6 +116,30 @@ Alternatively, we can perform the same task with this make command:
 make create-backing-db-instance
 ```
 
+This creates a project/namespace called `service-binding-demo`.
+
+#### Import an application
+
+In this example we will import an arbitrary [Quarkus application](https://github.com/sbose78/using-spring-data-jpa-quarkus).
+
+In the OpenShift Console switch to the Developer perspective. (We need to make sure we've selected the `service-binding-demo` project). Navigate to the `+Add` page from the menu and then click on the `[From Git]` button. Fill in the form with the following:
+
+* `Git Repo URL` = `https://github.com/sbose78/using-spring-data-jpa-quarkus`
+* `Builder Image` = `Ubi Quarkus Native S2i`
+* `Application`->`Create Application`
+* `Application Name` = `knative-app`
+* `Name` = `knative-app`
+* `Serverless`->`Enable scaling to zero when idle` = checked
+* `Advanced Options`->`Create a route to the application` = checked
+
+and click on the `[Create]` button.
+
+Notice, that during the import no DB config was mentioned or requestd.
+
+It take several minutes to build the application using the Quarkus native s2i builder image, we can check the running build progress in the Administrator's perspective under `Builds`->`Builds` view until the build status is `Complete`.
+
+After the application is built we can check the `Services` under `Serverless` view to see the deployed application. The application should fail at this point with `Reason` to be the "connection refused" error. That indicates that the application is not connected to the DB.
+
 #### Express an intent to bind the DB and the application together
 
 Now, the only thing that remains is to connect the DB and the application. We let the Service Binding Operator to make the connection for us.
@@ -190,9 +159,7 @@ spec:
     group: serving.knative.dev
     version: v1beta1
     resource: services
-    matchLabels:
-      connects-to: postgres
-      environment: demo
+    resourceRef: knative-app
   backingServiceSelector:
     group: postgresql.baiju.dev
     version: v1alpha1
@@ -216,7 +183,7 @@ make create-service-binding-request
 
 There are 2 parts in the request:
 
-* `applicationSelector` - used to search for the application based on the labels that we set earlier and the `group`, `version` and `resource` of the application to be a knative `Service`.
+* `applicationSelector` - used to search for the application based on the resourceRef that we set earlier and the `group`, `version` and `resource` of the application to be a knative `Service`.
 * `backingServiceSelector` - used to find the backing service - our operator-backed DB instance called `db-demo`.
 
 That causes the application to be re-deployed.

--- a/examples/knative_postgresql_customvar/service-binding-request.yaml
+++ b/examples/knative_postgresql_customvar/service-binding-request.yaml
@@ -9,9 +9,7 @@ spec:
     group: serving.knative.dev
     version: v1beta1
     resource: services
-    matchLabels:
-      connects-to: postgres
-      environment: demo
+    resourceRef: knative-app
   backingServiceSelector:
     group: postgresql.baiju.dev
     version: v1alpha1

--- a/examples/knative_postgresql_customvar/serving.yaml
+++ b/examples/knative_postgresql_customvar/serving.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: knative-serving
+---
+apiVersion: serving.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+ name: knative-serving
+ namespace: knative-serving
+


### PR DESCRIPTION
### Motivation
Update the Knative example to be in synch with OpenShift 4.3 and to replace the use of labels with resourceRef in the ApplicationSelector.

### Changes
* The ServiceBindingSelector is updated to use a resourcceRef and not labels as we are discouraging the use of labels.
* A new yaml file (serving.yaml) is added - this is necessary to install Knative after the operators are installed.
* The README and Makefile are updated to reflect the other changes.

### Testing
* To test, follow the steps in the README file on an OpenShift 4.3 cluster.


For further more details refer the CONTRIBUTING.md