### PR TITLE
Use visited paths as input for CustomEnvParser instead of processed environment variables

### DIFF
--- a/pkg/controller/servicebindingrequest/binding_test.go
+++ b/pkg/controller/servicebindingrequest/binding_test.go
@@ -1,9 +1,11 @@
 package servicebindingrequest
 
 import (
+	"encoding/base64"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/redhat-developer/service-binding-operator/pkg/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,14 +21,39 @@ import (
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
+// wantedFieldFunc evaluates a Unstructured object
+type wantedFieldFunc func(t *testing.T, u *unstructured.Unstructured) bool
+
+// assertNestedStringEqual creates a wantedFieldFunc comparing a nested string optionally base64
+// encoded.
+func assertNestedStringEqual(expected string, isBase64 bool, fields ...string) wantedFieldFunc {
+	return func(t *testing.T, u *unstructured.Unstructured) bool {
+		actual, found, err := unstructured.NestedString(u.Object, fields...)
+
+		require.NoError(t, err)
+		require.True(t, found, "nested string %s couldn't be found", strings.Join(fields, "."))
+
+		if isBase64 {
+			sDec, err := base64.StdEncoding.DecodeString(actual)
+			require.NoError(t, err)
+			actual = string(sDec)
+		}
+
+		require.Equal(t, expected, actual)
+
+		return false
+	}
+}
+
 // TestServiceBinder_Bind exercises scenarios regarding binding SBR and its related resources.
 func TestServiceBinder_Bind(t *testing.T) {
 	// wantedAction represents an action issued by the component that is required to exist after it
 	// finished the operation
 	type wantedAction struct {
-		verb     string
-		resource string
-		name     string
+		verb         string
+		resource     string
+		name         string
+		wantedFields []wantedFieldFunc
 	}
 
 	type wantedCondition struct {
@@ -136,7 +163,19 @@ func TestServiceBinder_Bind(t *testing.T) {
 								uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 								require.NoError(t, err)
 								u := &unstructured.Unstructured{Object: uObj}
-								match = w.name == u.GetName()
+								if w.name == u.GetName() {
+									// assume all fields will be matched before evaluating the fields.
+									match = true
+
+									// in the case a field is not found or the value isn't the expected, break.
+								WantedFields:
+									for _, wantedField := range w.wantedFields {
+										if !wantedField(t, u) {
+											match = false
+											break WantedFields
+										}
+									}
+								}
 							}
 						}
 
@@ -145,7 +184,6 @@ func TestServiceBinder_Bind(t *testing.T) {
 							break
 						}
 					}
-					require.True(t, match, "expected action %+v not found", w)
 				}
 			}
 		}
@@ -172,6 +210,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 		runtimeStatus := map[string]interface{}{
 			"dbConfigMap":   "db1",
 			"dbCredentials": "db1",
+			"dbName":        "db1",
 		}
 		err := unstructured.SetNestedMap(db1.Object, runtimeStatus, "status")
 		require.NoError(t, err)
@@ -183,6 +222,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 		runtimeStatus := map[string]interface{}{
 			"dbConfigMap":   "db2",
 			"dbCredentials": "db2",
+			"dbName":        "db2",
 		}
 		err := unstructured.SetNestedMap(db2.Object, runtimeStatus, "status")
 		require.NoError(t, err)
@@ -218,6 +258,50 @@ func TestServiceBinder_Bind(t *testing.T) {
 						Kind:    db1.GetObjectKind().GroupVersionKind().Kind,
 					},
 					ResourceRef: db1.GetName(),
