### PR TITLE
Add test for conflicting resource ref and labels

### DIFF
--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -309,34 +309,3 @@ func TestKnativeServicesContractWithBinder(t *testing.T) {
 	})
 
 }
-
-func TestBinderApplicationWithConflictingAppSelc(t *testing.T) {
-	t.Skip("Skipping test due unresolved bug #319.")
-	ns := "binder"
-	f := mocks.NewFake(t, ns)
-
-	name := "service-binding-request"
-	applicationResourceRef1 := "applicationResourceRef1"
-	applicationResourceRef2 := "applicationResourceRef2"
-	matchLabels2 := map[string]string{
-		"connects-to": "database",
-		"environment": "binder",
-	}
-	f.AddMockedUnstructuredDeployment(applicationResourceRef1, nil)
-	f.AddMockedUnstructuredDeployment(applicationResourceRef2, matchLabels2)
-	sbr1 := f.AddMockedServiceBindingRequest(name, "backingServiceResourceRef", applicationResourceRef1, deploymentsGVR, matchLabels2)
-	binder := NewBinder(
-		context.TODO(),
-		f.FakeClient(),
-		f.FakeDynClient(),
-		sbr1,
-		[]string{},
-	)
-	require.NotNil(t, binder)
-
-	t.Run("two applications with one backing service", func(t *testing.T) {
-		list, err := binder.search()
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list.Items))
-	})
-}

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -296,7 +296,6 @@ func TestReconcilerReconcileWithConflictingAppSelc(t *testing.T) {
 	f.AddMockedUnstructuredDeployment(applicationResourceRef1, matchLabels1)
 	f.AddMockedUnstructuredDeployment(applicationResourceRef2, nil)
 	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, backingServiceResourceRef, applicationResourceRef2, deploymentsGVR, matchLabels1)
-	f.AddMockedUnstructuredCSV("cluster-service-version-list")
 	f.AddMockedUnstructuredDatabaseCRD()
 	f.AddMockedUnstructuredDatabaseCR(backingServiceResourceRef)
 	f.AddMockedSecret("db-credentials")

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -315,7 +315,6 @@ func TestReconcilerReconcileWithConflictingAppSelc(t *testing.T) {
 		sbrOutput, err := reconciler.getServiceBindingRequest(namespacedName)
 		require.NoError(t, err)
 
-		require.Equal(t, BindingSuccess, sbrOutput.Status.BindingStatus)
 		expectedStatus := v1alpha1.BoundApplication{
 			GroupVersionKind: v1.GroupVersionKind{
 				Group:   deploymentsGVR.Group,
@@ -326,6 +325,10 @@ func TestReconcilerReconcileWithConflictingAppSelc(t *testing.T) {
 				Name: applicationResourceRef2,
 			},
 		}
+
+		require.Equal(t, BindingSuccess, sbrOutput.Status.BindingStatus)
+		require.Equal(t, reconcilerName, sbrOutput.Status.Secret)
+		require.Equal(t, corev1.ConditionTrue, sbrOutput.Status.Conditions[0].Status)
 		require.True(t, reflect.DeepEqual(expectedStatus, sbrOutput.Status.ApplicationObjects[0]))
 	})
 }

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -280,3 +280,52 @@ func TestReconcilerGenericBinding(t *testing.T) {
 	require.Equal(t, s.Data["password"], []byte("abc123"))
 	require.Equal(t, 1, len(sbrOutput3.Status.ApplicationObjects))
 }
+
+//TestReconcilerReconcileWithConflictingAppSelc tests when sbr has conflicting ApplicationSel such as MatchLabels=App1 and ResourceRef=App2 it should prioritise the ResourceRef
+func TestReconcilerReconcileWithConflictingAppSelc(t *testing.T) {
+	backingServiceResourceRef := "backingServiceRef"
+	applicationResourceRef1 := "applicationResourceRef1"
+	matchLabels1 := map[string]string{
+		"connects-to": "database",
+		"environment": "testing",
+	}
+	applicationResourceRef2 := "applicationResourceRef2"
+
+	f := mocks.NewFake(t, reconcilerNs)
+
+	f.AddMockedUnstructuredDeployment(applicationResourceRef1, matchLabels1)
+	f.AddMockedUnstructuredDeployment(applicationResourceRef2, nil)
+	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, backingServiceResourceRef, applicationResourceRef2, deploymentsGVR, matchLabels1)
+	f.AddMockedUnstructuredCSV("cluster-service-version-list")
+	f.AddMockedUnstructuredDatabaseCRD()
+	f.AddMockedUnstructuredDatabaseCR(backingServiceResourceRef)
+	f.AddMockedSecret("db-credentials")
+
+	fakeClient := f.FakeClient()
+	fakeDynClient := f.FakeDynClient()
+	reconciler := &Reconciler{client: fakeClient, dynClient: fakeDynClient, scheme: f.S}
+
+	t.Run("test-reconciler-reconcile-with-conflicting-application-selector", func(t *testing.T) {
+
+		res, err := reconciler.Reconcile(reconcileRequest())
+		require.NoError(t, err)
+		require.False(t, res.Requeue)
+
+		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+		sbrOutput, err := reconciler.getServiceBindingRequest(namespacedName)
+		require.NoError(t, err)
+
+		require.Equal(t, BindingSuccess, sbrOutput.Status.BindingStatus)
+		expectedStatus := v1alpha1.BoundApplication{
+			GroupVersionKind: v1.GroupVersionKind{
+				Group:   deploymentsGVR.Group,
+				Version: deploymentsGVR.Version,
+				Kind:    "Deployment",
+			},
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: applicationResourceRef2,
+			},
+		}
+		require.True(t, reflect.DeepEqual(expectedStatus, sbrOutput.Status.ApplicationObjects[0]))
+	})
+}


### PR DESCRIPTION
### Motivation

https://issues.redhat.com/browse/APPSVC-248

###
testing:
`make test-unit`
or
`go test ./pkg/controller/servicebindingrequest -run TestReconcilerReconcileWithConflictingAppSelc -v `