### PR TITLE
Increment version to 0.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ GOCOV ?= "-covermode=atomic -coverprofile REPLACE_FILE"
 
 GIT_COMMIT_ID ?= $(shell git rev-parse --short HEAD)
 
-OPERATOR_VERSION ?= 0.1.0
+OPERATOR_VERSION ?= 0.1.1
 OPERATOR_GROUP ?= ${GO_PACKAGE_ORG_NAME}
 OPERATOR_IMAGE ?= quay.io/${OPERATOR_GROUP}/${GO_PACKAGE_REPO_NAME}
 OPERATOR_IMAGE_REL ?= quay.io/${OPERATOR_GROUP}/app-binding-operator


### PR DESCRIPTION
This is required to fix Dev release.

"It looks like OperatorSource is always pulling the latest version from the Quay application registry. Since we can't remove releases from Quay, we should increment the version."