### PR TITLE
Implement workaround for GOFLAGS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - KUBE_VERSION="1.14.3"
     # FIXME: GO111MODULE should only be exported in controlled environments, never globally;
     - GO111MODULE=on
+    - GOFLAGS="-mod=vendor"
 
 # FIXME: make sure all CI actions are *only* triggered make targets;
 # FIXME: move all scripting to hack directory;
@@ -51,6 +52,6 @@ script:
   # Run lint
   - make lint
   # Run unit tests
-  - go test -mod vendor $(go list ./...|grep -v e2e) -v
+  - go test $(go list ./...|grep -v e2e) -v
   # Run e2e tests
   - operator-sdk test local ./test/e2e --namespace=operator-test --up-local --go-test-flags "-v"


### PR DESCRIPTION
Travis CI fails [1] because of https://github.com/golang/go/issues/35827, and the workaround is either clean `GOFLAGS` and keep `go test -mod=vendor ...` as it is, or remove the `-mod=vendor` flag from `go test` and keep `GOFLAGS` properly configured.

This change implements the latter.

[1] https://travis-ci.org/redhat-developer/service-binding-operator/builds/623623393?utm_source=github_status&utm_medium=notification.

Edit: rewording.