### PR TITLE
Add boilerplate file as operator-sdk generate open-api is deprecated

### DIFF
--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+


### PR DESCRIPTION
As the `operator-sdk generate open-api` is deprecated this PR adds a boilerplate file for open api gen.

Refer https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#openapi 

Boilerplate file at - https://github.com/kubernetes/kube-openapi/blob/master/boilerplate/boilerplate.go.txt
