### PR TITLE
Propagate Makefile failures to the travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ before_install:
 script:
   # Run merge-to-master-release
   - if [ "$TRAVIS_BRANCH" = "master" ]; then
-    make merge-to-master-release;
-    make push-to-manifest-repo;
-    make push-bundle-to-quay;
+    make merge-to-master-release && \
+    make push-to-manifest-repo && \
+    make push-bundle-to-quay || exit 1
     fi
 
 after_success:


### PR DESCRIPTION
### Motivation

The travis.ci passes even if any of the make commands fails - tha failures are thrown away.

### Changes

All the `make` commands under the `if`condition in the `.travis.yaml`'s `script` are executed in a way, which returns a non-zero exit code, in case any of those fails.

### Testing

For further more details refer the CONTRIBUTING.md