### PR TITLE
Handle errors for CSV CRD does not installed

### DIFF
--- a/pkg/controller/servicebindingrequest/olm.go
+++ b/pkg/controller/servicebindingrequest/olm.go
@@ -42,7 +42,10 @@ func (o *OLM) listCSVs() ([]unstructured.Unstructured, error) {
 	gvr := olmv1alpha1.SchemeGroupVersion.WithResource(csvResource)
 	resourceClient := o.client.Resource(gvr).Namespace(o.ns)
 	csvs, err := resourceClient.List(metav1.ListOptions{})
-	if err != nil {
+	if err != nil && errors.IsNotFound(err) {
+		log.Warning("ClusterServiceVersions CRD is not installed")
+		return nil, nil
+	} else if err != nil {
 		log.Error(err, "during listing CSV objects from cluster")
 		return nil, err
 	}

--- a/pkg/controller/servicebindingrequest/sbrcontroller.go
+++ b/pkg/controller/servicebindingrequest/sbrcontroller.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -145,9 +147,18 @@ func (s *SBRController) AddWatchForGVK(gvk schema.GroupVersionKind) error {
 // addCSVWatch creates a watch on ClusterServiceVersion.
 func (s *SBRController) addCSVWatch() error {
 	log := s.logger
+	gvr := olmv1alpha1.SchemeGroupVersion.WithResource(ClusterServiceVersionKind)
+	resourceClient := s.Client.Resource(gvr).Namespace(os.Getenv("WATCH_NAMESPACE"))
+	_, err := resourceClient.List(metav1.ListOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		log.Warning("ClusterServiceVersions CRD is not installed, skip watching")
+		return nil
+	} else if err != nil {
+		return err
+	}
 	csvGVK := olmv1alpha1.SchemeGroupVersion.WithKind(ClusterServiceVersionKind)
 	source := s.createSourceForGVK(csvGVK)
-	err := s.Controller.Watch(source, NewCreateWatchEventHandler(s))
+	err = s.Controller.Watch(source, NewCreateWatchEventHandler(s))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Motivation
Currently the operator will throw error `"olm","msg":"on listting CSVs","error":"the server could not find the requested resource"` if CSV CRD is not installed.
Handle these errors will make service binding operator work with less dependency(With SBR CRD only).

More detials refer to Issue https://github.com/redhat-developer/service-binding-operator/issues/385

### Changes
Handle errors in `olm.listCSVs()` and also check CSV resources before add watching.

### Testing

The fake client will not return 404 error while listing non-existing resources kind. So test case is not present for this error handling. Maybe we could add cases in e2e test.