### PR TITLE
Increment operator version to 0.0.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ GOCOV ?= "-covermode=atomic -coverprofile REPLACE_FILE"
 
 GIT_COMMIT_ID = $(shell git rev-parse --short HEAD)
 
-OPERATOR_VERSION ?= 0.0.23
+OPERATOR_VERSION ?= 0.0.24
 OPERATOR_GROUP ?= ${GO_PACKAGE_ORG_NAME}
 OPERATOR_IMAGE ?= quay.io/${OPERATOR_GROUP}/${GO_PACKAGE_REPO_NAME}
 OPERATOR_IMAGE_REL ?= quay.io/${OPERATOR_GROUP}/app-binding-operator


### PR DESCRIPTION
After making a manual release, the version number should be incremented.