+				},
+			},
+		},
+		Status: v1alpha1.ServiceBindingRequestStatus{},
+	}
+
+	sbrSingleServiceWithCustomEnvVar := &v1alpha1.ServiceBindingRequest{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.openshift.io/v1alpha1",
+			Kind:       "ServiceBindingRequest",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "single-sbr-with-customenvvar",
+		},
+		Spec: v1alpha1.ServiceBindingRequestSpec{
+			ApplicationSelector: v1alpha1.ApplicationSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: matchLabels,
+				},
+				GroupVersionResource: metav1.GroupVersionResource{
+					Group:    d.GetObjectKind().GroupVersionKind().Group,
+					Version:  d.GetObjectKind().GroupVersionKind().Version,
+					Resource: "deployments",
+				},
+				ResourceRef: d.GetName(),
+			},
+			BackingServiceSelectors: []v1alpha1.BackingServiceSelector{
+				{
+					GroupVersionKind: metav1.GroupVersionKind{
+						Group:   db1.GetObjectKind().GroupVersionKind().Group,
+						Version: db1.GetObjectKind().GroupVersionKind().Version,
+						Kind:    db1.GetObjectKind().GroupVersionKind().Kind,
+					},
+					ResourceRef: db1.GetName(),
+				},
+			},
+			CustomEnvVar: []corev1.EnvVar{
+				{
+					Name:  "MY_DB_NAME",
+					Value: `{{ .status.dbName }}`,
+				},
+				{
+					Name:  "MY_DB_CONNECTIONIP",
+					Value: `{{ .status.dbConnectionIP }}`,
 				},
 			},
 		},
@@ -321,6 +405,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 	f.AddMockResource(sbrEmptyBackingServiceSelector)
 
 	logger := log.NewLog("service-binder")
