### PR TITLE
oc is not installed in the openshift-ci in our cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -455,14 +455,14 @@ push-bundle-to-quay:
 .PHONY: dev-release
 ## validating the operator by installing new quay releases
 dev-release:
-	$(Q)oc apply -f ./test/operator-hub/operator_source.yaml
+	$(Q)kubectl apply -f ./test/operator-hub/operator_source.yaml
 	# Subscribing to the operator
-	$(Q)oc apply -f ./test/operator-hub/subscription.yaml
-	while [ "$(oc get pods --field-selector=status.phase=Running -n openshift-marketplace" == "No resources found." ]
+	$(Q)kubectl apply -f ./test/operator-hub/subscription.yaml
+	while [ "$(kubectl get pods --field-selector=status.phase=Running -n openshift-marketplace" == "No resources found." ]
 	do
 		sleep 1s
 	done
-	$(eval VERSION_NUMBER := $(shell oc get csvs  -n=default -o jsonpath='{.items[*].spec.version}'))
+	$(eval VERSION_NUMBER := $(shell kubectl get csvs  -n=default -o jsonpath='{.items[*].spec.version}'))
 	@if [ ${VERSION_NUMBER} == ${BUNDLE_VERSION} ]; \
 	then \
     	echo -e "OLM Bundle Version validation succeeded \n " \


### PR DESCRIPTION
The oc cli is not installed under openshift-ci/Dockerfile.tools . Replace oc with kubectl
Follow up the cron job history here https://prow.svc.ci.openshift.org/job-history/origin-ci-test/logs/periodic-ci-redhat-developer-service-binding-operator-master-dev-release