### PR TITLE
Update RDS example to match 4.3 Deployments and SBO use of resourceRefs

### DIFF
--- a/examples/nodejs_awsrds_varprefix/namespace.yaml
+++ b/examples/nodejs_awsrds_varprefix/namespace.yaml
@@ -1,0 +1,5 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: service-binding-demo

--- a/examples/nodejs_awsrds_varprefix/service-binding-request.nodejs-app.yaml
+++ b/examples/nodejs_awsrds_varprefix/service-binding-request.nodejs-app.yaml
@@ -12,9 +12,7 @@ spec:
     kind: RDSDatabase
     resourceRef: mydb
   applicationSelector:
-    matchLabels:
-      connects-to: postgres
-      environment: nodejs
-    group: apps.openshift.io
+    resourceRef: nodejs-app
+    group: apps
     version: v1
-    resource: deploymentconfigs
+    resource: deployments

--- a/examples/nodejs_awsrds_varprefix/service-binding-request.shell-app.yaml
+++ b/examples/nodejs_awsrds_varprefix/service-binding-request.shell-app.yaml
@@ -12,9 +12,7 @@ spec:
     kind: RDSDatabase
     resourceRef: mydb
   applicationSelector:
-    matchLabels:
-      connects-to: postgres
-      environment: shell
+    resourceRef: shell-app
     group: apps.openshift.io
     version: v1
     resource: deploymentconfigs


### PR DESCRIPTION
### Motivation
The goals of this pull request are to get the RDS example up to date with OpenShift's use of Deployments, and up to date with the Service Binding Operator's use of reeeesrouceRef for Application selectors. 

### Changes
The README, Makefile. and ServiceBindingRequest definitions are updated. 

### Testing
The example was verified by following the steps in the README.

For further more details refer the CONTRIBUTING.md