### PR TITLE
WIP Support binding to an app in a different ns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/coreos/etcd-operator v0.9.4
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.0
 	github.com/go-openapi/swag v0.19.0 // indirect
@@ -25,6 +26,7 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/build v0.0.0-20190314133821-5284462c4bec // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -497,7 +497,7 @@ github.com/operator-framework/operator-registry v1.0.1/go.mod h1:1xEdZjjUg2hPEd5
 github.com/operator-framework/operator-registry v1.0.4/go.mod h1:hve6YwcjM2nGVlscLtNsp9sIIBkNZo6jlJgzWw7vP9s=
 github.com/operator-framework/operator-registry v1.1.1/go.mod h1:7D4WEwL+EKti5npUh4/u64DQhawCBRugp8Ql20duUb4=
 github.com/operator-framework/operator-sdk v0.8.2-0.20190522220659-031d71ef8154/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
-github.com/operator-framework/operator-sdk v0.12.0 h1:9eAD1L8e6pPCpFCAacBUVf2eloDkRuVm29GTCOktLqQ=
+github.com/operator-framework/operator-sdk v0.12.0 h1:aD4qPbSAbZgRj1jFdFLq/dBI4P4aKX8d4rJowyQtTYM=
 github.com/operator-framework/operator-sdk v0.12.0/go.mod h1:mW8isQxiXlLCVf2E+xqflkQAVLOTbiqjndKdkKIrR0M=
 github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -67,6 +67,7 @@ type ApplicationSelector struct {
 	LabelSelector               *metav1.LabelSelector `json:"labelSelector,omitempty"`
 	metav1.GroupVersionResource `json:",inline"`
 	ResourceRef                 string `json:"resourceRef,omitempty"`
+	Namespace                   string `json:"namespace,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -45,7 +45,7 @@ type Binder struct {
 
 // search objects based in Kind/APIVersion, which contain the labels defined in ApplicationSelector.
 func (b *Binder) search() (*unstructured.UnstructuredList, error) {
-	ns := b.sbr.GetNamespace()
+	ns := b.sbr.Spec.ApplicationSelector.Namespace
 	gvr := schema.GroupVersionResource{
 		Group:    b.sbr.Spec.ApplicationSelector.GroupVersionResource.Group,
 		Version:  b.sbr.Spec.ApplicationSelector.GroupVersionResource.Version,

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -39,13 +39,14 @@ func (s *Secret) customEnvParser(data map[string][]byte, cache map[string]interf
 // buildResourceClient creates a resource client to handle corev1/secret resource.
 func (s *Secret) buildResourceClient() dynamic.ResourceInterface {
 	gvr := corev1.SchemeGroupVersion.WithResource(SecretResource)
-	return s.client.Resource(gvr).Namespace(s.plan.Ns)
+	return s.client.Resource(gvr).Namespace(s.plan.SBR.Spec.ApplicationSelector.Namespace)
 }
 
 // createOrUpdate will take informed payload and either create a new secret or update an existing
 // one. It can return error when Kubernetes client does.
 func (s *Secret) createOrUpdate(payload map[string][]byte) (*unstructured.Unstructured, error) {
-	ns := s.plan.Ns
+	// create token in target namespace
+	ns := s.plan.SBR.Spec.ApplicationSelector.Namespace
 	name := s.plan.Name
 	logger := s.logger.WithValues("Namespace", ns, "Name", name)
 	secretObj := &corev1.Secret{


### PR DESCRIPTION
Trying out https://github.com/redhat-developer/service-binding-operator/issues/314

1. Import app in namespace `foo`
2. Create db in namespace `bar`
3. Create an SBR in namespace `bar` to bind `foo` with `bar`.

```
apiVersion: apps.openshift.io/v1alpha1
kind: ServiceBindingRequest
metadata:
  creationTimestamp: '2020-02-05T19:16:24Z'
  finalizers:
    - finalizer.servicebindingrequest.openshift.io
  generation: 4
  name: nodejs-rest-http-crud-dc-demo-database-postgresql-d
  namespace: sbose
  resourceVersion: '217743'
  selfLink: >-
    /apis/apps.openshift.io/v1alpha1/namespaces/sbose/servicebindingrequests/nodejs-rest-http-crud-dc-demo-database-postgresql-d
  uid: 7e8b9979-94e0-453c-8ac8-e116a3620169
spec:
  applicationSelector:
    group: apps.openshift.io
    namespace: sbose2
    resource: deploymentconfigs
    resourceRef: nodejs-rest-http-crud
    version: v1
  backingServiceSelector:
    group: postgresql.baiju.dev
    kind: Database
    resourceRef: demo-database
    version: v1alpha1
  backingServiceSelectors: null
  detectBindingResources: true
status:
  applicationObjects:
    - sbose2/nodejs-rest-http-crud
  bindingStatus: Success
  secret: nodejs-rest-http-crud-dc-demo-database-postgresql-d
```