### PR TITLE
pre-req refactor to support multiple backing services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 
 // Pinned to kubernetes-1.15.4
 replace (
+	github.com/openshift/api => github.com/openshift/api v0.0.0-20190424152011-77b8897ec79a
 	k8s.io/api => k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d

--- a/go.sum
+++ b/go.sum
@@ -497,7 +497,7 @@ github.com/operator-framework/operator-registry v1.0.1/go.mod h1:1xEdZjjUg2hPEd5
 github.com/operator-framework/operator-registry v1.0.4/go.mod h1:hve6YwcjM2nGVlscLtNsp9sIIBkNZo6jlJgzWw7vP9s=
 github.com/operator-framework/operator-registry v1.1.1/go.mod h1:7D4WEwL+EKti5npUh4/u64DQhawCBRugp8Ql20duUb4=
 github.com/operator-framework/operator-sdk v0.8.2-0.20190522220659-031d71ef8154/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
-github.com/operator-framework/operator-sdk v0.12.0 h1:9eAD1L8e6pPCpFCAacBUVf2eloDkRuVm29GTCOktLqQ=
+github.com/operator-framework/operator-sdk v0.12.0 h1:aD4qPbSAbZgRj1jFdFLq/dBI4P4aKX8d4rJowyQtTYM=
 github.com/operator-framework/operator-sdk v0.12.0/go.mod h1:mW8isQxiXlLCVf2E+xqflkQAVLOTbiqjndKdkKIrR0M=
 github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/go.sum
+++ b/go.sum
@@ -475,6 +475,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/runc v0.0.0-20181113202123-f000fe11ece1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
+github.com/openshift/api v0.0.0-20190424152011-77b8897ec79a h1:zJauc4Mzrbn2C+G6cMwvvMCGWQZoyHaDlhoP6AjQDs8=
+github.com/openshift/api v0.0.0-20190424152011-77b8897ec79a/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible h1:q2JBuObKafI7B4Eli6eLd+2T5JsU9ioWZ82zQwyjJPg=
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=

--- a/go.sum
+++ b/go.sum
@@ -497,7 +497,7 @@ github.com/operator-framework/operator-registry v1.0.1/go.mod h1:1xEdZjjUg2hPEd5
 github.com/operator-framework/operator-registry v1.0.4/go.mod h1:hve6YwcjM2nGVlscLtNsp9sIIBkNZo6jlJgzWw7vP9s=
 github.com/operator-framework/operator-registry v1.1.1/go.mod h1:7D4WEwL+EKti5npUh4/u64DQhawCBRugp8Ql20duUb4=
 github.com/operator-framework/operator-sdk v0.8.2-0.20190522220659-031d71ef8154/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
-github.com/operator-framework/operator-sdk v0.12.0 h1:aD4qPbSAbZgRj1jFdFLq/dBI4P4aKX8d4rJowyQtTYM=
+github.com/operator-framework/operator-sdk v0.12.0 h1:9eAD1L8e6pPCpFCAacBUVf2eloDkRuVm29GTCOktLqQ=
 github.com/operator-framework/operator-sdk v0.12.0/go.mod h1:mW8isQxiXlLCVf2E+xqflkQAVLOTbiqjndKdkKIrR0M=
 github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -29,6 +29,9 @@ type ServiceBindingRequestSpec struct {
 	// BackingServiceSelector is used to identify the backing service operator.
 	BackingServiceSelector BackingServiceSelector `json:"backingServiceSelector"`
 
+	// BackingServiceSelectors is used to identify multiple backing services.
+	BackingServiceSelectors []BackingServiceSelector `json:"backingServiceSelectors"`
+
 	// ApplicationSelector is used to identify the application connecting to the
 	// backing service operator.
 	ApplicationSelector ApplicationSelector `json:"applicationSelector"`

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -121,6 +121,11 @@ func (in *ServiceBindingRequestSpec) DeepCopyInto(out *ServiceBindingRequestSpec
 		}
 	}
 	out.BackingServiceSelector = in.BackingServiceSelector
+	if in.BackingServiceSelectors != nil {
+		in, out := &in.BackingServiceSelectors, &out.BackingServiceSelectors
+		*out = make([]BackingServiceSelector, len(*in))
+		copy(*out, *in)
+	}
 	in.ApplicationSelector.DeepCopyInto(&out.ApplicationSelector)
 	return
 }

