### PR TITLE
Reuse retrieve.Cache for customEnvParser in secret.go

### DIFF
--- a/pkg/controller/servicebindingrequest/custom_env_parser_test.go
+++ b/pkg/controller/servicebindingrequest/custom_env_parser_test.go
@@ -41,3 +41,36 @@ func TestCustomEnvPath_Parse(t *testing.T) {
 	str2 := values["ANOTHER_STRING"]
 	require.Equal(t, "database-name_database-user", str2, "Connection string is not matching")
 }
+
+func TestCustomEnvPath_Parse_exampleCase(t *testing.T) {
+	cache := map[string]interface{}{
+		"status": map[string]interface{}{
+			"dbConfigMap": map[string]interface{}{
+				"db.user":     "database-user",
+				"db.password": "database-pass",
+			},
+		},
+	}
+
+	envMap := []corev1.EnvVar{
+		corev1.EnvVar{
+			Name:  "JDBC_USERNAME",
+			Value: `{{ index .status.dbConfigMap "db.user" }}`,
+		},
+		corev1.EnvVar{
+			Name:  "JDBC_PASSWORD",
+			Value: `{{ index .status.dbConfigMap "db.password" }}`,
+		},
+	}
+
+	customEnvPath := NewCustomEnvParser(envMap, cache)
+	values, err := customEnvPath.Parse()
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+	str := values["JDBC_USERNAME"]
+	require.Equal(t, "database-user", str, "Connection string is not matching")
+	str2 := values["JDBC_PASSWORD"]
+	require.Equal(t, "database-pass", str2, "Connection string is not matching")
+}

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -242,6 +242,7 @@ func (r *Reconciler) bind(
 	binder *Binder,
 	secret *Secret,
 	retrievedData map[string][]byte,
+	retrievedCache map[string]interface{},
 	sbr *v1alpha1.ServiceBindingRequest,
 	sbrStatus *v1alpha1.ServiceBindingRequestStatus,
 	objectsToAnnotate []*unstructured.Unstructured,
@@ -249,7 +250,7 @@ func (r *Reconciler) bind(
 	logger = logger.WithName("bind")
 
 	logger.Info("Saving data on intermediary secret...")
-	secretObj, err := secret.Commit(retrievedData)
+	secretObj, err := secret.Commit(retrievedData, retrievedCache)
 	if err != nil {
 		logger.Error(err, "On saving secret data..")
 		return r.onError(err, sbr, sbrStatus, nil)
@@ -352,7 +353,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	logger.Debug("Retrieving data to create intermediate secret.")
 	retriever := NewRetriever(r.dynClient, plan, sbr.Spec.EnvVarPrefix)
-	retrievedData, err := retriever.Retrieve()
+	retrievedData, retrievedCache, err := retriever.Retrieve()
 	if err != nil {
 		logger.Error(err, "On retrieving binding data.")
 		return r.onError(err, sbr, sbrStatus, nil)
@@ -374,5 +375,5 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	logger.Info("Starting the bind of application(s) with backing service...")
-	return r.bind(logger, binder, secret, retrievedData, sbr, sbrStatus, objectsToAnnotate)
+	return r.bind(logger, binder, secret, retrievedData, retrievedCache, sbr, sbrStatus, objectsToAnnotate)
 }

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -267,19 +267,19 @@ func (r *Retriever) store(key string, value []byte) {
 // Retrieve loop and read data pointed by the references in plan instance. Also runs through
 // "bindable resources", gathering extra data. It can return error on retrieving and reading
 // resources.
-func (r *Retriever) Retrieve() (map[string][]byte, error) {
+func (r *Retriever) Retrieve() (map[string][]byte, map[string]interface{}, error) {
 	var err error
 	r.logger.Info("Looking for spec-descriptors in 'spec'...")
 	for _, specDescriptor := range r.plan.CRDDescription.SpecDescriptors {
 		if err = r.read("spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	r.logger.Info("Looking for status-descriptors in 'status'...")
 	for _, statusDescriptor := range r.plan.CRDDescription.StatusDescriptors {
 		if err = r.read("status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -293,14 +293,14 @@ func (r *Retriever) Retrieve() (map[string][]byte, error) {
 
 		vals, err := b.GetBindableVariables()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		for k, v := range vals {
 			r.store(k, []byte(fmt.Sprintf("%v", v)))
 		}
 	}
 
-	return r.data, nil
+	return r.data, r.cache, nil
 }
 
 // NewRetriever instantiate a new retriever instance.

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -33,7 +33,7 @@ func TestRetriever(t *testing.T) {
 	require.NotNil(t, retriever)
 
 	t.Run("retrive", func(t *testing.T) {
-		objs, err := retriever.Retrieve()
+		objs, _, err := retriever.Retrieve()
 		require.NoError(t, err)
 		require.NotEmpty(t, retriever.data)
 		require.True(t, len(objs) > 0)
@@ -142,7 +142,6 @@ func TestRetrieverWithNestedCRKey(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "somevalue", something)
 	})
-
 }
 
 func TestRetrieverWithConfigMap(t *testing.T) {
@@ -181,7 +180,6 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_CONFIGMAP_USER")
 		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_CONFIGMAP_PASSWORD")
 	})
-
 	t.Run("extractConfigMapItemName", func(t *testing.T) {
 		require.Equal(t, "user", retriever.extractConfigMapItemName(
 			"binding:env:object:configmap:user"))
@@ -196,7 +194,6 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 		require.Contains(t, retriever.data, ("SERVICE_BINDING_DATABASE_CONFIGMAP_USER"))
 		require.Contains(t, retriever.data, ("SERVICE_BINDING_DATABASE_CONFIGMAP_PASSWORD"))
 	})
-
 }
 
 func TestCustomEnvParser(t *testing.T) {
@@ -207,7 +204,7 @@ func TestCustomEnvParser(t *testing.T) {
 	crName := "db-testing"
 
 	f := mocks.NewFake(t, ns)
-	f.AddMockedUnstructuredCSV("csv")
+	// f.AddMockedUnstructuredCSV("csv")
 	f.AddMockedSecret("db-credentials")
 
 	crdDescription := mocks.CRDDescriptionMock()
@@ -222,10 +219,8 @@ func TestCustomEnvParser(t *testing.T) {
 	require.NotNil(t, retriever)
 
 	t.Run("Should detect custom env values", func(t *testing.T) {
-		_, err = retriever.Retrieve()
+		_, _, err = retriever.Retrieve()
 		require.NoError(t, err)
-
-		t.Logf("\nCache %+v", retriever.cache)
 
 		envMap := []corev1.EnvVar{
 			{

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -204,7 +204,6 @@ func TestCustomEnvParser(t *testing.T) {
 	crName := "db-testing"
 
 	f := mocks.NewFake(t, ns)
-	// f.AddMockedUnstructuredCSV("csv")
 	f.AddMockedSecret("db-credentials")
 
 	crdDescription := mocks.CRDDescriptionMock()

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -20,12 +20,8 @@ type Secret struct {
 
 // customEnvParser parse informed data in order to interpolate with values provided by custom
 // environment component.
-func (s *Secret) customEnvParser(data map[string][]byte) (map[string][]byte, error) {
+func (s *Secret) customEnvParser(data map[string][]byte, cache map[string]interface{}) (map[string][]byte, error) {
 	// transforming input into format expected by custom environment parser
-	cache := make(map[string]interface{})
-	for k, v := range data {
-		cache[k] = v
-	}
 
 	// interpolating custom environment
 	envParser := NewCustomEnvParser(s.plan.SBR.Spec.CustomEnvVar, cache)
@@ -84,8 +80,8 @@ func (s *Secret) createOrUpdate(payload map[string][]byte) (*unstructured.Unstru
 
 // Commit will store informed data as a secret, commit it against the API server. It can forward
 // errors from custom environment parser component, or from the API server itself.
-func (s *Secret) Commit(data map[string][]byte) (*unstructured.Unstructured, error) {
-	payload, err := s.customEnvParser(data)
+func (s *Secret) Commit(data map[string][]byte, cache map[string]interface{}) (*unstructured.Unstructured, error) {
+	payload, err := s.customEnvParser(data, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/servicebindingrequest/secret_test.go
+++ b/pkg/controller/servicebindingrequest/secret_test.go
@@ -27,9 +27,10 @@ func TestSecretNew(t *testing.T) {
 	data := map[string][]byte{"key": []byte("value")}
 
 	s := NewSecret(f.FakeDynClient(), plan)
-
+	fakeDynClient := f.FakeDynClient()
+	retriever := NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
 	t.Run("customEnvParser", func(t *testing.T) {
-		customData, err := s.customEnvParser(data)
+		customData, err := s.customEnvParser(data, retriever.cache)
 		assert.NoError(t, err)
 		assert.NotNil(t, customData)
 	})
@@ -46,7 +47,7 @@ func TestSecretNew(t *testing.T) {
 	})
 
 	t.Run("Commit", func(t *testing.T) {
-		u, err := s.Commit(data)
+		u, err := s.Commit(data, retriever.cache)
 		assert.NoError(t, err)
 		assertSecretNamespacedName(t, u, ns, name)
 	})


### PR DESCRIPTION
Fix for https://github.com/redhat-developer/service-binding-operator/issues/272