### PR TITLE
Update examples to use community version of the SBO.

### DIFF
--- a/examples/commons.mk
+++ b/examples/commons.mk
@@ -82,11 +82,6 @@ help: ## Credit: https://gist.github.com/prwhite/8168133#gistcomment-2749866
 
 ## --- Service Binding Operator ---
 
-.PHONY: install-service-binding-operator-source
-## Install the Service Binding Operator Source
-install-service-binding-operator-source:
-	${Q}${EC} install_service_binding_operator_source
-
 .PHONY: install-service-binding-operator-subscription
 ## Install the Service Binding Operator Subscription
 install-service-binding-operator-subscription:
@@ -94,12 +89,7 @@ install-service-binding-operator-subscription:
 
 .PHONY: install-service-binding-operator
 ## Install the Service Binding Operator
-install-service-binding-operator: install-service-binding-operator-source install-service-binding-operator-subscription
-
-.PHONY: uninstall-service-binding-operator-source
-## Uninstall the Service Binding Operator Source
-uninstall-service-binding-operator-source:
-	${Q}${EC} uninstall_service_binding_operator_source
+install-service-binding-operator: install-service-binding-operator-subscription
 
 .PHONY: uninstall-service-binding-operator-subscription
 ## Uninstall the Service Binding Operator Subscription
@@ -108,7 +98,7 @@ uninstall-service-binding-operator-subscription:
 
 .PHONY: uninstall-service-binding-operator
 ## Uninstall the Service Binding Operator
-uninstall-service-binding-operator: uninstall-service-binding-operator-subscription uninstall-service-binding-operator-source
+uninstall-service-binding-operator: uninstall-service-binding-operator-subscription
 
 ## --- Backing Service DB (PostgreSQL) Operator ---
 

--- a/examples/java_postgresql_customvar/README.md
+++ b/examples/java_postgresql_customvar/README.md
@@ -30,11 +30,17 @@ demonstrate a sample use case.
 
 #### Install the Service Binding Operator
 
-Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Other` category select the `Service Bidning Operator` operator
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Bidning Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 
-and install a `stable` version.
+and install a `alpha` version.
+
+Alternatively, you can perform the same task with this make command:
+
+``` shell
+make install-service-binding-operator
+```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
 

--- a/examples/java_postgresql_customvar/README.md
+++ b/examples/java_postgresql_customvar/README.md
@@ -30,7 +30,7 @@ demonstrate a sample use case.
 
 #### Install the Service Binding Operator
 
-Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Bidning Operator` operator
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Binding Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 

--- a/examples/knative_postgresql_customvar/README.md
+++ b/examples/knative_postgresql_customvar/README.md
@@ -32,11 +32,17 @@ demonstrate a sample use case.
 
 #### Install the Service Binding Operator
 
-Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Other` category select the `Service Binding Operator` operator
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Bidning Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 
-and install a `stable` version.
+and install a `alpha` version.
+
+Alternatively, you can perform the same task with this make command:
+
+``` shell
+make install-service-binding-operator
+```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
 
@@ -53,6 +59,7 @@ This makes the `Database` custom resource available, that the application develo
 Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Cloud Provider` category select the `OpenShift Serverless Operator` operator.
 
 Note that installing this operator will automatically install this set of operators:
+
 * Elasticsearch Operator
 * Jaeger Operator
 * Kiali Operator

--- a/examples/knative_postgresql_customvar/README.md
+++ b/examples/knative_postgresql_customvar/README.md
@@ -32,7 +32,7 @@ demonstrate a sample use case.
 
 #### Install the Service Binding Operator
 
-Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Bidning Operator` operator
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Binding Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 

--- a/examples/nodejs_awsrds_varprefix/README.md
+++ b/examples/nodejs_awsrds_varprefix/README.md
@@ -24,7 +24,7 @@ manage off-cluster RDS database instances on AWS.
 
 #### Install the Service Binding Operator
 
-Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Bidning Operator` operator
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Binding Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 

--- a/examples/nodejs_awsrds_varprefix/README.md
+++ b/examples/nodejs_awsrds_varprefix/README.md
@@ -22,15 +22,21 @@ The Backing Service Operator represents a database required by the
 applications. We'll use [aws-rds-operator](https://github.com/operator-backing-service-samples/aws-rds) to
 manage off-cluster RDS database instances on AWS.
 
