### PR TITLE
Fix double base64 encoding for customEnvVar (#264)

### DIFF
--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -199,7 +199,7 @@ func (r *Retriever) readSecret(
 		log.Debug("Inspecting secret key...")
 		r.markVisitedPaths(path, k, fromPath)
 		// update cache after reading configmap/secret in cache
-		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = string(value)
+		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = string(data)
 		// making sure key name has a secret reference
 		r.store(fmt.Sprintf("configMap_%s", k), data)
 		r.store(fmt.Sprintf("secret_%s", k), data)

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -243,7 +243,7 @@ func TestCustomEnvParser(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		require.Equal(t, "dXNlcg==_cGFzc3dvcmQ=", values["ANOTHER_STRING"], "Custom env values are not matching")
-		require.Equal(t, "postgres@cGFzc3dvcmQ=", values["JDBC_CONNECTION_STRING"], "Custom env values are not matching")
+		require.Equal(t, "user_password", values["ANOTHER_STRING"], "Custom env values are not matching")
+		require.Equal(t, "postgres@password", values["JDBC_CONNECTION_STRING"], "Custom env values are not matching")
 	})
 }


### PR DESCRIPTION
### Motivation

Fix #264 

### Changes

Changes are in retriever.go to check if variables for customEnvVar are already base 64-encoded and decoding them if they are, since all variables are base 64 encoded when written to the binding request secret.

### Testing

Did not add new tests, just checked that double base 64 encoding does not happen for customEnvVar retrieved from a secret and no changes are made when variables are retrieved directly from status.


For further more details refer the CONTRIBUTING.md