### PR TITLE
Avoid using / root paths in Dockerfile

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,3 +1,5 @@
+ARG BUILD_DIR=/tmp/service-binding-operator
+
 # On CI, use
 # FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 
@@ -9,7 +11,7 @@ ENV GIT_COMMITTER_EMAIL devtools@redhat.com
 LABEL com.redhat.delivery.appregistry=true
 
 # GOPATH-ish dir structure not needed anymore
-WORKDIR /tmp/service-binding-operator
+WORKDIR $BUILD_DIR
 
 # TODO: Use a RUN command to copy over specific files/dirs in a different PR
 # Collapsing it into a single COPY to reduce layers, as of now.
@@ -30,7 +32,7 @@ LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Shoubhik Bose <shbose@redhat.com>"
 ENV LANG=en_US.utf8
 
-COPY --from=builder /tmp/service-binding-operator/out/operator /usr/local/bin/service-binding-operator
+COPY --from=builder $BUILD_DIR/out/operator /usr/local/bin/service-binding-operator
 
 USER 10001
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -4,6 +4,7 @@ ARG BUILD_DIR=/tmp/service-binding-operator
 # FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 
 FROM openshift/origin-release:golang-1.13 AS builder
+ARG BUILD_DIR
 
 ENV LANG=en_US.utf8
 ENV GIT_COMMITTER_NAME devtools
@@ -26,6 +27,7 @@ RUN make build
 # FROM registry.redhat.io/ubi8/ubi
 
 FROM registry.access.redhat.com/ubi7/ubi-minimal
+ARG BUILD_DIR
 
 LABEL com.redhat.delivery.appregistry=true
 LABEL maintainer "Devtools <devtools@redhat.com>"

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -8,31 +8,20 @@ ENV GIT_COMMITTER_NAME devtools
 ENV GIT_COMMITTER_EMAIL devtools@redhat.com
 LABEL com.redhat.delivery.appregistry=true
 
-WORKDIR /go/src/github.com/redhat-developer/service-binding-operator
+# GOPATH-ish dir structure not needed anymore
+WORKDIR /tmp/service-binding-operator
 
-# Copy only relevant things (instead of all) to speed-up the build.
-COPY assets assets
-COPY build build
-COPY cmd cmd
-COPY deploy deploy
-COPY hack hack
-COPY manifests manifests
-COPY pkg pkg
-COPY test test
-COPY vendor vendor
-COPY go.mod .
-COPY go.sum .
-COPY LICENSE .
-COPY Makefile .
-COPY tools.go .
+# TODO: Use a RUN command to copy over specific files/dirs in a different PR
+# Collapsing it into a single COPY to reduce layers, as of now.
+COPY . . 
 
 ARG VERBOSE=2
 RUN make build
 
 #--------------------------------------------------------------------
 
-# On CI , use
-# FROM registry.svc.ci.openshift.org/ocp/ubi-minimal:7
+# On CI with pull secrets , use
+# FROM registry.redhat.io/ubi8/ubi
 
 FROM registry.access.redhat.com/ubi7/ubi-minimal
 
@@ -41,7 +30,7 @@ LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Shoubhik Bose <shbose@redhat.com>"
 ENV LANG=en_US.utf8
 
-COPY --from=builder /go/src/github.com/redhat-developer/service-binding-operator/out/operator /usr/local/bin/service-binding-operator
+COPY --from=builder /tmp/service-binding-operator/out/operator /usr/local/bin/service-binding-operator
 
 USER 10001
 


### PR DESCRIPTION
### Motivation

Avoid writing to `/` in the Dockerfile

### Changes

- Avoid using GOPATH-ish paths
- Avoid writing to any path which is typically writable to, only by root.
- Collapse the multiple layers for copying source code into the image.

<< What has been changed in order to achieve "story's" objective? >>

### Testing

<< How to test those changes, reference implementation of unit/e2e tests. >>

https://quay.io/repository/redhat-developer/app-binding-operator/build/5ed422ff-eb4a-404a-bc28-94adffedba47

Build validated above.