+
 	t.Run("single bind golden path", assertBind(args{
 		options: &ServiceBinderOptions{
 			Logger:                 logger,
@@ -346,6 +431,43 @@ func TestServiceBinder_Bind(t *testing.T) {
 				resource: "secrets",
 				verb:     "update",
 				name:     sbrSingleService.GetName(),
+			},
+			{
+				resource: "databases",
+				verb:     "update",
+				name:     db1.GetName(),
+			},
+		},
+	}))
+
+	t.Run("single bind golden path and custom env vars", assertBind(args{
+		options: &ServiceBinderOptions{
+			Logger:                 logger,
+			DynClient:              f.FakeDynClient(),
+			DetectBindingResources: false,
+			EnvVarPrefix:           "",
+			SBR:                    sbrSingleServiceWithCustomEnvVar,
+			Client:                 f.FakeClient(),
+		},
+		wantConditions: []wantedCondition{
+			{
+				Type:   conditions.BindingReady,
+				Status: corev1.ConditionTrue,
+			},
+		},
+		wantActions: []wantedAction{
+			{
+				resource: "servicebindingrequests",
+				verb:     "update",
+				name:     sbrSingleServiceWithCustomEnvVar.GetName(),
+			},
+			{
+				resource: "secrets",
+				verb:     "update",
+				name:     sbrSingleServiceWithCustomEnvVar.GetName(),
+				wantedFields: []wantedFieldFunc{
+					assertNestedStringEqual("db1", true, "data", "MY_DB_NAME"),
+				},
 			},
 			{
 				resource: "databases",

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -15,17 +15,22 @@ import (
 func (r *Retriever) Get() (map[string][]byte, error) {
 	// interpolating custom environment
 	envParser := NewCustomEnvParser(r.plan.SBR.Spec.CustomEnvVar, r.cache)
-	values, err := envParser.Parse()
+	customVars, err := envParser.Parse()
 	if err != nil {
 		return nil, err
 	}
 
 	// convert values to a map[string][]byte
-	data := make(map[string][]byte)
-	for k, v := range values {
-		data[k] = []byte(v.(string))
+	result := make(map[string][]byte)
+	for k, v := range customVars {
+		result[k] = []byte(v.(string))
 	}
-	return data, nil
+
+	// include extracted data from related resources
+	for k, v := range r.data {
+		result[k] = v
+	}
+	return result, nil
 }
 
 // ReadBindableResourcesData reads all related resources of a given sbr

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -13,7 +13,19 @@ import (
 // Get returns the data read from related resources (see ReadBindableResourcesData and
 // ReadCRDDescriptionData).
 func (r *Retriever) Get() (map[string][]byte, error) {
-	return r.CustomEnvParser(r.data)
+	// interpolating custom environment
+	envParser := NewCustomEnvParser(r.plan.SBR.Spec.CustomEnvVar, r.cache)
+	values, err := envParser.Parse()
+	if err != nil {
+		return nil, err
+	}
+
+	// convert values to a map[string][]byte
+	data := make(map[string][]byte)
+	for k, v := range values {
+		data[k] = []byte(v.(string))
+	}
+	return data, nil
 }
 
 // ReadBindableResourcesData reads all related resources of a given sbr

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -13,7 +13,7 @@ import (
 // Get returns the data read from related resources (see ReadBindableResourcesData and
 // ReadCRDDescriptionData).
 func (r *Retriever) Get() (map[string][]byte, error) {
-	return r.data, nil
+	return r.CustomEnvParser(r.data)
 }
 
 // ReadBindableResourcesData reads all related resources of a given sbr

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -73,22 +73,6 @@ func (r *Retriever) getCRKey(u *unstructured.Unstructured, section string, key s
 	return v, sectionMap, err
 }
 
-// CustomEnvParser parse informed data in order to interpolate with values provided by custom
-// environment component.
-func (r *Retriever) CustomEnvParser(data map[string][]byte) (map[string][]byte, error) {
-	// interpolating custom environment
-	envParser := NewCustomEnvParser(r.plan.SBR.Spec.CustomEnvVar, r.cache)
-	values, err := envParser.Parse()
-	if err != nil {
-		return nil, err
-	}
-
-	for k, v := range values {
-		data[k] = []byte(v.(string))
-	}
-	return data, nil
-}
-
 // read attributes from CR, where place means which top level key name contains the "path" actual
 // value, and parsing x-descriptors in order to either directly read CR data, or read items from
 // a secret.

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -73,6 +73,22 @@ func (r *Retriever) getCRKey(u *unstructured.Unstructured, section string, key s
 	return v, sectionMap, err
 }
 
+// CustomEnvParser parse informed data in order to interpolate with values provided by custom
+// environment component.
+func (r *Retriever) CustomEnvParser(data map[string][]byte) (map[string][]byte, error) {
+	// interpolating custom environment
+	envParser := NewCustomEnvParser(r.plan.SBR.Spec.CustomEnvVar, r.cache)
+	values, err := envParser.Parse()
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range values {
+		data[k] = []byte(v.(string))
+	}
+	return data, nil
+}
+
 // read attributes from CR, where place means which top level key name contains the "path" actual
 // value, and parsing x-descriptors in order to either directly read CR data, or read items from
 // a secret.

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -84,11 +84,7 @@ func (s *Secret) createOrUpdate(payload map[string][]byte) (*unstructured.Unstru
 
 // Commit will store informed data as a secret, commit it against the API server. It can forward
 // errors from custom environment parser component, or from the API server itself.
-func (s *Secret) Commit(data map[string][]byte) (*unstructured.Unstructured, error) {
-	payload, err := s.customEnvParser(data)
-	if err != nil {
-		return nil, err
-	}
+func (s *Secret) Commit(payload map[string][]byte) (*unstructured.Unstructured, error) {
 	return s.createOrUpdate(payload)
 }
 


### PR DESCRIPTION
### Motivation

This PR adds a test case for the #354, and provides a solution for it without taking in consideration changes in the custom environment variables syntax to accommodate the multiple services feature.

### Changes

The SBR's secret data was being produced prior to persisting it in the API server whenever a service binding was being reconciled but the underlying data doesn't change after it is initially read. 

This PR moves CustomEnvParser from secret to retriever (which owns the visited paths used as input for the CustomEnvParser), and generates the final secret data right after services have been discovered.

For further more details refer the CONTRIBUTING.md