### PR TITLE
Avoiding Repeated Finalizers

### DIFF
--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -284,9 +284,11 @@ func (r *Reconciler) bind(
 	}
 
 	// appending finalizer, should be later removed upon resource deletion
-	sbr.SetFinalizers(append(sbr.GetFinalizers(), sbrFinalizer))
-	if _, err = r.updateServiceBindingRequest(sbr); err != nil {
-		return NoRequeue(err)
+	if !containsStringSlice(sbr.GetFinalizers(), sbrFinalizer) {
+		sbr.SetFinalizers(append(sbr.GetFinalizers(), sbrFinalizer))
+		if _, err = r.updateServiceBindingRequest(sbr); err != nil {
+			return NoRequeue(err)
+		}
 	}
 
 	logger.Info("All done!")


### PR DESCRIPTION
### Motivation

Fixing Issue #287, reporting finalizers are getting repeated.

### Changes

Probing if finalizer is already present before appending.

### Testing

Regular end-to-end and unit-tests are covering this scenario already.