### PR TITLE
Add CSVstep in e2e scenario-csv-db-app-sbr

### DIFF
--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -106,7 +106,7 @@ func TestAddSchemesToFramework(t *testing.T) {
 			ServiceBindingRequest(t, []Step{SBRStep, AppStep, DBStep})
 		})
 		t.Run("scenario-csv-db-app-sbr", func(t *testing.T) {
-			ServiceBindingRequest(t, []Step{DBStep, AppStep, SBRStep})
+			ServiceBindingRequest(t, []Step{CSVStep, DBStep, AppStep, SBRStep})
 		})
 		t.Run("scenario-csv-app-db-sbr", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{CSVStep, AppStep, DBStep, SBRStep})


### PR DESCRIPTION
### Motivation

The e2e scenario is described as `scenario-csv-db-app-sbr` but there is no csv step in `ServiceBindingRequest(t, []Step{SBRStep, AppStep, DBStep})`.

### Changes

Add `CSVStep` in scenario.

### Testing

`make test-e2e`