--- a/pkg/controller/servicebindingrequest/binding.go
+++ b/pkg/controller/servicebindingrequest/binding.go
@@ -1,0 +1,319 @@
+package servicebindingrequest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gotest.tools/assert/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/pkg/converter"
+	"github.com/redhat-developer/service-binding-operator/pkg/log"
+)
+
+const (
+	// bindingInProgress binding is in progress
+	bindingInProgress = "InProgress"
+	// bindingFail binding has failed
+	bindingFail = "Fail"
+	// time in seconds to wait before requeuing requests
+	requeueAfter int64 = 45
+	// Finalizer annotation used in finalizer steps
+	Finalizer = "finalizer.servicebindingrequest.openshift.io"
+)
+
+// GroupVersion represents the service binding request resource's group version.
+var GroupVersion = v1alpha1.SchemeGroupVersion.WithResource(ServiceBindingRequestResource)
+
+// ServiceBinderOptions is BuildServiceBinder arguments.
+type ServiceBinderOptions struct {
+	Logger                 *log.Log
+	DynClient              dynamic.Interface
+	DetectBindingResources bool
+	EnvVarPrefix           string
+	SBR                    *v1alpha1.ServiceBindingRequest
+	Client                 client.Client
+}
+
+// Valid returns whether the options are valid.
+func (o *ServiceBinderOptions) Valid() bool {
+	return o.SBR != nil && o.DynClient != nil && o.Client != nil
+}
+
+// ServiceBinder manages binding for a Service Binding Request and associated objects.
+type ServiceBinder struct {
+	// Binder is responsible for interacting with the cluster and apply binding related changes.
+	Binder *Binder
+	// Data is the collection of all data read by the manager.
+	Data map[string][]byte
+	// DynClient is the Kubernetes dynamic client used to interact with the cluster.
+	DynClient dynamic.Interface
+	// Logger provides logging facilities for internal components.
+	Logger *log.Log
+	// Objects is a list of additional unstructured objects related to the Service Binding Request.
+	Objects []*unstructured.Unstructured
+	// SBR is the ServiceBindingRequest associated with binding..
+	SBR *v1alpha1.ServiceBindingRequest
+	// Secret is the Secret associated with the Service Binding Request.
+	Secret *Secret
+}
+
+// updateServiceBindingRequest execute update API call on a SBR request. It can return errors from
+// this action.
+func (b *ServiceBinder) updateServiceBindingRequest(
+	sbr *v1alpha1.ServiceBindingRequest,
+) (*v1alpha1.ServiceBindingRequest, error) {
+	u, err := converter.ToUnstructured(sbr)
+	if err != nil {
+		return nil, err
+	}
+
+	u, err = b.DynClient.
+		Resource(GroupVersion).
+		Namespace(sbr.GetNamespace()).
+		Update(u, v1.UpdateOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, sbr)
+	if err != nil {
+		return nil, err
+	}
+	return sbr, nil
+}
+
+// Unbind removes the relationship between a Service Binding Request and its related objects.
+func (b *ServiceBinder) Unbind() (reconcile.Result, error) {
+	logger := b.Logger.WithName("Unbind")
+
+	logger.Info("Cleaning related objects from operator's annotations...")
+	if err := RemoveSBRAnnotations(b.DynClient, b.Objects); err != nil {
+		logger.Error(err, "On removing annotations from related objects.")
+		return RequeueError(err)
+	}
+
+	if err := b.Binder.Unbind(); err != nil {
+		logger.Error(err, "On unbinding related objects")
+		return RequeueError(err)
+	}
+
+	logger.Info("Deleting intermediary secret")
+	if err := b.Secret.Delete(); err != nil {
+		logger.Error(err, "On deleting intermediary secret.")
+		return RequeueError(err)
+	}
+
+	logger.Debug("Removing resource finalizers...")
+	b.SBR.SetFinalizers(removeStringSlice(b.SBR.GetFinalizers(), Finalizer))
+	if _, err := b.updateServiceBindingRequest(b.SBR); err != nil {
+		return NoRequeue(err)
+	}
+
+	return Done()
+}
+
+// updateStatusServiceBindingRequest updates the Service Binding Request's status field.
+func (b *ServiceBinder) updateStatusServiceBindingRequest(
+	sbr *v1alpha1.ServiceBindingRequest,
+	sbrStatus *v1alpha1.ServiceBindingRequestStatus,
+) (
+	*v1alpha1.ServiceBindingRequest,
+	error,
+) {
+	// do not update if both statuses are equal
+	if result := cmp.DeepEqual(sbr.Status, sbrStatus)(); result.Success() {
+		return sbr, nil
+	}
+
+	// coping status over informed object
+	sbr.Status = *sbrStatus
+
+	// converting object into unstructured
+	u, err := converter.ToUnstructured(sbr)
+	if err != nil {
+		return nil, err
+	}
+
+	gr := v1alpha1.SchemeGroupVersion.WithResource(ServiceBindingRequestResource)
+	resourceClient := b.DynClient.Resource(gr).Namespace(sbr.GetNamespace())
+	u, err = resourceClient.UpdateStatus(u, v1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, sbr)
+	if err != nil {
+		return nil, err
+	}
+	return sbr, nil
+}
+
+// onError comprise the update of ServiceBindingRequest status to set error flag, and inspect
+// informed error to apply a different behavior for not-founds.
+func (b *ServiceBinder) onError(
+	err error,
+	sbr *v1alpha1.ServiceBindingRequest,
+	sbrStatus *v1alpha1.ServiceBindingRequestStatus,
+	objs []*unstructured.Unstructured,
+) (reconcile.Result, error) {
+	sbrStatus.BindingStatus = bindingFail
+
+	if objs != nil {
+		sbrStatus.BindingStatus = BindingSuccess
+		b.setApplicationObjects(sbrStatus, objs)
+	}
+
+	_, errStatus := b.updateStatusServiceBindingRequest(sbr, sbrStatus)
+	if errStatus != nil {
+		return RequeueError(errStatus)
+	}
+
+	return RequeueOnNotFound(err, requeueAfter)
+}
+
+// Bind configures binding between the Service Binding Request and its related objects.
+func (b *ServiceBinder) Bind() (reconcile.Result, error) {
+	sbrStatus := b.SBR.Status.DeepCopy()
+
+	b.Logger.Info("Saving data on intermediary secret...")
+	secretObj, err := b.Secret.Commit(b.Data, nil)
+	if err != nil {
+		b.Logger.Error(err, "On saving secret data..")
+		return b.onError(err, b.SBR, sbrStatus, nil)
+	}
+
+	// update status information
+	sbrStatus.BindingStatus = bindingInProgress
+	sbrStatus.Secret = secretObj.GetName()
+
+	updatedObjects, err := b.Binder.Bind()
+	if err != nil {
+		b.Logger.Error(err, "On binding application.")
+		return b.onError(err, b.SBR, sbrStatus, updatedObjects)
+	}
+
+	// saving on status the list of objects that have been touched
+	sbrStatus.BindingStatus = BindingSuccess
+	b.setApplicationObjects(sbrStatus, updatedObjects)
+
+	// annotating objects related to binding
+	namespacedName := types.NamespacedName{Namespace: b.SBR.GetNamespace(), Name: b.SBR.GetName()}
+	if err = SetSBRAnnotations(b.DynClient, namespacedName, b.Objects); err != nil {
+		b.Logger.Error(err, "On setting annotations in related objects.")
+		return b.onError(err, b.SBR, sbrStatus, updatedObjects)
+	}
+
+	// updating status of request instance
+	sbr, err := b.updateStatusServiceBindingRequest(b.SBR, sbrStatus)
+	if err != nil {
+		return RequeueOnConflict(err)
+	}
+
+	// appending finalizer, should be later removed upon resource deletion
+	sbr.SetFinalizers(append(sbr.GetFinalizers(), Finalizer))
+	if _, err = b.updateServiceBindingRequest(sbr); err != nil {
+		return NoRequeue(err)
+	}
+
+	b.Logger.Info("All done!")
+	return Done()
+}
+
+// setApplicationObjects replaces the Status's equivalent field.
+func (b *ServiceBinder) setApplicationObjects(
+	sbrStatus *v1alpha1.ServiceBindingRequestStatus,
+	objs []*unstructured.Unstructured,
+) {
+	names := []string{}
+	for _, obj := range objs {
+		names = append(names, fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName()))
+	}
+	sbrStatus.ApplicationObjects = names
+}
+
+// buildPlan creates a new plan.
+func buildPlan(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	sbr *v1alpha1.ServiceBindingRequest,
+) (*Plan, error) {
+	planner := NewPlanner(ctx, dynClient, sbr)
+	return planner.Plan()
+}
+
+// InvalidOptionsErr is returned when ServiceBinderOptions are not valid.
+var InvalidOptionsErr = errors.New("invalid options")
+
+// BuildServiceBinder creates a new binding manager according to options.
+func BuildServiceBinder(options *ServiceBinderOptions) (*ServiceBinder, error) {
+	if !options.Valid() {
+		return nil, InvalidOptionsErr
+	}
+
+	// objs groups all extra objects related to the informed SBR
+	objs := make([]*unstructured.Unstructured, 0, 0)
+
+	// plan is a source of information regarding the binding process
+	ctx := context.Background()
+	plan, err := buildPlan(ctx, options.DynClient, options.SBR)
+	if err != nil {
+		return nil, err
+	}
+
+	rs := plan.GetCRs()
+	// append all SBR related CRs
+	objs = append(objs, rs...)
+
+	// retriever is responsible for gathering data related to the given plan.
+	retriever := NewRetriever(options.DynClient, plan, options.EnvVarPrefix)
+
+	// read bindable data from the specified resources
+	if options.DetectBindingResources {
+		err := retriever.ReadBindableResourcesData(&plan.SBR, rs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// read bindable data from the CRDDescription found by the planner
+	for _, r := range plan.GetRelatedResources() {
+		err = retriever.ReadCRDDescriptionData(r.CR, r.CRDDescription)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// gather retriever's read data
+	// TODO: do not return error
+	retrievedData, err := retriever.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	// gather related secret, again only appending it if there's a value.
+	secret := NewSecret(options.DynClient, plan)
+	secretObj, found, err := secret.Get()
+	if found {
+		objs = append(objs, secretObj)
+	}
+
+	return &ServiceBinder{
+		Logger:    options.Logger,
+		Binder:    NewBinder(ctx, options.Client, options.DynClient, options.SBR, retriever.volumeKeys),
+		DynClient: options.DynClient,
+		SBR:       options.SBR,
+		Objects:   objs,
+		Data:      retrievedData,
+		Secret:    secret,
+	}, nil
+}

--- a/pkg/controller/servicebindingrequest/binding.go
+++ b/pkg/controller/servicebindingrequest/binding.go
@@ -303,6 +303,9 @@ func BuildServiceBinder(options *ServiceBinderOptions) (*ServiceBinder, error) {
 	// gather related secret, again only appending it if there's a value.
 	secret := NewSecret(options.DynClient, plan)
 	secretObj, found, err := secret.Get()
+	if err != nil {
+		return nil, err
+	}
 	if found {
 		objs = append(objs, secretObj)
 	}

--- a/pkg/controller/servicebindingrequest/binding.go
+++ b/pkg/controller/servicebindingrequest/binding.go
@@ -261,7 +261,7 @@ func BuildServiceBinder(options *ServiceBinderOptions) (*ServiceBinder, error) {
 	}
 
 	// objs groups all extra objects related to the informed SBR
-	objs := make([]*unstructured.Unstructured, 0, 0)
+	objs := make([]*unstructured.Unstructured, 0)
 
 	// plan is a source of information regarding the binding process
 	ctx := context.Background()

--- a/pkg/controller/servicebindingrequest/binding_test.go
+++ b/pkg/controller/servicebindingrequest/binding_test.go
@@ -154,16 +154,24 @@ func TestServiceBinder_Bind(t *testing.T) {
 		},
 		Spec: v1alpha1.ServiceBindingRequestSpec{
 			ApplicationSelector: v1alpha1.ApplicationSelector{
-				MatchLabels: matchLabels,
-				Group:       d.GetObjectKind().GroupVersionKind().Group,
-				Version:     d.GetObjectKind().GroupVersionKind().Version,
-				Resource:    "deployments",
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: matchLabels,
+				},
+				GroupVersionResource: metav1.GroupVersionResource{
+					Group:    d.GetObjectKind().GroupVersionKind().Group,
+					Version:  d.GetObjectKind().GroupVersionKind().Version,
+					Resource: "deployments",
+				},
 				ResourceRef: d.GetName(),
 			},
 			BackingServiceSelectors: []v1alpha1.BackingServiceSelector{
 				{
-					GroupVersionKind: db1.GetObjectKind().GroupVersionKind(),
-					ResourceRef:      db1.GetName(),
+					GroupVersionKind: metav1.GroupVersionKind{
+						Group:   db1.GetObjectKind().GroupVersionKind().Group,
+						Version: db1.GetObjectKind().GroupVersionKind().Version,
+						Kind:    db1.GetObjectKind().GroupVersionKind().Kind,
+					},
+					ResourceRef: db1.GetName(),
 				},
 			},
 		},
@@ -182,20 +190,32 @@ func TestServiceBinder_Bind(t *testing.T) {
 		},
 		Spec: v1alpha1.ServiceBindingRequestSpec{
 			ApplicationSelector: v1alpha1.ApplicationSelector{
-				MatchLabels: matchLabels,
-				Group:       d.GetObjectKind().GroupVersionKind().Group,
-				Version:     d.GetObjectKind().GroupVersionKind().Version,
-				Resource:    "deployments",
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: matchLabels,
+				},
+				GroupVersionResource: metav1.GroupVersionResource{
+					Group:    d.GetObjectKind().GroupVersionKind().Group,
+					Version:  d.GetObjectKind().GroupVersionKind().Version,
+					Resource: "deployments",
+				},
 				ResourceRef: d.GetName(),
 			},
 			BackingServiceSelectors: []v1alpha1.BackingServiceSelector{
 				{
-					GroupVersionKind: db1.GetObjectKind().GroupVersionKind(),
-					ResourceRef:      db1.GetName(),
+					GroupVersionKind: metav1.GroupVersionKind{
+						Group:   db1.GetObjectKind().GroupVersionKind().Group,
+						Version: db1.GetObjectKind().GroupVersionKind().Version,
+						Kind:    db1.GetObjectKind().GroupVersionKind().Kind,
+					},
+					ResourceRef: db1.GetName(),
 				},
 				{
-					GroupVersionKind: db2.GetObjectKind().GroupVersionKind(),
-					ResourceRef:      "db2",
+					GroupVersionKind: metav1.GroupVersionKind{
+						Group:   db2.GetObjectKind().GroupVersionKind().Group,
+						Version: db2.GetObjectKind().GroupVersionKind().Version,
+						Kind:    db2.GetObjectKind().GroupVersionKind().Kind,
+					},
+					ResourceRef: db2.GetName(),
 				},
 			},
 		},

--- a/pkg/controller/servicebindingrequest/binding_test.go
+++ b/pkg/controller/servicebindingrequest/binding_test.go
@@ -1,0 +1,291 @@
+package servicebindingrequest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/pkg/log"
+	"github.com/redhat-developer/service-binding-operator/test/mocks"
+)
+
+// TestServiceBinder_Bind exercises scenarios regarding binding SBR and its related resources.
+func TestServiceBinder_Bind(t *testing.T) {
+	t.Skip("functionality is not ready yet")
+
+	// wantedAction represents an action issued by the component that is required to exist after it
+	// finished the operation
+	type wantedAction struct {
+		verb     string
+		resource string
+		name     string
+	}
+
+	// args are the test arguments
+	type args struct {
+		// options inform the test how to build the ServiceBinder.
+		options *ServiceBinderOptions
+		// wantBuildErr informs the test an error is wanted at build phase.
+		wantBuildErr error
+		// wantErr informs the test an error is wanted at ServiceBinder's bind phase.
+		wantErr error
+		// wantedActions informs the test all the actions that should have been issued by
+		// ServiceBinder.
+		wantedActions []wantedAction
+	}
+
+	// assertBind exercises the bind functionality
+	assertBind := func(args args) func(*testing.T) {
+		return func(t *testing.T) {
+			sb, err := BuildServiceBinder(args.options)
+			if args.wantBuildErr != nil {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			res, err := sb.Bind()
+
+			if args.wantErr != nil {
+				require.Error(t, err)
+				require.Equal(t, args.wantErr, err)
+				require.Nil(t, res)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+			}
+
+			// extract actions from the dynamic client, regardless of the bind status; it is expected
+			// that failures also issue updates for ServiceBindingRequest objects
+			dynClient, ok := sb.DynClient.(*fake.FakeDynamicClient)
+			require.True(t, ok)
+			actions := dynClient.Actions()
+			require.NotNil(t, actions)
+
+			// regardless of the result, verify the actions expected by the reconciliation
+			// process have been issued if user has specified wanted actions
+			if len(args.wantedActions) > 0 {
+				// proceed to find whether actions match wanted actions
+				for _, w := range args.wantedActions {
+					var match bool
+					// search for each wanted action in the slice of actions issued by ServiceBinder
+					for _, a := range actions {
+						// match will be updated in the switch branches below
+						if match {
+							break
+						}
+
+						if a.Matches(w.verb, w.resource) {
+							// there are several action types; here it is required to 'type
+							// switch' it and perform the right check.
+							switch v := a.(type) {
+							case k8stesting.GetAction:
+								match = v.GetName() == w.name
+							case k8stesting.UpdateAction:
+								obj := v.GetObject()
+								uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+								require.NoError(t, err)
+								u := &unstructured.Unstructured{Object: uObj}
+								match = w.name == u.GetName()
+							}
+						}
+
+						// short circuit to the end of collected actions if the action has matched.
+						if match {
+							break
+						}
+					}
+					require.True(t, match, "expected action %+v not found", w)
+				}
+			}
+		}
+	}
+
+	matchLabels := map[string]string{
+		"connects-to": "database",
+	}
+
+	f := mocks.NewFake(t, reconcilerName)
+	f.S.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.ServiceBindingRequest{})
+	f.S.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ConfigMap{})
+
+	d := f.AddMockedUnstructuredDeployment(reconcilerName, matchLabels)
+	f.AddMockedUnstructuredDatabaseCRD()
+	f.AddMockedUnstructuredConfigMap("db1")
+	f.AddMockedUnstructuredConfigMap("db2")
+
+	// create and munge a Database CR since there's no "Status" field in
+	// databases.postgres.baiju.dev, requiring us to add the field directly in the unstructured
+	// object
+	db1 := f.AddMockedUnstructuredPostgresDatabaseCR("db1")
+	{
+		runtimeStatus := map[string]interface{}{
+			"dbConfigMap": "db1",
+		}
+		err := unstructured.SetNestedMap(db1.Object, runtimeStatus, "status")
+		require.NoError(t, err)
+	}
+
+	db2 := f.AddMockedUnstructuredPostgresDatabaseCR("db2")
+	{
+		runtimeStatus := map[string]interface{}{
+			"dbConfigMap": "db2",
+		}
+		err := unstructured.SetNestedMap(db2.Object, runtimeStatus, "status")
+		require.NoError(t, err)
+	}
+
+	// create the ServiceBindingRequest
+	sbrSingleService := &v1alpha1.ServiceBindingRequest{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.openshift.io/v1alpha1",
+			Kind:       "ServiceBindingRequest",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "single-sbr",
+		},
+		Spec: v1alpha1.ServiceBindingRequestSpec{
+			ApplicationSelector: v1alpha1.ApplicationSelector{
+				MatchLabels: matchLabels,
+				Group:       d.GetObjectKind().GroupVersionKind().Group,
+				Version:     d.GetObjectKind().GroupVersionKind().Version,
+				Resource:    "deployments",
+				ResourceRef: d.GetName(),
+			},
+			BackingServiceSelectors: []v1alpha1.BackingServiceSelector{
+				{
+					GroupVersionKind: db1.GetObjectKind().GroupVersionKind(),
+					ResourceRef:      db1.GetName(),
+				},
+			},
+		},
+		Status: v1alpha1.ServiceBindingRequestStatus{},
+	}
+	f.AddMockResource(sbrSingleService)
+
+	// create the ServiceBindingRequest
+	sbrMultipleServices := &v1alpha1.ServiceBindingRequest{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.openshift.io/v1alpha1",
+			Kind:       "ServiceBindingRequest",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "multiple-sbr",
+		},
+		Spec: v1alpha1.ServiceBindingRequestSpec{
+			ApplicationSelector: v1alpha1.ApplicationSelector{
+				MatchLabels: matchLabels,
+				Group:       d.GetObjectKind().GroupVersionKind().Group,
+				Version:     d.GetObjectKind().GroupVersionKind().Version,
+				Resource:    "deployments",
+				ResourceRef: d.GetName(),
+			},
+			BackingServiceSelectors: []v1alpha1.BackingServiceSelector{
+				{
+					GroupVersionKind: db1.GetObjectKind().GroupVersionKind(),
+					ResourceRef:      db1.GetName(),
+				},
+				{
+					GroupVersionKind: db2.GetObjectKind().GroupVersionKind(),
+					ResourceRef:      "db2",
+				},
+			},
+		},
+		Status: v1alpha1.ServiceBindingRequestStatus{},
+	}
+	f.AddMockResource(sbrMultipleServices)
+
+	logger := log.NewLog("service-binder")
+	t.Run("single bind golden path", assertBind(args{
+		options: &ServiceBinderOptions{
+			Logger:                 logger,
+			DynClient:              f.FakeDynClient(),
+			DetectBindingResources: false,
+			EnvVarPrefix:           "",
+			SBR:                    sbrSingleService,
+			Client:                 f.FakeClient(),
+		},
+		wantedActions: []wantedAction{
+			{
+				resource: "servicebindingrequests",
+				verb:     "update",
+				name:     sbrSingleService.GetName(),
+			},
+			{
+				resource: "secrets",
+				verb:     "update",
+				name:     sbrSingleService.GetName(),
+			},
+			{
+				resource: "databases",
+				verb:     "update",
+				name:     db1.GetName(),
+			},
+		},
+	}))
+
+	t.Run("bind with binding resource detection", assertBind(args{
+		options: &ServiceBinderOptions{
+			Logger:                 logger,
+			DynClient:              f.FakeDynClient(),
+			DetectBindingResources: true,
+			EnvVarPrefix:           "",
+			SBR:                    sbrSingleService,
+			Client:                 f.FakeClient(),
+		},
+	}))
+
+	// Missing SBR returns an InvalidOptionsErr
+	t.Run("bind missing SBR", assertBind(args{
+		options: &ServiceBinderOptions{
+			Logger:                 logger,
+			DynClient:              f.FakeDynClient(),
+			DetectBindingResources: false,
+			EnvVarPrefix:           "",
+			SBR:                    nil,
+			Client:                 f.FakeClient(),
+		},
+		wantBuildErr: InvalidOptionsErr,
+	}))
+
+	t.Run("multiple services bind golden path", assertBind(args{
+		options: &ServiceBinderOptions{
+			Logger:                 logger,
+			DynClient:              f.FakeDynClient(),
+			DetectBindingResources: false,
+			EnvVarPrefix:           "",
+			SBR:                    sbrMultipleServices,
+			Client:                 f.FakeClient(),
+		},
+		wantedActions: []wantedAction{
+			{
+				resource: "servicebindingrequests",
+				verb:     "update",
+				name:     sbrMultipleServices.GetName(),
+			},
+			{
+				resource: "secrets",
+				verb:     "update",
+				name:     sbrMultipleServices.GetName(),
+			},
+			{
+				resource: "databases",
+				verb:     "update",
+				name:     db1.GetName(),
+			},
+			{
+				resource: "databases",
+				verb:     "update",
+				name:     db2.GetName(),
+			},
+		},
+	}))
+}

