### PR TITLE
Update csv mock, add selector and containers.

### DIFF
--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -232,7 +232,20 @@ func clusterServiceVersionMock(
 	strategy := olminstall.StrategyDetailsDeployment{
 		DeploymentSpecs: []olminstall.StrategyDeploymentSpec{{
 			Name: "deployment",
-			Spec: appsv1.DeploymentSpec{},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						name: "service-binding-operator",
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Command: []string{"service-binding-operator"},
+						}},
+					},
+				},
+			},
 		}},
 	}
 


### PR DESCRIPTION
### Motivation
CSV mock is broken which causing test failure: 
```
Error:      	Received unexpected error:
                	            	ClusterServiceVersion.operators.coreos.com "cluster-service-version-6129484611666145821" is invalid: [spec.install.spec.deployments.spec.template.spec.containers: Invalid value: "null": spec.install.spec.deployments.spec.template.spec.containers in body must be of type array: "null", spec.install.spec.deployments.spec.selector: Invalid value: "null": spec.install.spec.deployments.spec.selector in body must be of type object: "null"]
                	Test:       	TestAddSchemesToFramework/end-to-end/scenario-csv-app-db-sbr
FAIL
```
Issue: https://github.com/redhat-developer/service-binding-operator/issues/306
### Changes

Updating csv mock.

### Testing

make test-e2e

After changes: 
```
 PASS: TestAddSchemesToFramework/end-to-end (43.03s)
        --- PASS: TestAddSchemesToFramework/end-to-end/scenario-csv-app-db-sbr (43.03s)
            servicebindingrequest_test.go:148: Creating a new test context...
            servicebindingrequest_test.go:129: Initializing cluster resources...
            servicebindingrequest_test.go:139: Using namespace 'test-namespace-66d204f4-fc36-4865-9fb1-363901889d95' for testing...
            servicebindingrequest_test.go:503: Starting end-to-end tests for operator, using suffix '6129484611666145821'!
            servicebindingrequest_test.go:400: Creating ClusterServiceVersion mock object: 'types.NamespacedName{Namespace:"test-namespace-66d204f4-fc36-4865-9fb1-363901889d
95", Name:"cluster-service-version-6129484611666145821"}'...

```
