### PR TITLE
(bug) Fix normalization of annotations to CRDDescription

### DIFF
--- a/pkg/controller/servicebindingrequest/olm.go
+++ b/pkg/controller/servicebindingrequest/olm.go
@@ -198,11 +198,11 @@ func buildCRDDescriptionFromCRD(crd *unstructured.Unstructured) (*olmv1alpha1.CR
 	}
 
 	if specDescriptor != nil {
-		crdDescription.SpecDescriptors = append(crdDescription.SpecDescriptors, *specDescriptor)
+		crdDescription.SpecDescriptors = append(crdDescription.SpecDescriptors, specDescriptor...)
 	}
 
 	if statusDescriptor != nil {
-		crdDescription.StatusDescriptors = append(crdDescription.StatusDescriptors, *statusDescriptor)
+		crdDescription.StatusDescriptors = append(crdDescription.StatusDescriptors, statusDescriptor...)
 	}
 
 	return crdDescription, nil
@@ -211,12 +211,12 @@ func buildCRDDescriptionFromCRD(crd *unstructured.Unstructured) (*olmv1alpha1.CR
 // buildDescriptorsFromAnnotations builds two descriptors collection, one for spec descriptors and
 // another for status descriptors.
 func buildDescriptorsFromAnnotations(annotations map[string]string) (
-	*olmv1alpha1.SpecDescriptor,
-	*olmv1alpha1.StatusDescriptor,
+	[]olmv1alpha1.SpecDescriptor,
+	[]olmv1alpha1.StatusDescriptor,
 	error,
 ) {
-	var currentSpecDescriptor *olmv1alpha1.SpecDescriptor
-	var currentStatusDescriptor *olmv1alpha1.StatusDescriptor
+	var specDescriptors []olmv1alpha1.SpecDescriptor
+	var statusDescriptors []olmv1alpha1.StatusDescriptor
 
 	acc := make(map[string][]string)
 
@@ -250,19 +250,19 @@ func buildDescriptorsFromAnnotations(annotations map[string]string) (
 		sort.Strings(descriptors)
 		path := strings.Split(fieldPath, ".")
 		if path[0] == "status" {
-			currentStatusDescriptor = &olmv1alpha1.StatusDescriptor{
+			statusDescriptors = append(statusDescriptors, olmv1alpha1.StatusDescriptor{
 				Path:         path[1],
 				XDescriptors: descriptors,
-			}
+			})
 		} else if path[0] == "spec" {
-			currentSpecDescriptor = &olmv1alpha1.SpecDescriptor{
+			specDescriptors = append(specDescriptors, olmv1alpha1.SpecDescriptor{
 				Path:         path[1],
 				XDescriptors: descriptors,
-			}
+			})
 		}
 	}
 
-	return currentSpecDescriptor, currentStatusDescriptor, nil
+	return specDescriptors, statusDescriptors, nil
 }
 
 // extractGVKs loop owned objects and extract the GVK information from them.

--- a/pkg/controller/servicebindingrequest/olm.go
+++ b/pkg/controller/servicebindingrequest/olm.go
@@ -192,18 +192,12 @@ func buildCRDDescriptionFromCRD(crd *unstructured.Unstructured) (*olmv1alpha1.CR
 		return nil, err
 	}
 
-	specDescriptor, statusDescriptor, err := buildDescriptorsFromAnnotations(crd.GetAnnotations())
+	specDescriptors, statusDescriptors, err := buildDescriptorsFromAnnotations(crd.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
-
-	if specDescriptor != nil {
-		crdDescription.SpecDescriptors = append(crdDescription.SpecDescriptors, specDescriptor...)
-	}
-
-	if statusDescriptor != nil {
-		crdDescription.StatusDescriptors = append(crdDescription.StatusDescriptors, statusDescriptor...)
-	}
+	crdDescription.SpecDescriptors = append(crdDescription.SpecDescriptors, specDescriptors...)
+	crdDescription.StatusDescriptors = append(crdDescription.StatusDescriptors, statusDescriptors...)
 
 	return crdDescription, nil
 }

--- a/pkg/controller/servicebindingrequest/olm_test.go
+++ b/pkg/controller/servicebindingrequest/olm_test.go
@@ -116,9 +116,6 @@ func TestAnnotationParsing(t *testing.T) {
 		require.Len(t, crdDescription.StatusDescriptors, 2)
 		require.Len(t, crdDescription.SpecDescriptors, 2)
 
-		require.Equal(t, "dbName", crdDescription.SpecDescriptors[0].Path)
-		require.Equal(t, "binding:env:attribute:spec.dbName", crdDescription.SpecDescriptors[0].XDescriptors[0])
-
 		expected := map[string]string{
 			"dbName":        "binding:env:attribute:spec.dbName",
 			"image":         "binding:env:attribute:spec.image",

--- a/pkg/controller/servicebindingrequest/olm_test.go
+++ b/pkg/controller/servicebindingrequest/olm_test.go
@@ -122,6 +122,9 @@ func TestAnnotationParsing(t *testing.T) {
 			"dbCredentials": "binding:env:object:secret:db.password",
 			"dbConfigMap":   "binding:env:object:configmap:db.host",
 		}
+		for _, value := range crdDescription.SpecDescriptors {
+			require.Equal(t, expected[value.Path], value.XDescriptors[0])
+		}
 
 		for _, value := range crdDescription.StatusDescriptors {
 			require.Equal(t, expected[value.Path], value.XDescriptors[0])

--- a/pkg/controller/servicebindingrequest/olm_test.go
+++ b/pkg/controller/servicebindingrequest/olm_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -73,5 +74,60 @@ func TestOLMNew(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, gvks, 1)
 		assertGVKs(t, gvks)
+	})
+}
+
+func TestAnnotationParsing(t *testing.T) {
+	annotations := map[string]interface{}{
+		"servicebindingoperator.redhat.io/status.dbCredentials-db.password": "binding:env:object:secret",
+		"servicebindingoperator.redhat.io/spec.dbName":                      "binding:env:attribute",
+		"servicebindingoperator.redhat.io/spec.image":                       "binding:env:attribute",
+		"servicebindingoperator.redhat.io/status.dbConfigMap-db.host":       "binding:env:object:configmap",
+	}
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata":   map[string]interface{}{},
+			"spec": map[string]interface{}{
+				"names": map[string]interface{}{
+					"kind": "Carp",
+				},
+				"group":   "app.dev",
+				"version": "v1",
+			},
+			"status": map[string]interface{}{},
+		},
+	}
+	t.Run("Build CSV from CRD - no annotations", func(t *testing.T) {
+		crdDescription, err := buildCRDDescriptionFromCRD(crd)
+		require.NoError(t, err)
+		require.Len(t, crdDescription.SpecDescriptors, 0)
+		require.Len(t, crdDescription.StatusDescriptors, 0)
+	})
+
+	t.Run("Build CSV from CRD", func(t *testing.T) {
+		crd.Object["metadata"] = map[string]interface{}{
+			"annotations": annotations,
+		}
+		crdDescription, err := buildCRDDescriptionFromCRD(crd)
+		require.NoError(t, err)
+
+		require.Len(t, crdDescription.StatusDescriptors, 2)
+		require.Len(t, crdDescription.SpecDescriptors, 2)
+
+		require.Equal(t, "dbName", crdDescription.SpecDescriptors[0].Path)
+		require.Equal(t, "binding:env:attribute:spec.dbName", crdDescription.SpecDescriptors[0].XDescriptors[0])
+
+		expected := map[string]string{
+			"dbName":        "binding:env:attribute:spec.dbName",
+			"image":         "binding:env:attribute:spec.image",
+			"dbCredentials": "binding:env:object:secret:db.password",
+			"dbConfigMap":   "binding:env:object:configmap:db.host",
+		}
+
+		for _, value := range crdDescription.StatusDescriptors {
+			require.Equal(t, expected[value.Path], value.XDescriptors[0])
+		}
 	})
 }


### PR DESCRIPTION
### Motivation

Parsing the annotations into the data structures which contained spec|status descriptors had a bug where only one spec descriptor and one status descriptor was being persisted irrespective of the total number of annotations present.

Example, the following 
```
"servicebindingoperator.redhat.io/status.dbCredentials-db.password": "binding:env:object:secret",
"servicebindingoperator.redhat.io/spec.dbName":                      "binding:env:attribute",
"servicebindingoperator.redhat.io/spec.image":                       "binding:env:attribute",
"servicebindingoperator.redhat.io/status.dbConfigMap-db.host":       "binding:env:object:configmap",
```
was being mapped to only one spec descriptor and one status descriptor, instead of two each.

### Changes

Fix the 

```
func buildDescriptorsFromAnnotations(annotations map[string]string) (
	[]olmv1alpha1.SpecDescriptor,
	[]olmv1alpha1.StatusDescriptor,
	error, 
``` 
function to append parsed annotations into a list. 

### Testing

Ideally, use of a backing service which has no CSV should validate this.

- [x] Added tests
- [x] The fix was put in https://github.com/redhat-developer/service-binding-operator/pull/367 so that we could test use of backing service objects which had no CSV/CRD. The change has been validated there.