--- a/pkg/controller/servicebindingrequest/plan_decoupled.go
+++ b/pkg/controller/servicebindingrequest/plan_decoupled.go
@@ -1,0 +1,15 @@
+package servicebindingrequest
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// GetCRs returns a slice of unstructured CRs contained in the internal related resources collection.
+func (p *Plan) GetCRs() []*unstructured.Unstructured {
+	// return p.RelatedResources.GetCRs()
+	panic("implement me")
+}
+
+// GetRelatedResources returns the collection of related resources enumerated in the plan.
+func (p *Plan) GetRelatedResources() RelatedResources {
+	//return p.RelatedResources
+	panic("implement me")
+}

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -197,7 +197,7 @@ func (r *Reconciler) unbind(
 	}
 
 	logger.Debug("Reading intermediary secret before deletion.")
-	secretObj, err := secret.Get()
+	secretObj, _, err := secret.Get()
 	if err != nil {
 		logger.Error(err, "On reading intermediary secret.")
 		return RequeueError(err)

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -27,14 +27,8 @@ type Reconciler struct {
 }
 
 const (
-	// bindingInProgress binding is in progress
-	bindingInProgress = "InProgress"
 	// BindingSuccess binding has succeeded
 	BindingSuccess = "Success"
-	// bindingFail binding has failed
-	bindingFail = "Fail"
-	// time in seconds to wait before requeuing requests
-	requeueAfter int64 = 45
 	// sbrFinalizer annotation used in finalizer steps
 	sbrFinalizer = "finalizer.servicebindingrequest.openshift.io"
 )

--- a/pkg/controller/servicebindingrequest/related_resources.go
+++ b/pkg/controller/servicebindingrequest/related_resources.go
@@ -1,0 +1,24 @@
+package servicebindingrequest
+
+import (
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// RelatedResource represents a SBR related resource, composed by its CR and CRDDescription.
+type RelatedResource struct {
+	CRDDescription *v1alpha1.CRDDescription
+	CR             *unstructured.Unstructured
+}
+
+// RelatedResources contains a collection of SBR related resources.
+type RelatedResources []*RelatedResource
+
+// GetCRs returns a slice of unstructured CRs contained in the collection.
+func (rr RelatedResources) GetCRs() []*unstructured.Unstructured {
+	var crs []*unstructured.Unstructured
+	for _, r := range rr {
+		crs = append(crs, r.CR)
+	}
+	return crs
+}

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -1,0 +1,71 @@
+package servicebindingrequest
+
+import (
+	"fmt"
+
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+)
+
+// Retrieve returns the data read from related resources (see ReadBindableResourcesData and
+// ReadCRDDescriptionData).
+func (r *Retriever) Get() (map[string][]byte, error) {
+	return r.data, nil
+}
+
+// ReadBindableResourcesData reads all related resources of a given sbr
+func (r *Retriever) ReadBindableResourcesData(
+	sbr *v1alpha1.ServiceBindingRequest,
+	crs []*unstructured.Unstructured,
+) error {
+	r.logger.Info("Detecting extra resources for binding...")
+	for _, cr := range crs {
+		b := NewDetectBindableResources(sbr, cr, []schema.GroupVersionResource{
+			{Group: "", Version: "v1", Resource: "configmaps"},
+			{Group: "", Version: "v1", Resource: "services"},
+			{Group: "route.openshift.io", Version: "v1", Resource: "routes"},
+		}, r.client)
+
+		vals, err := b.GetBindableVariables()
+		if err != nil {
+			return err
+		}
+		for k, v := range vals {
+			r.storeInto(cr, k, []byte(fmt.Sprintf("%v", v)))
+		}
+	}
+
+	return nil
+}
+
+func (r *Retriever) storeInto(cr *unstructured.Unstructured, key string, value []byte) {
+	// r.store(cr, k, v)
+	panic("implement me")
+}
+
+func (r *Retriever) copyFrom(u *unstructured.Unstructured, path string, fieldPath string, descriptors []string) error {
+	// r.read(u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
+	panic("implement me")
+}
+
+// ReadCRDDescriptionData reads data related to given crdDescription
+func (r *Retriever) ReadCRDDescriptionData(u *unstructured.Unstructured, crdDescription *olmv1alpha1.CRDDescription) error {
+	r.logger.Info("Looking for spec-descriptors in 'spec'...")
+	for _, specDescriptor := range crdDescription.SpecDescriptors {
+		if err := r.copyFrom(u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
+			return err
+		}
+	}
+
+	r.logger.Info("Looking for status-descriptors in 'status'...")
+	for _, statusDescriptor := range crdDescription.StatusDescriptors {
+		if err := r.copyFrom(u, "status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -10,7 +10,7 @@ import (
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 )
 
-// Retrieve returns the data read from related resources (see ReadBindableResourcesData and
+// Get returns the data read from related resources (see ReadBindableResourcesData and
 // ReadCRDDescriptionData).
 func (r *Retriever) Get() (map[string][]byte, error) {
 	return r.data, nil

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -153,7 +153,7 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 
 	f := mocks.NewFake(t, ns)
 	f.AddMockedUnstructuredCSV("csv")
-	f.AddMockedConfigMap(crName)
+	f.AddMockedUnstructuredConfigMap(crName)
 	f.AddMockedDatabaseCR(crName)
 
 	crdDescription := mocks.CRDDescriptionConfigMapMock()

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -90,9 +90,13 @@ func (s *Secret) Commit(data map[string][]byte, cache map[string]interface{}) (*
 
 // Get an unstructured object from the secret handled by this component. It can return errors in case
 // the API server does.
-func (s *Secret) Get() (*unstructured.Unstructured, error) {
+func (s *Secret) Get() (*unstructured.Unstructured, bool, error) {
 	resourceClient := s.buildResourceClient()
-	return resourceClient.Get(s.plan.Name, metav1.GetOptions{})
+	u, err := resourceClient.Get(s.plan.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, false, err
+	}
+	return u, u != nil, nil
 }
 
 // Delete the secret represented by this component. It can return error when the API server does.

--- a/pkg/controller/servicebindingrequest/secret_test.go
+++ b/pkg/controller/servicebindingrequest/secret_test.go
@@ -54,7 +54,7 @@ func TestSecretNew(t *testing.T) {
 	})
 
 	t.Run("Get", func(t *testing.T) {
-		u, err := s.Get()
+		u, _, err := s.Get()
 		assert.NoError(t, err)
 		assertSecretNamespacedName(t, u, ns, name)
 	})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -135,7 +135,7 @@ github.com/mitchellh/go-homedir
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
+# github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible => github.com/openshift/api v0.0.0-20190424152011-77b8897ec79a
 github.com/openshift/api/apps/v1
 github.com/openshift/api/route/v1
 # github.com/operator-backing-service-samples/postgresql-operator v0.0.0-20191023140509-5c3697ed3069


### PR DESCRIPTION
### Motivation

This PR is a preparation for binding multiple backing services with the specified application.

### Changes

It introduces the ServiceBinder component, which is responsible for orchestrating the low-level components handling operational tasks such as updating Kubernetes resources related to the Service Binding Request.

ServiceBinder is still incomplete in this PR, but the changes made in the current tests should prove whether the existing functionality is still covered.

Since it is incomplete, its tests are currently skipped and will be enabled when all dependencies are in place.

For further more details refer the CONTRIBUTING.md