### PR TITLE
Include past releases in the bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - if [ "$TRAVIS_BRANCH" = "master" ]; then
     make merge-to-master-release &&
     make push-to-manifest-repo &&
-    make push-bundle-to-quay || exit 1;
+    make prepare-bundle-to-quay || exit 1;
     fi
 
 after_success:
@@ -50,3 +50,4 @@ after_success:
   - git add .
   - git commit -m ${MESSAGE}
   - git push "https://${GITHUB_TOKEN}@${GH_REMOTE_REPO}" master > /dev/null 2>&1
+  - make push-bundle-to-quay

--- a/Makefile
+++ b/Makefile
@@ -462,10 +462,6 @@ push-bundle-quay:
 	$(Q)$(OUTPUT_DIR)/venv3/bin/operator-courier verify $(SBR_MANIFESTS)
 	$(Q)$(OUTPUT_DIR)./venv3/bin/operator-courier push $(SBR_MANIFESTS) redhat-developer service-binding-operator $(BUNDLE_VERSION) "$(QUAY_BUNDLE_TOKEN)"
 
-.PHONY: aa
-aa:
-	echo $(SBR_MANIFESTS)
-
 ## -- Target for validating the operator --
 .PHONY: dev-release
 ## validating the operator by installing new quay releases

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,9 @@ GO_PACKAGE_ORG_NAME ?= $(shell basename $$(dirname $$PWD))
 GO_PACKAGE_REPO_NAME ?= $(shell basename $$PWD)
 GO_PACKAGE_PATH ?= github.com/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}
 
+PROJECT_DIR ?= $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+SBR_MANIFESTS ?= ${PROJECT_DIR}service-binding-operator-manifests
+
 CGO_ENABLED ?= 0
 GO111MODULE ?= on
 GOCACHE ?= "$(shell echo ${PWD})/out/gocache"
@@ -440,18 +443,28 @@ push-to-manifest-repo:
 	sed -i -e 's,ICON_BASE64_DATA,$(shell base64 --wrap=0 ./assets/icon/red-hat-logo.svg),g' $(MANIFESTS_TMP)/${BUNDLE_VERSION}/*.clusterserviceversion.yaml
 	sed -i -e 's,ICON_MEDIA_TYPE,image/svg+xml,g' $(MANIFESTS_TMP)/${BUNDLE_VERSION}/*.clusterserviceversion.yaml
 
-## -- Target for pushing manifest bundle to quay application --
-.PHONY: push-bundle-to-quay
-## Push manifest bundle to quay application
-push-bundle-to-quay:
+## -- Target for preparing manifest bundle to quay application --
+.PHONY: prepare-bundle-to-quay
+## Prepare manifest bundle to quay application
+prepare-bundle-to-quay:
 	$(Q)python3.7 -m venv $(OUTPUT_DIR)/venv3
 	$(Q)$(OUTPUT_DIR)/venv3/bin/pip install --upgrade setuptools
 	$(Q)$(OUTPUT_DIR)/venv3/bin/pip install --upgrade pip
 	$(Q)$(OUTPUT_DIR)/venv3/bin/pip install operator-courier==2.1.2
 	$(Q)$(OUTPUT_DIR)/venv3/bin/operator-courier --version
 	$(Q)$(OUTPUT_DIR)/venv3/bin/operator-courier verify $(MANIFESTS_TMP)
-	$(Q)$(OUTPUT_DIR)/venv3/bin/operator-courier push $(MANIFESTS_TMP) $(OPERATOR_GROUP) $(GO_PACKAGE_REPO_NAME) $(BUNDLE_VERSION) "$(QUAY_BUNDLE_TOKEN)"
 	rm -rf deploy/olm-catalog/$(GO_PACKAGE_REPO_NAME)/$(BUNDLE_VERSION)
+
+## -- Target to push bundle to quay
+.PHONY: push-bundle-to-quay
+## Push manifest bundle to quay application
+push-bundle-quay:
+	$(Q)$(OUTPUT_DIR)/venv3/bin/operator-courier verify $(SBR_MANIFESTS)
+	$(Q)$(OUTPUT_DIR)./venv3/bin/operator-courier push $(SBR_MANIFESTS) redhat-developer service-binding-operator $(BUNDLE_VERSION) "$(QUAY_BUNDLE_TOKEN)"
+
+.PHONY: aa
+aa:
+	echo $(SBR_MANIFESTS)
 
 ## -- Target for validating the operator --
 .PHONY: dev-release

--- a/hack/dev-release.sh
+++ b/hack/dev-release.sh
@@ -7,6 +7,8 @@ OPERATOR_SOURCE="./test/operator-hub/operator_source.yaml"
 SUBSCRIPTION="./test/operator-hub/subscription.yaml"
 INSTALL_PLAN_PRIOR=service-binding-operator.v${BUNDLE_VERSION}
 
+sed -i -e "s,REPLACE_CSV_VERSION,service-binding-operator.v${BUNDLE_VERSION},g" ${SUBSCRIPTION}
+
 kubectl apply -f ${OPERATOR_SOURCE}
 # Subscribing to the operator
 kubectl apply -f ${SUBSCRIPTION}

--- a/test/operator-hub/subscription.yaml
+++ b/test/operator-hub/subscription.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: alpha
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: service-binding-operator
   source: example-operators
   sourceNamespace: openshift-marketplace
+  startingCSV: REPLACE_CSV_VERSION


### PR DESCRIPTION
Also specify the version in the subscription with Manual upgrade.

Fixes #390

The current issue is coming because we decrement the version of the Quay application bundle. Since we are using a periodic job there is a chance for false positives if we merge to master within short intervals.

These issues are addressed with these changes:

1. Include all past releases in the Quay application bundle (Without this only the latest will be available in the catalog)

2. Specify the start version of CSV and use Manual mode for install plan approval (This prevent automatic upgrade)