### PR TITLE
added `createdAt`, `support`, `repository` annotations to improve UX on OperatorHub.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ BUNDLE_VERSION ?= $(OPERATOR_VERSION)-$(COMMIT_COUNT)
 BASE_BUNDLE_VERSION ?= 0.0.23
 OPERATOR_IMAGE_REF ?= $(OPERATOR_IMAGE_REL):$(GIT_COMMIT_ID)
 CSV_PACKAGE_NAME ?= $(GO_PACKAGE_REPO_NAME)
+CSV_CREATION_TIMESTAMP ?= $(shell date '+%FT%T%Z')
 
 QUAY_TOKEN ?= ""
 QUAY_BUNDLE_TOKEN ?= ""
@@ -432,6 +433,7 @@ push-to-manifest-repo:
 	cp -vrf $(OLM_CATALOG_DIR)/$(GO_PACKAGE_REPO_NAME)/*package.yaml $(MANIFESTS_TMP)/
 	cp -vrf $(CRDS_DIR)/*_crd.yaml $(MANIFESTS_TMP)/${BUNDLE_VERSION}/
 	sed -i -e 's,REPLACE_IMAGE,$(OPERATOR_IMAGE_REF),g' $(MANIFESTS_TMP)/${BUNDLE_VERSION}/*.clusterserviceversion.yaml
+	sed -i -e 's,CSV_CREATION_TIMESTAMP,$(CSV_CREATION_TIMESTAMP),g' $(MANIFESTS_TMP)/${BUNDLE_VERSION}/*.clusterserviceversion.yaml
 	awk -i inplace '!/^[[:space:]]+replaces:[[:space:]]+[[:graph:]]+/ { print $0 }' $(MANIFESTS_TMP)/${BUNDLE_VERSION}/*.clusterserviceversion.yaml
 	sed -i -e 's,BUNDLE_VERSION,$(BUNDLE_VERSION),g' $(MANIFESTS_TMP)/*.yaml
 	sed -i -e 's,PACKAGE_NAME,$(CSV_PACKAGE_NAME),g' $(MANIFESTS_TMP)/*.yaml

--- a/deploy/olm-catalog/service-binding-operator/0.0.23/service-binding-operator.v0.0.23.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-binding-operator/0.0.23/service-binding-operator.v0.0.23.clusterserviceversion.yaml
@@ -29,6 +29,9 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Developer Tools, OpenShift Optional, Integration & Delivery
+    createdAt: CSV_CREATION_TIMESTAMP
+    repository: https://github.com/redhat-developer/service-binding-operator
+    support: Red Hat, Inc
     containerImage: REPLACE_IMAGE
     description: An operator to support binding capabilities between imported apps and operator backed services
   name: service-binding-operator.v0.0.23
@@ -175,8 +178,8 @@ spec:
     type: AllNamespaces
   maturity: alpha
   links:
-    - name: Source Code
-      url: https://github.com/redhat-developer/service-binding-operator
+    - name: Blog post
+      url: https://developers.redhat.com/blog/2019/12/19/introducing-the-service-binding-operator
   maintainers:
     - email: shbose@redhat.com
       name: Shoubhik Bose


### PR DESCRIPTION
### Motivation

Improve rendering of the operator entry on OperatorHub.io

### Changes

added `createdAt`, `support`, `repository` annotations to improve UX on OperatorHub.io

In addition that, added link to the blog post.

The fields listed in in https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md
are mandatory for a good user experience/proper rendering of operator info at operatorhub.io


### Testing

`make push-to-manifest-repo` should generate CSV with additional fields