-#### Install the Service Binding Operator using an `OperatorSource`
+#### Install the Service Binding Operator
 
-Navigate to the `Operators`->`OperatorHub` in the OpenShift console under the `openshift-marketplace` project and in the `Other` category select the `Service Bidning Operator` operator
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Bidning Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 
-and install a `stable` version.
+and install a `alpha` version.
 
-This makes the `ServiceBindingRequest` custom resource available, that we as the application developer will [use later](#bind-the-db-to-the-shell-application).
+Alternatively, you can perform the same task with this make command:
+
+``` shell
+make install-service-binding-operator
+```
+
+This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
 
 #### Install the DB operator using an `OperatorSource`
 
@@ -242,6 +248,7 @@ The Node.js application should be already up and running after we [imported it b
 Let's check by navigating to the application's route to verify that it is up. Notice that in the header it says `(DB: N/A)`. That means that the application is not connected to DB and so it should not work properly. Try the application's UI to add a fruit - it causes an error proving that the DB is not connected.
 
 Now we ask the Service Binding Operator to bind the DB to the Node.js application in the following step:
+
 * [Create `ServiceBindingRequest`](#create-servicebindingrequest-for-the-nodejs-application)
 
 #### Create `ServiceBindingRequest` for the Node.js application

--- a/examples/nodejs_postgresql/README.md
+++ b/examples/nodejs_postgresql/README.md
@@ -29,7 +29,7 @@ demonstrate a sample use case.
 
 #### Install the Service Binding Operator
 
-Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Bidning Operator` operator
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Binding Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 

--- a/examples/nodejs_postgresql/README.md
+++ b/examples/nodejs_postgresql/README.md
@@ -29,11 +29,17 @@ demonstrate a sample use case.
 
 #### Install the Service Binding Operator
 
-Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Other` category select the `Service Bidning Operator` operator
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Bidning Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 
-and install a `stable` version.
+and install a `alpha` version.
+
+Alternatively, you can perform the same task with this make command:
+
+``` shell
+make install-service-binding-operator
+```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
 
@@ -201,4 +207,3 @@ spec:
 | Secret | The name of the intermediate secret |
 
 That's it, folks!
-

--- a/hack/examples-commons.sh
+++ b/hack/examples-commons.sh
@@ -127,34 +127,18 @@ function uninstall_postgresql_db_instance {
 
 ## Service Binding Operator
 
-function install_service_binding_operator_source {
-    OPSRC_NAMESPACE=redhat-developer
-    OPSRC_NAME=redhat-developer-operators
-    PACKAGE_NAME=service-binding-operator
-
-    install_operator_source $OPSRC_NAMESPACE $OPSRC_NAME
-    wait_for_packagemanifest $PACKAGE_NAME
-}
-
-function uninstall_service_binding_operator_source {
-    OPSRC_NAMESPACE=redhat-developer
-    OPSRC_NAME=redhat-developer-operators
-
-    uninstall_operator_source $OPSRC_NAMESPACE $OPSRC_NAME
-}
-
 function install_service_binding_operator_subscription {
     NAME=service-binding-operator
-    OPSRC_NAME=redhat-developer-operators
-    CHANNEL=stable
+    OPSRC_NAME=community-operators
+    CHANNEL=alpha
 
     install_operator_subscription $NAME $OPSRC_NAME $CHANNEL
 }
 
 function uninstall_service_binding_operator_subscription {
     NAME=service-binding-operator
-    OPSRC_NAME=redhat-developer-operators
-    CHANNEL=stable
+    OPSRC_NAME=community-operators
+    CHANNEL=alpha
 
     uninstall_operator_subscription $NAME $OPSRC_NAME $CHANNEL
     uninstall_current_csv $NAME $CHANNEL


### PR DESCRIPTION
### Motivation

Previously, before service binding operator became part of the community operators there was a need to add it to the internal OperatorHub via an Operator Source. Now it is not necessary.

### Changes

* The use of Operator Source for installing of the Service Binding Operator is removed.
* The SBO's subscription is changed to the community version.

### Testing

Manually follow the examples' step-by-step instructions.


For further more details refer the CONTRIBUTING.md