### PR TITLE
Support binding to a backing Service in a different namespace

### DIFF
--- a/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
+++ b/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
@@ -106,6 +106,8 @@ spec:
                   type: string
                 kind:
                   type: string
+                namespace:
+                  type: string
                 resourceRef:
                   type: string
                 version:
@@ -126,6 +128,8 @@ spec:
                   group:
                     type: string
                   kind:
+                    type: string
+                  namespace:
                     type: string
                   resourceRef:
                     type: string

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -62,6 +62,8 @@ type ServiceBindingRequestStatus struct {
 type BackingServiceSelector struct {
 	metav1.GroupVersionKind `json:",inline"`
 	ResourceRef             string `json:"resourceRef"`
+	// +optional
+	Namespace *string `json:"namespace,omitempty"`
 }
 
 // ApplicationSelector defines the selector based on labels and GVR

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -37,6 +37,11 @@ func (in *ApplicationSelector) DeepCopy() *ApplicationSelector {
 func (in *BackingServiceSelector) DeepCopyInto(out *BackingServiceSelector) {
 	*out = *in
 	out.GroupVersionKind = in.GroupVersionKind
+	if in.Namespace != nil {
+		in, out := &in.Namespace, &out.Namespace
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -121,11 +126,13 @@ func (in *ServiceBindingRequestSpec) DeepCopyInto(out *ServiceBindingRequestSpec
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.BackingServiceSelector = in.BackingServiceSelector
+	in.BackingServiceSelector.DeepCopyInto(&out.BackingServiceSelector)
 	if in.BackingServiceSelectors != nil {
 		in, out := &in.BackingServiceSelectors, &out.BackingServiceSelectors
 		*out = make([]BackingServiceSelector, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	in.ApplicationSelector.DeepCopyInto(&out.ApplicationSelector)
 	return

--- a/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
@@ -95,6 +95,12 @@ func schema_pkg_apis_apps_v1alpha1_BackingServiceSelector(ref common.ReferenceCa
 							Format: "",
 						},
 					},
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"group", "version", "kind", "resourceRef"},
 			},

--- a/pkg/controller/servicebindingrequest/bind_custom_resources.go
+++ b/pkg/controller/servicebindingrequest/bind_custom_resources.go
@@ -47,7 +47,7 @@ func NewDetectBindableResources(
 func (b DetectBindableResources) GetOwnedResources() ([]unstructured.Unstructured, error) {
 	var subResources []unstructured.Unstructured
 	for _, resource := range b.resourcesToCheck {
-		lst, err := b.client.Resource(resource).List(v1.ListOptions{})
+		lst, err := b.client.Resource(resource).Namespace(b.cr.GetNamespace()).List(v1.ListOptions{})
 		if err != nil {
 			return subResources, err
 		}

--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -38,7 +38,7 @@ func TestBinderNew(t *testing.T) {
 		"environment": "binder",
 	}
 	f := mocks.NewFake(t, ns)
-	sbr := f.AddMockedServiceBindingRequest(name, "ref", "", deploymentsGVR, matchLabels)
+	sbr := f.AddMockedServiceBindingRequest(name, nil, "ref", "", deploymentsGVR, matchLabels)
 	f.AddMockedUnstructuredDeployment("ref", matchLabels)
 
 	binder := NewBinder(
@@ -53,6 +53,7 @@ func TestBinderNew(t *testing.T) {
 
 	sbrWithResourceRef := f.AddMockedServiceBindingRequest(
 		"service-binding-request-with-ref",
+		nil,
 		"ref",
 		"ref",
 		deploymentsGVR,
@@ -184,7 +185,7 @@ func TestBinderApplicationName(t *testing.T) {
 	ns := "binder"
 	name := "service-binding-request"
 	f := mocks.NewFake(t, ns)
-	sbr := f.AddMockedServiceBindingRequest(name, "backingServiceResourceRef", "applicationResourceRef", deploymentsGVR, nil)
+	sbr := f.AddMockedServiceBindingRequest(name, nil, "backingServiceResourceRef", "applicationResourceRef", deploymentsGVR, nil)
 	f.AddMockedUnstructuredDeployment("ref", nil)
 
 	binder := NewBinder(
@@ -208,7 +209,7 @@ func TestBindingWithDeploymentConfig(t *testing.T) {
 	ns := "service-binding-demo-with-deploymentconfig"
 	name := "service-binding-request"
 	f := mocks.NewFake(t, ns)
-	sbr := f.AddMockedServiceBindingRequest(name, "backingServiceResourceRef", "applicationResourceRef", deploymentConfigsGVR, nil)
+	sbr := f.AddMockedServiceBindingRequest(name, nil, "backingServiceResourceRef", "applicationResourceRef", deploymentConfigsGVR, nil)
 	f.AddMockedUnstructuredDeploymentConfig("ref", nil)
 
 	binder := NewBinder(
@@ -240,7 +241,7 @@ func TestBindTwoApplications(t *testing.T) {
 		"environment": "binder",
 	}
 	f.AddMockedUnstructuredDeployment("applicationResourceRef1", matchLabels1)
-	sbr1 := f.AddMockedServiceBindingRequest(name1, "backingServiceResourceRef", "", deploymentsGVR, matchLabels1)
+	sbr1 := f.AddMockedServiceBindingRequest(name1, nil, "backingServiceResourceRef", "", deploymentsGVR, matchLabels1)
 	binder1 := NewBinder(
 		context.TODO(),
 		f.FakeClient(),
@@ -256,7 +257,7 @@ func TestBindTwoApplications(t *testing.T) {
 		"environment": "demo",
 	}
 	f.AddMockedUnstructuredDeployment("applicationResourceRef2", matchLabels2)
-	sbr2 := f.AddMockedServiceBindingRequest(name2, "backingServiceResourceRef", "", deploymentsGVR, matchLabels2)
+	sbr2 := f.AddMockedServiceBindingRequest(name2, nil, "backingServiceResourceRef", "", deploymentsGVR, matchLabels2)
 	binder2 := NewBinder(
 		context.TODO(),
 		f.FakeClient(),
@@ -287,7 +288,7 @@ func TestKnativeServicesContractWithBinder(t *testing.T) {
 
 	f := mocks.NewFake(t, ns)
 	gvr := knativev1.SchemeGroupVersion.WithResource("services") // Group/Version/Resource for sbr
-	sbr := f.AddMockedServiceBindingRequest(name, "", "knative-app", gvr, matchLabels)
+	sbr := f.AddMockedServiceBindingRequest(name, nil, "", "knative-app", gvr, matchLabels)
 	f.AddMockedUnstructuredKnativeService("knative-app", matchLabels)
 
 	binder := NewBinder(

--- a/pkg/controller/servicebindingrequest/planner.go
+++ b/pkg/controller/servicebindingrequest/planner.go
@@ -37,6 +37,11 @@ type Plan struct {
 
 // searchCR based on a CustomResourceDefinitionDescription and name, search for the object.
 func (p *Planner) searchCR(namespace string, selector v1alpha1.BackingServiceSelector) (*unstructured.Unstructured, error) {
+
+	if selector.Namespace != nil {
+		namespace = *selector.Namespace
+	}
+
 	// gvr is the plural guessed resource for the given selector
 	gvk := schema.GroupVersionKind{
 		Group:   selector.Group,
@@ -81,6 +86,7 @@ func (p *Planner) Plan() (*Plan, error) {
 
 	relatedResources := make([]*RelatedResource, 0)
 	for _, s := range selectors {
+
 		bssGVK := schema.GroupVersionKind{Kind: s.Kind, Version: s.Version, Group: s.Group}
 
 		// resolve the CRD using the service's GVK

--- a/pkg/controller/servicebindingrequest/planner.go
+++ b/pkg/controller/servicebindingrequest/planner.go
@@ -15,7 +15,8 @@ import (
 )
 
 var (
-	plannerLog = log.NewLog("planner")
+	plannerLog                 = log.NewLog("planner")
+	errBackingServiceNamespace = errors.New("backing Service Namespace is unspecified")
 )
 
 // Planner plans resources needed to bind a given backend service, using OperatorLifecycleManager
@@ -46,7 +47,7 @@ func (p *Planner) searchCR(selector v1alpha1.BackingServiceSelector) (*unstructu
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 
 	if selector.Namespace == nil {
-		return nil, errors.New("selector namespace is empty")
+		return nil, errBackingServiceNamespace
 	}
 
 	// delegate the search selector's namespaced resource client

--- a/pkg/controller/servicebindingrequest/planner_test.go
+++ b/pkg/controller/servicebindingrequest/planner_test.go
@@ -17,7 +17,7 @@ func init() {
 	logf.SetLogger(logf.ZapLogger(true))
 }
 
-func TestPlannerNew(t *testing.T) {
+func TestPlanner(t *testing.T) {
 	ns := "planner"
 	name := "service-binding-request"
 	resourceRef := "db-testing"
@@ -26,24 +26,27 @@ func TestPlannerNew(t *testing.T) {
 		"environment": "planner",
 	}
 	f := mocks.NewFake(t, ns)
-	sbr := f.AddMockedServiceBindingRequest(name, resourceRef, "", deploymentsGVR, matchLabels)
+	sbr := f.AddMockedServiceBindingRequest(name, nil, resourceRef, "", deploymentsGVR, matchLabels)
 	sbr.Spec.BackingServiceSelectors = []v1alpha1.BackingServiceSelector{
 		sbr.Spec.BackingServiceSelector,
 	}
 	f.AddMockedUnstructuredCSV("cluster-service-version")
-	f.AddMockedDatabaseCR(resourceRef)
+	f.AddMockedDatabaseCR(resourceRef, ns)
 	f.AddMockedUnstructuredDatabaseCRD()
 
 	planner = NewPlanner(context.TODO(), f.FakeDynClient(), sbr)
 	require.NotNil(t, planner)
 
-	t.Run("searchCR", func(t *testing.T) {
-		cr, err := planner.searchCR(ns, sbr.Spec.BackingServiceSelector)
-
-		require.NoError(t, err)
-		require.NotNil(t, cr)
+	// Out of the box, our mocks don't set the namespace
+	// ensure SearchCR fails.
+	t.Run("search CR with namespace not set", func(t *testing.T) {
+		cr, err := planner.searchCR(sbr.Spec.BackingServiceSelector)
+		require.Error(t, err)
+		require.Nil(t, cr)
 	})
 
+	// Plan should pass because namespaces in the
+	// selector are set if missing.
 	t.Run("plan", func(t *testing.T) {
 		plan, err := planner.Plan()
 
@@ -52,12 +55,21 @@ func TestPlannerNew(t *testing.T) {
 		require.NotEmpty(t, plan.RelatedResources)
 		require.Equal(t, ns, plan.Ns)
 		require.Equal(t, name, plan.Name)
+	})
+
+	// The searchCR contract only cares about the backingServiceNamespace
+	sbr.Spec.BackingServiceSelector.Namespace = &ns
+	t.Run("searchCR", func(t *testing.T) {
+		cr, err := planner.searchCR(sbr.Spec.BackingServiceSelector)
+		require.NoError(t, err)
+		require.NotNil(t, cr)
 	})
 }
 
-func TestPlannerNewWithMultipleNamespaces(t *testing.T) {
+func TestPlannerWithExplicitBackingServiceNamespace(t *testing.T) {
+
 	ns := "planner"
-	backingServiceNs := "planner-backing-service-ns"
+	backingServiceNamespace := "backing-service-namespace"
 	name := "service-binding-request"
 	resourceRef := "db-testing"
 	matchLabels := map[string]string{
@@ -65,32 +77,33 @@ func TestPlannerNewWithMultipleNamespaces(t *testing.T) {
 		"environment": "planner",
 	}
 	f := mocks.NewFake(t, ns)
-	sbr := f.AddMockedServiceBindingRequestWithMultiNamespaces(name, resourceRef, backingServiceNs, "", deploymentsGVR, matchLabels)
-	sbr.Spec.BackingServiceSelectors = []v1alpha1.BackingServiceSelector{
-		sbr.Spec.BackingServiceSelector,
-	}
+	sbr := f.AddMockedServiceBindingRequest(name, &backingServiceNamespace, resourceRef, "", deploymentsGVR, matchLabels)
+	require.NotNil(t, sbr.Spec.BackingServiceSelector.Namespace)
+
 	f.AddMockedUnstructuredCSV("cluster-service-version")
-	f.AddCrossNamespaceMockedDatabaseCR(resourceRef, backingServiceNs)
+	f.AddMockedDatabaseCR(resourceRef, backingServiceNamespace)
 	f.AddMockedUnstructuredDatabaseCRD()
 
 	planner = NewPlanner(context.TODO(), f.FakeDynClient(), sbr)
 	require.NotNil(t, planner)
 
 	t.Run("searchCR", func(t *testing.T) {
-		cr, err := planner.searchCR(ns, sbr.Spec.BackingServiceSelector)
-
+		cr, err := planner.searchCR(sbr.Spec.BackingServiceSelector)
 		require.NoError(t, err)
 		require.NotNil(t, cr)
 	})
 
-	t.Run("plan", func(t *testing.T) {
+	t.Run("plan : backing service in different namespace", func(t *testing.T) {
 		plan, err := planner.Plan()
 
 		require.NoError(t, err)
 		require.NotNil(t, plan)
 		require.NotEmpty(t, plan.RelatedResources)
+		require.NotEmpty(t, plan.RelatedResources.GetCRs())
+		require.Equal(t, backingServiceNamespace, plan.RelatedResources.GetCRs()[0].GetNamespace())
 		require.Equal(t, ns, plan.Ns)
 		require.Equal(t, name, plan.Name)
+
 	})
 }
 
@@ -103,9 +116,9 @@ func TestPlannerAnnotation(t *testing.T) {
 		"environment": "planner",
 	}
 	f := mocks.NewFake(t, ns)
-	sbr := f.AddMockedServiceBindingRequest(name, resourceRef, "", deploymentsGVR, matchLabels)
+	sbr := f.AddMockedServiceBindingRequest(name, nil, resourceRef, "", deploymentsGVR, matchLabels)
 	f.AddMockedUnstructuredDatabaseCRD()
-	cr := f.AddMockedDatabaseCR("database")
+	cr := f.AddMockedDatabaseCR("database", ns)
 
 	planner = NewPlanner(context.TODO(), f.FakeDynClient(), sbr)
 	require.NotNil(t, planner)

--- a/pkg/controller/servicebindingrequest/planner_test.go
+++ b/pkg/controller/servicebindingrequest/planner_test.go
@@ -55,6 +55,45 @@ func TestPlannerNew(t *testing.T) {
 	})
 }
 
+func TestPlannerNewWithMultipleNamespaces(t *testing.T) {
+	ns := "planner"
+	backingServiceNs := "planner-backing-service-ns"
+	name := "service-binding-request"
+	resourceRef := "db-testing"
+	matchLabels := map[string]string{
+		"connects-to": "database",
+		"environment": "planner",
+	}
+	f := mocks.NewFake(t, ns)
+	sbr := f.AddMockedServiceBindingRequestWithMultiNamespaces(name, resourceRef, backingServiceNs, "", deploymentsGVR, matchLabels)
+	sbr.Spec.BackingServiceSelectors = []v1alpha1.BackingServiceSelector{
+		sbr.Spec.BackingServiceSelector,
+	}
+	f.AddMockedUnstructuredCSV("cluster-service-version")
+	f.AddCrossNamespaceMockedDatabaseCR(resourceRef, backingServiceNs)
+	f.AddMockedUnstructuredDatabaseCRD()
+
+	planner = NewPlanner(context.TODO(), f.FakeDynClient(), sbr)
+	require.NotNil(t, planner)
+
+	t.Run("searchCR", func(t *testing.T) {
+		cr, err := planner.searchCR(ns, sbr.Spec.BackingServiceSelector)
+
+		require.NoError(t, err)
+		require.NotNil(t, cr)
+	})
+
+	t.Run("plan", func(t *testing.T) {
+		plan, err := planner.Plan()
+
+		require.NoError(t, err)
+		require.NotNil(t, plan)
+		require.NotEmpty(t, plan.RelatedResources)
+		require.Equal(t, ns, plan.Ns)
+		require.Equal(t, name, plan.Name)
+	})
+}
+
 func TestPlannerAnnotation(t *testing.T) {
 	ns := "planner"
 	name := "service-binding-request"

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -172,7 +172,7 @@ func (r *Retriever) readSecret(cr *unstructured.Unstructured, name string, items
 	log.Debug("Reading secret items...")
 
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
-	secret, err := r.client.Resource(gvr).Namespace(r.plan.Ns).Get(name, metav1.GetOptions{})
+	secret, err := r.client.Resource(gvr).Namespace(cr.GetNamespace()).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (r *Retriever) readConfigMap(cr *unstructured.Unstructured, name string, it
 	log.Debug("Reading ConfigMap items...")
 
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
-	u, err := r.client.Resource(gvr).Namespace(r.plan.Ns).Get(name, metav1.GetOptions{})
+	u, err := r.client.Resource(gvr).Namespace(cr.GetNamespace()).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -254,37 +254,6 @@ func (r *Retriever) store(u *unstructured.Unstructured, key string, value []byte
 	}
 	key = strings.ToUpper(key)
 	r.data[key] = value
-}
-
-// Retrieve loop and read data pointed by the references in plan instance. Also runs through
-// "bindable resources", gathering extra data. It can return error on retrieving and reading
-// resources.
-func (r *Retriever) Retrieve() (map[string][]byte, error) {
-	// read bindable data from the specified resources
-	if r.plan.SBR.Spec.DetectBindingResources {
-		err := r.ReadBindableResourcesData(&r.plan.SBR, r.plan.GetCRs())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// read bindable data from the CRDDescription found by the planner
-	for _, relatedResource := range r.plan.GetRelatedResources() {
-
-		err := r.ReadCRDDescriptionData(relatedResource.CR, relatedResource.CRDDescription)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// gather retriever's read data
-	var err error
-	retrievedData, err := r.Get()
-	if err != nil {
-		return nil, err
-	}
-
-	return retrievedData, nil
 }
 
 // NewRetriever instantiate a new retriever instance.

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -256,37 +256,6 @@ func (r *Retriever) store(u *unstructured.Unstructured, key string, value []byte
 	r.data[key] = value
 }
 
-// Retrieve loop and read data pointed by the references in plan instance. Also runs through
-// "bindable resources", gathering extra data. It can return error on retrieving and reading
-// resources.
-func (r *Retriever) Retrieve() (map[string][]byte, error) {
-	// read bindable data from the specified resources
-	if r.plan.SBR.Spec.DetectBindingResources {
-		err := r.ReadBindableResourcesData(&r.plan.SBR, r.plan.GetCRs())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// read bindable data from the CRDDescription found by the planner
-	for _, relatedResource := range r.plan.GetRelatedResources() {
-
-		err := r.ReadCRDDescriptionData(relatedResource.CR, relatedResource.CRDDescription)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// gather retriever's read data
-	var err error
-	retrievedData, err := r.Get()
-	if err != nil {
-		return nil, err
-	}
-
-	return retrievedData, nil
-}
-
 // NewRetriever instantiate a new retriever instance.
 func NewRetriever(client dynamic.Interface, plan *Plan, bindingPrefix string) *Retriever {
 	return &Retriever{

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -195,14 +195,6 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
 
-	t.Run("retrieve", func(t *testing.T) {
-		_ = retriever.ReadCRDDescriptionData(cr, &crdDescription)
-		objs, err := retriever.Retrieve()
-		require.NoError(t, err)
-		require.NotEmpty(t, retriever.data)
-		require.True(t, len(objs) > 0)
-	})
-
 	t.Run("read", func(t *testing.T) {
 		// reading from configMap, from status attribute
 		err = retriever.read(cr, "spec", "dbConfigMap", []string{

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -14,14 +14,18 @@ func TestRetriever(t *testing.T) {
 	var retriever *Retriever
 
 	ns := "testing"
+	backingServiceNs := "backing-servicec-ns"
 	crName := "db-testing"
 
 	f := mocks.NewFake(t, ns)
 	f.AddMockedUnstructuredCSV("csv")
-	f.AddMockedSecret("db-credentials")
+	f.AddNamespacedMockedSecret("db-credentials", backingServiceNs)
 
 	crdDescription := mocks.CRDDescriptionMock()
-	cr, err := mocks.UnstructuredDatabaseCRMock(ns, crName)
+	cr, err := mocks.UnstructuredDatabaseCRMock(backingServiceNs, crName)
+	require.NoError(t, err)
+
+	crInSameNamespace, err := mocks.UnstructuredDatabaseCRMock(ns, crName)
 	require.NoError(t, err)
 
 	plan := &Plan{
@@ -31,6 +35,10 @@ func TestRetriever(t *testing.T) {
 			{
 				CRDDescription: &crdDescription,
 				CR:             cr,
+			},
+			{
+				CRDDescription: &crdDescription,
+				CR:             crInSameNamespace,
 			},
 		},
 	}

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
@@ -15,17 +16,21 @@ func TestRetriever(t *testing.T) {
 
 	ns := "testing"
 	backingServiceNs := "backing-servicec-ns"
+
 	crName := "db-testing"
+	crNameDifferentNamespace := "db-credentials-different-ns"
 
 	f := mocks.NewFake(t, ns)
 	f.AddMockedUnstructuredCSV("csv")
-	f.AddNamespacedMockedSecret("db-credentials", backingServiceNs)
+
+	f.AddNamespacedMockedSecret("db-credentials-different-ns", backingServiceNs)
+	f.AddNamespacedMockedSecret("db-credentials", ns)
 
 	crdDescription := mocks.CRDDescriptionMock()
 	cr, err := mocks.UnstructuredDatabaseCRMock(backingServiceNs, crName)
 	require.NoError(t, err)
 
-	crInSameNamespace, err := mocks.UnstructuredDatabaseCRMock(ns, crName)
+	crInSameNamespace, err := mocks.UnstructuredDatabaseCRMock(ns, crNameDifferentNamespace)
 	require.NoError(t, err)
 
 	plan := &Plan{
@@ -47,6 +52,14 @@ func TestRetriever(t *testing.T) {
 
 	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
+
+	t.Run("retrieve", func(t *testing.T) {
+		_ = retriever.ReadCRDDescriptionData(cr, &crdDescription)
+		objs, err := retriever.Retrieve()
+		require.NoError(t, err)
+		require.NotEmpty(t, retriever.data)
+		require.True(t, len(objs) > 0)
+	})
 
 	t.Run("getCRKey", func(t *testing.T) {
 		imageName, _, err := retriever.getCRKey(cr, "spec", "imageName")
@@ -172,7 +185,7 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 	f := mocks.NewFake(t, ns)
 	f.AddMockedUnstructuredCSV("csv")
 	f.AddMockedUnstructuredConfigMap(crName)
-	f.AddMockedDatabaseCR(crName)
+	f.AddMockedDatabaseCR(crName, ns)
 
 	crdDescription := mocks.CRDDescriptionConfigMapMock()
 
@@ -254,4 +267,31 @@ func TestCustomEnvParser(t *testing.T) {
 
 	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
+
+	t.Run("Should detect custom env values", func(t *testing.T) {
+		_ = retriever.ReadCRDDescriptionData(cr, &crdDescription)
+		_, err = retriever.Retrieve()
+		require.NoError(t, err)
+
+		t.Logf("\nCache %+v", retriever.cache)
+
+		envMap := []corev1.EnvVar{
+			{
+				Name:  "JDBC_CONNECTION_STRING",
+				Value: `{{ .spec.imageName }}@{{ .status.dbCredentials.password }}`,
+			},
+			{
+				Name:  "ANOTHER_STRING",
+				Value: `{{ .status.dbCredentials.user }}_{{ .status.dbCredentials.password }}`,
+			},
+		}
+
+		c := NewCustomEnvParser(envMap, retriever.cache)
+		values, err := c.Parse()
+		if err != nil {
+			t.Error(err)
+		}
+		require.Equal(t, "user_password", values["ANOTHER_STRING"], "Custom env values are not matching")
+		require.Equal(t, "postgres@password", values["JDBC_CONNECTION_STRING"], "Custom env values are not matching")
+	})
 }

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
@@ -40,14 +39,6 @@ func TestRetriever(t *testing.T) {
 
 	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
-
-	t.Run("retrieve", func(t *testing.T) {
-		_ = retriever.ReadCRDDescriptionData(cr, &crdDescription)
-		objs, err := retriever.Retrieve()
-		require.NoError(t, err)
-		require.NotEmpty(t, retriever.data)
-		require.True(t, len(objs) > 0)
-	})
 
 	t.Run("getCRKey", func(t *testing.T) {
 		imageName, _, err := retriever.getCRKey(cr, "spec", "imageName")
@@ -255,31 +246,4 @@ func TestCustomEnvParser(t *testing.T) {
 
 	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
 	require.NotNil(t, retriever)
-
-	t.Run("Should detect custom env values", func(t *testing.T) {
-		_ = retriever.ReadCRDDescriptionData(cr, &crdDescription)
-		_, err = retriever.Retrieve()
-		require.NoError(t, err)
-
-		t.Logf("\nCache %+v", retriever.cache)
-
-		envMap := []corev1.EnvVar{
-			{
-				Name:  "JDBC_CONNECTION_STRING",
-				Value: `{{ .spec.imageName }}@{{ .status.dbCredentials.password }}`,
-			},
-			{
-				Name:  "ANOTHER_STRING",
-				Value: `{{ .status.dbCredentials.user }}_{{ .status.dbCredentials.password }}`,
-			},
-		}
-
-		c := NewCustomEnvParser(envMap, retriever.cache)
-		values, err := c.Parse()
-		if err != nil {
-			t.Error(err)
-		}
-		require.Equal(t, "user_password", values["ANOTHER_STRING"], "Custom env values are not matching")
-		require.Equal(t, "postgres@password", values["JDBC_CONNECTION_STRING"], "Custom env values are not matching")
-	})
 }

--- a/pkg/controller/servicebindingrequest/secret_test.go
+++ b/pkg/controller/servicebindingrequest/secret_test.go
@@ -21,7 +21,7 @@ func TestSecretNew(t *testing.T) {
 	f := mocks.NewFake(t, ns)
 
 	matchLabels := map[string]string{}
-	sbr := mocks.ServiceBindingRequestMock(ns, name, "", "", deploymentsGVR, matchLabels)
+	sbr := mocks.ServiceBindingRequestMock(ns, name, nil, "", "", deploymentsGVR, matchLabels)
 
 	plan := &Plan{
 		Ns:   ns,

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -358,7 +358,7 @@ func CreateSBR(
 ) *v1alpha1.ServiceBindingRequest {
 	t.Logf("Creating ServiceBindingRequest mock object '%#v'...", namespacedName)
 	sbr := mocks.ServiceBindingRequestMock(
-		namespacedName.Namespace, namespacedName.Name, resourceRef, "", applicationGVR, matchLabels)
+		namespacedName.Namespace, namespacedName.Name, nil, resourceRef, "", applicationGVR, matchLabels)
 
 	// This function call explicitly modifies default SBR created by
 	// the mock

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -34,28 +34,14 @@ type Fake struct {
 // AddMockedServiceBindingRequest add mocked object from ServiceBindingRequestMock.
 func (f *Fake) AddMockedServiceBindingRequest(
 	name string,
+	backingServiceNamespace *string,
 	backingServiceResourceRef string,
 	applicationResourceRef string,
 	applicationGVR schema.GroupVersionResource,
 	matchLabels map[string]string,
 ) *v1alpha1.ServiceBindingRequest {
 	f.S.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.ServiceBindingRequest{})
-	sbr := ServiceBindingRequestMock(f.ns, name, backingServiceResourceRef, applicationResourceRef, applicationGVR, matchLabels)
-	f.objs = append(f.objs, sbr)
-	return sbr
-}
-
-// AddMockedServiceBindingRequestWithMultiNamespaces add mocked object from ServiceBindingRequestMock.
-func (f *Fake) AddMockedServiceBindingRequestWithMultiNamespaces(
-	name string,
-	backingServiceResourceRef string,
-	backingServiceNamespace string,
-	applicationResourceRef string,
-	applicationGVR schema.GroupVersionResource,
-	matchLabels map[string]string,
-) *v1alpha1.ServiceBindingRequest {
-	f.S.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.ServiceBindingRequest{})
-	sbr := MultiNamespaceServiceBindingRequestMock(f.ns, name, backingServiceResourceRef, backingServiceNamespace, applicationResourceRef, applicationGVR, matchLabels)
+	sbr := ServiceBindingRequestMock(f.ns, name, backingServiceNamespace, backingServiceResourceRef, applicationResourceRef, applicationGVR, matchLabels)
 	f.objs = append(f.objs, sbr)
 	return sbr
 }
@@ -69,11 +55,12 @@ func (f *Fake) AddMockedServiceBindingRequestWithUnannotated(
 	matchLabels map[string]string,
 ) *v1alpha1.ServiceBindingRequest {
 	f.S.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.ServiceBindingRequest{})
-	sbr := ServiceBindingRequestMock(f.ns, name, backingServiceResourceRef, applicationResourceRef, applicationGVR, matchLabels)
+	sbr := ServiceBindingRequestMock(f.ns, name, nil, backingServiceResourceRef, applicationResourceRef, applicationGVR, matchLabels)
 	f.objs = append(f.objs, sbr)
 	return sbr
 }
 
+// AddMockedUnstructuredServiceBindingRequest creates a mock ServiceBindingRequest object
 func (f *Fake) AddMockedUnstructuredServiceBindingRequest(
 	name string,
 	backingServiceResourceRef string,
@@ -122,16 +109,7 @@ func (f *Fake) AddMockedUnstructuredCSVWithVolumeMount(name string) {
 }
 
 // AddMockedDatabaseCR add mocked object from DatabaseCRMock.
-func (f *Fake) AddMockedDatabaseCR(ref string) runtime.Object {
-	require.NoError(f.t, pgapis.AddToScheme(f.S))
-	f.S.AddKnownTypes(pgv1alpha1.SchemeGroupVersion, &pgv1alpha1.Database{})
-	mock := DatabaseCRMock(f.ns, ref)
-	f.objs = append(f.objs, mock)
-	return mock
-}
-
-// AddCrossNamespaceMockedDatabaseCR add mocked object from DatabaseCRMock.
-func (f *Fake) AddCrossNamespaceMockedDatabaseCR(ref string, namespace string) runtime.Object {
+func (f *Fake) AddMockedDatabaseCR(ref string, namespace string) runtime.Object {
 	require.NoError(f.t, pgapis.AddToScheme(f.S))
 	f.S.AddKnownTypes(pgv1alpha1.SchemeGroupVersion, &pgv1alpha1.Database{})
 	mock := DatabaseCRMock(namespace, ref)

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -45,6 +45,21 @@ func (f *Fake) AddMockedServiceBindingRequest(
 	return sbr
 }
 
+// AddMockedServiceBindingRequestWithMultiNamespaces add mocked object from ServiceBindingRequestMock.
+func (f *Fake) AddMockedServiceBindingRequestWithMultiNamespaces(
+	name string,
+	backingServiceResourceRef string,
+	backingServiceNamespace string,
+	applicationResourceRef string,
+	applicationGVR schema.GroupVersionResource,
+	matchLabels map[string]string,
+) *v1alpha1.ServiceBindingRequest {
+	f.S.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.ServiceBindingRequest{})
+	sbr := MultiNamespaceServiceBindingRequestMock(f.ns, name, backingServiceResourceRef, backingServiceNamespace, applicationResourceRef, applicationGVR, matchLabels)
+	f.objs = append(f.objs, sbr)
+	return sbr
+}
+
 // AddMockedServiceBindingRequestWithUnannotated add mocked object from ServiceBindingRequestMock with DetectBindingResources.
 func (f *Fake) AddMockedServiceBindingRequestWithUnannotated(
 	name string,
@@ -115,6 +130,15 @@ func (f *Fake) AddMockedDatabaseCR(ref string) runtime.Object {
 	return mock
 }
 
+// AddCrossNamespaceMockedDatabaseCR add mocked object from DatabaseCRMock.
+func (f *Fake) AddCrossNamespaceMockedDatabaseCR(ref string, namespace string) runtime.Object {
+	require.NoError(f.t, pgapis.AddToScheme(f.S))
+	f.S.AddKnownTypes(pgv1alpha1.SchemeGroupVersion, &pgv1alpha1.Database{})
+	mock := DatabaseCRMock(namespace, ref)
+	f.objs = append(f.objs, mock)
+	return mock
+}
+
 func (f *Fake) AddMockedUnstructuredDatabaseCR(ref string) {
 	require.NoError(f.t, pgapis.AddToScheme(f.S))
 	d, err := UnstructuredDatabaseCRMock(f.ns, ref)
@@ -169,6 +193,12 @@ func (f *Fake) AddMockedUnstructuredPostgresDatabaseCR(ref string) *unstructured
 // AddMockedSecret add mocked object from SecretMock.
 func (f *Fake) AddMockedSecret(name string) {
 	f.objs = append(f.objs, SecretMock(f.ns, name))
+}
+
+// AddNamespacedMockedSecret add mocked object from SecretMock in a namespace
+// which isn't necessarily same as that of the ServiceBindingRequest namespace.
+func (f *Fake) AddNamespacedMockedSecret(name string, namespace string) {
+	f.objs = append(f.objs, SecretMock(namespace, name))
 }
 
 // AddMockedUnstructuredConfigMap add mocked object from ConfigMapMock.

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -430,6 +430,7 @@ func MultiNamespaceServiceBindingRequestMock(
 func ServiceBindingRequestMock(
 	ns string,
 	name string,
+	backingServiceNamespace *string,
 	backingServiceResourceRef string,
 	applicationResourceRef string,
 	applicationGVR schema.GroupVersionResource,
@@ -457,6 +458,7 @@ func ServiceBindingRequestMock(
 			BackingServiceSelector: v1alpha1.BackingServiceSelector{
 				GroupVersionKind: metav1.GroupVersionKind{Group: CRDName, Version: CRDVersion, Kind: CRDKind},
 				ResourceRef:      backingServiceResourceRef,
+				Namespace:        backingServiceNamespace,
 			},
 		},
 	}
@@ -472,7 +474,7 @@ func UnstructuredServiceBindingRequestMock(
 	applicationGVR schema.GroupVersionResource,
 	matchLabels map[string]string,
 ) (*unstructured.Unstructured, error) {
-	sbr := ServiceBindingRequestMock(ns, name, backingServiceResourceRef, applicationResourceRef, applicationGVR, matchLabels)
+	sbr := ServiceBindingRequestMock(ns, name, nil, backingServiceResourceRef, applicationResourceRef, applicationGVR, matchLabels)
 	return converter.ToUnstructuredAsGVK(&sbr, v1alpha1.SchemeGroupVersion.WithKind(OperatorKind))
 }
 

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -387,6 +387,45 @@ func ConfigMapMock(ns, name string) *corev1.ConfigMap {
 	}
 }
 
+// MultiNamespaceServiceBindingRequestMock return a binding-request mock of informed name and match labels.
+func MultiNamespaceServiceBindingRequestMock(
+	ns string,
+	name string,
+	backingServiceResourceRef string,
+	backingServiceNamespace string,
+	applicationResourceRef string,
+	applicationGVR schema.GroupVersionResource,
+	matchLabels map[string]string,
+) *v1alpha1.ServiceBindingRequest {
+	sbr := &v1alpha1.ServiceBindingRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Spec: v1alpha1.ServiceBindingRequestSpec{
+			MountPathPrefix: "/var/redhat",
+			CustomEnvVar: []corev1.EnvVar{
+				{
+					Name:  "IMAGE_PATH",
+					Value: "spec.imagePath",
+				},
+			},
+			ApplicationSelector: v1alpha1.ApplicationSelector{
+				GroupVersionResource: metav1.GroupVersionResource{Group: applicationGVR.Group, Version: applicationGVR.Version, Resource: applicationGVR.Resource},
+				ResourceRef:          applicationResourceRef,
+				LabelSelector:        &metav1.LabelSelector{MatchLabels: matchLabels},
+			},
+			DetectBindingResources: false,
+			BackingServiceSelector: v1alpha1.BackingServiceSelector{
+				GroupVersionKind: metav1.GroupVersionKind{Group: CRDName, Version: CRDVersion, Kind: CRDKind},
+				ResourceRef:      backingServiceResourceRef,
+				Namespace:        &backingServiceNamespace,
+			},
+		},
+	}
+	return sbr
+}
+
 // ServiceBindingRequestMock return a binding-request mock of informed name and match labels.
 func ServiceBindingRequestMock(
 	ns string,


### PR DESCRIPTION
fixes #314 

1. Create a new nodejs app in namespace `sbose`

2. Create a new Database in namespace `sbose-x`

3. Create a ServiceBindingRequest

```
kind: ServiceBindingRequest
metadata:
  name: nodejs-rest-http-crud-dc-demo-database-postgresql-d
  namespace: sbose
spec:
  applicationSelector:
    group: apps.openshift.io
    resource: deploymentconfigs
    resourceRef: nodejs-rest-http-crud
    version: v1
  backingServiceSelector:
    group: postgresql.baiju.dev
    kind: Database
    namespace: sbose-x
    resourceRef: demo-database
    version: v1alpha1
  detectBindingResources: true
status:
  applicationObjects:
  - sbose/nodejs-rest-http-crud
  bindingStatus: BindingSuccess
  conditions:
  - lastHeartbeatTime: 2020-02-20T21:52:51Z
    lastTransitionTime: 2020-02-20T21:47:30Z
    status: "True"
    type: Ready
  secret: nodejs-rest-http-crud-dc-demo-database-postgresql-d
```


Observations: 
- CRUD works!
- Backing Service CR gets annotated properly

```
apiVersion: postgresql.baiju.dev/v1alpha1
kind: Database
metadata:
  annotations:
    service-binding-operator.apps.openshift.io/binding-name: nodejs-rest-http-crud-dc-demo-database-postgresql-d
    service-binding-operator.apps.openshift.io/binding-namespace: sbose
  creationTimestamp: 2020-02-20T21:48:36Z
  generation: 1
  name: demo-database
  namespace: sbose-x
  resourceVersion: "385150"
  selfLink: /apis/postgresql.baiju.dev/v1alpha1/namespaces/sbose-x/databases/demo-database
  uid: e7827629-7ffc-41ea-a99c-82e25c81f46f
spec:
  dbName: postgres
  image: docker.io/postgres
  imageName: postgres
status:
  dbConfigMap: demo-database
  dbConnectionIP: 172.30.159.95
  dbConnectionPort: 5432
  dbCredentials: demo-database-postgresql
  dbName: postgres
```