### PR TITLE
Fix .travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ before_install:
 script:
   # Run merge-to-master-release
   - if [ "$TRAVIS_BRANCH" = "master" ]; then
-    make merge-to-master-release && \
-    make push-to-manifest-repo && \
-    make push-bundle-to-quay || exit 1
+    make merge-to-master-release &&
+    make push-to-manifest-repo &&
+    make push-bundle-to-quay || exit 1;
     fi
 
 after_success:


### PR DESCRIPTION
### Motivation
Follow-up to #337 
The current travis script fails with the following:
```
$ if [ "$TRAVIS_BRANCH" = "master" ]; then make merge-to-master-release && \ make push-to-manifest-repo && \ make push-bundle-to-quay || exit 1 fi
/home/travis/.travis/functions: eval: line 110: syntax error: unexpected end of file
The command "if [ "$TRAVIS_BRANCH" = "master" ]; then make merge-to-master-release && \ make push-to-manifest-repo && \ make push-bundle-to-quay || exit 1 fi" exited with 1.
```

The  `\` symbols are removed and `;` is added at the end of the `then` block to fix the problem.

### Testing

For further more details refer the CONTRIBUTING.md