### PR TITLE
Add "id" and "envVarPrefix" to backingServiceSelector to enable multiple service binding

### DIFF
--- a/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
+++ b/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
@@ -116,6 +116,8 @@ spec:
                   type: string
                 id:
                   type: string
+                envVarPrefix:
+                  type: string
               required:
               - group
               - kind
@@ -141,6 +143,8 @@ spec:
                   version:
                     type: string
                   id:
+                    type: string
+                  envVarPrefix:
                     type: string
                 required:
                 - group

--- a/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
+++ b/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
@@ -114,6 +114,8 @@ spec:
                   type: string
                 version:
                   type: string
+                id:
+                  type: string
               required:
               - group
               - kind
@@ -138,11 +140,14 @@ spec:
                     type: string
                   version:
                     type: string
+                  id:
+                    type: string
                 required:
                 - group
                 - kind
                 - resourceRef
                 - version
+                - id
                 type: object
               type: array
             customEnvVar:

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -82,8 +82,9 @@ type BackingServiceSelector struct {
 	// customEnvVar:
 	// 	- name: CONNECTION_URL
 	// 	value: {{  X.status.username }} / {{ Y.status.url }}
-	Id        string  `json:"id,omitempty"`
-	Namespace *string `json:"namespace,omitempty"`
+	Id           string  `json:"id,omitempty"`
+	Namespace    *string `json:"namespace,omitempty"`
+	EnvVarPrefix string  `json:"envVarPrefix,omitempty"`
 }
 
 // BoundApplication defines the application workloads to which the binding secret has

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -66,6 +66,22 @@ type BackingServiceSelector struct {
 	metav1.GroupVersionKind `json:",inline"`
 	ResourceRef             string `json:"resourceRef"`
 	// +optional
+	// The id is provided by user to identify the backing service in the custom env var tempalte.
+	// Below is an example:
+	// backingServiceSelectors:
+	//   - group: postgres.dev
+	// 	   kind: Service
+	// 	   resourceRef: user-db
+	// 	   version: v1beta1
+	// 	   id: X
+	//   - group: postgres.dev
+	// 	   kind: Credentials
+	// 	   resourceRef: admin-creds
+	// 	   version: v1beta1
+	// 	   id: Y
+	// customEnvVar:
+	// 	- name: CONNECTION_URL
+	// 	value: {{  X.status.username }} / {{ Y.status.url }}
 	Id        string  `json:"id,omitempty"`
 	Namespace *string `json:"namespace,omitempty"`
 }

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -66,6 +66,7 @@ type BackingServiceSelector struct {
 	metav1.GroupVersionKind `json:",inline"`
 	ResourceRef             string `json:"resourceRef"`
 	// +optional
+	Id        string  `json:"id,omitempty"`
 	Namespace *string `json:"namespace,omitempty"`
 }
 

--- a/pkg/controller/servicebindingrequest/binding.go
+++ b/pkg/controller/servicebindingrequest/binding.go
@@ -330,7 +330,7 @@ func BuildServiceBinder(options *ServiceBinderOptions) (*ServiceBinder, error) {
 
 	// read bindable data from the CRDDescription found by the planner
 	for _, r := range plan.GetRelatedResources() {
-		err = retriever.ReadCRDDescriptionData(r.CR, r.CRDDescription)
+		err = retriever.ReadCRDDescriptionData(r.Id, r.CR, r.CRDDescription)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/servicebindingrequest/binding.go
+++ b/pkg/controller/servicebindingrequest/binding.go
@@ -322,7 +322,7 @@ func BuildServiceBinder(options *ServiceBinderOptions) (*ServiceBinder, error) {
 
 	// read bindable data from the specified resources
 	if options.DetectBindingResources {
-		err := retriever.ReadBindableResourcesData(&plan.SBR, rs)
+		err := retriever.ReadBindableResourcesData(&plan.SBR, plan.GetRelatedResources())
 		if err != nil {
 			return nil, err
 		}
@@ -330,7 +330,7 @@ func BuildServiceBinder(options *ServiceBinderOptions) (*ServiceBinder, error) {
 
 	// read bindable data from the CRDDescription found by the planner
 	for _, r := range plan.GetRelatedResources() {
-		err = retriever.ReadCRDDescriptionData(r.Id, r.CR, r.CRDDescription)
+		err = retriever.ReadCRDDescriptionData(r.Id, r.EnvVarPrefix, r.CR, r.CRDDescription)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/servicebindingrequest/binding_test.go
+++ b/pkg/controller/servicebindingrequest/binding_test.go
@@ -229,7 +229,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 		require.NoError(t, err)
 	}
 	f.AddMockedSecret("db2")
-
+	testCrId := "testCrId"
 	// create the ServiceBindingRequest
 	sbrSingleService := &v1alpha1.ServiceBindingRequest{
 		TypeMeta: metav1.TypeMeta{
@@ -259,6 +259,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 						Kind:    db1.GetObjectKind().GroupVersionKind().Kind,
 					},
 					ResourceRef: db1.GetName(),
+					Id:          testCrId,
 				},
 			},
 		},
@@ -293,16 +294,17 @@ func TestServiceBinder_Bind(t *testing.T) {
 						Kind:    db1.GetObjectKind().GroupVersionKind().Kind,
 					},
 					ResourceRef: db1.GetName(),
+					Id:          testCrId,
 				},
 			},
 			CustomEnvVar: []corev1.EnvVar{
 				{
 					Name:  "MY_DB_NAME",
-					Value: `{{ .status.dbName }}`,
+					Value: `{{ .testCrId.status.dbName }}`,
 				},
 				{
 					Name:  "MY_DB_CONNECTIONIP",
-					Value: `{{ .status.dbConnectionIP }}`,
+					Value: `{{ .testCrId.status.dbConnectionIP }}`,
 				},
 			},
 		},

--- a/pkg/controller/servicebindingrequest/custom_env_parser.go
+++ b/pkg/controller/servicebindingrequest/custom_env_parser.go
@@ -11,11 +11,11 @@ import (
 // CustomEnvParser is responsible to interpolate a given EnvVar containing templates.
 type CustomEnvParser struct {
 	EnvMap []corev1.EnvVar
-	Cache  map[string]interface{}
+	Cache  map[string]map[string]interface{}
 }
 
 // NewCustomEnvParser returns a new CustomEnvParser.
-func NewCustomEnvParser(envMap []corev1.EnvVar, cache map[string]interface{}) *CustomEnvParser {
+func NewCustomEnvParser(envMap []corev1.EnvVar, cache map[string]map[string]interface{}) *CustomEnvParser {
 	return &CustomEnvParser{
 		EnvMap: envMap,
 		Cache:  cache,

--- a/pkg/controller/servicebindingrequest/custom_env_parser_test.go
+++ b/pkg/controller/servicebindingrequest/custom_env_parser_test.go
@@ -8,14 +8,16 @@ import (
 )
 
 func TestCustomEnvPath_Parse(t *testing.T) {
-	cache := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"dbName": "database-name",
-		},
-		"status": map[string]interface{}{
-			"creds": map[string]interface{}{
-				"user": "database-user",
-				"pass": "database-pass",
+	cache := map[string]map[string]interface{}{
+		"testCrId": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"dbName": "database-name",
+			},
+			"status": map[string]interface{}{
+				"creds": map[string]interface{}{
+					"user": "database-user",
+					"pass": "database-pass",
+				},
 			},
 		},
 	}
@@ -23,11 +25,11 @@ func TestCustomEnvPath_Parse(t *testing.T) {
 	envMap := []corev1.EnvVar{
 		corev1.EnvVar{
 			Name:  "JDBC_CONNECTION_STRING",
-			Value: `{{ .spec.dbName }}:{{ .status.creds.user }}@{{ .status.creds.pass }}`,
+			Value: `{{ .testCrId.spec.dbName }}:{{ .testCrId.status.creds.user }}@{{ .testCrId.status.creds.pass }}`,
 		},
 		corev1.EnvVar{
 			Name:  "ANOTHER_STRING",
-			Value: `{{ .spec.dbName }}_{{ .status.creds.user }}`,
+			Value: `{{ .testCrId.spec.dbName }}_{{ .testCrId.status.creds.user }}`,
 		},
 	}
 	customEnvPath := NewCustomEnvParser(envMap, cache)
@@ -43,11 +45,13 @@ func TestCustomEnvPath_Parse(t *testing.T) {
 }
 
 func TestCustomEnvPath_Parse_exampleCase(t *testing.T) {
-	cache := map[string]interface{}{
-		"status": map[string]interface{}{
-			"dbConfigMap": map[string]interface{}{
-				"db.user":     "database-user",
-				"db.password": "database-pass",
+	cache := map[string]map[string]interface{}{
+		"testCrId": map[string]interface{}{
+			"status": map[string]interface{}{
+				"dbConfigMap": map[string]interface{}{
+					"db.user":     "database-user",
+					"db.password": "database-pass",
+				},
 			},
 		},
 	}
@@ -55,11 +59,11 @@ func TestCustomEnvPath_Parse_exampleCase(t *testing.T) {
 	envMap := []corev1.EnvVar{
 		corev1.EnvVar{
 			Name:  "JDBC_USERNAME",
-			Value: `{{ index .status.dbConfigMap "db.user" }}`,
+			Value: `{{ index .testCrId.status.dbConfigMap "db.user" }}`,
 		},
 		corev1.EnvVar{
 			Name:  "JDBC_PASSWORD",
-			Value: `{{ index .status.dbConfigMap "db.password" }}`,
+			Value: `{{ index .testCrId.status.dbConfigMap "db.password" }}`,
 		},
 	}
 
@@ -76,14 +80,16 @@ func TestCustomEnvPath_Parse_exampleCase(t *testing.T) {
 }
 
 func TestCustomEnvPath_Parse_ToJson(t *testing.T) {
-	cache := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"dbName": "database-name",
-		},
-		"status": map[string]interface{}{
-			"creds": map[string]interface{}{
-				"user": "database-user",
-				"pass": "database-pass",
+	cache := map[string]map[string]interface{}{
+		"testCrId": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"dbName": "database-name",
+			},
+			"status": map[string]interface{}{
+				"creds": map[string]interface{}{
+					"user": "database-user",
+					"pass": "database-pass",
+				},
 			},
 		},
 	}
@@ -95,19 +101,19 @@ func TestCustomEnvPath_Parse_ToJson(t *testing.T) {
 		},
 		corev1.EnvVar{
 			Name:  "spec",
-			Value: `{{ json .spec }}`,
+			Value: `{{ json .testCrId.spec }}`,
 		},
 		corev1.EnvVar{
 			Name:  "status",
-			Value: `{{ json .status }}`,
+			Value: `{{ json .testCrId.status }}`,
 		},
 		corev1.EnvVar{
 			Name:  "creds",
-			Value: `{{ json .status.creds }}`,
+			Value: `{{ json .testCrId.status.creds }}`,
 		},
 		corev1.EnvVar{
 			Name:  "dbName",
-			Value: `{{ json .spec.dbName }}`,
+			Value: `{{ json .testCrId.spec.dbName }}`,
 		},
 		corev1.EnvVar{
 			Name:  "notExist",
@@ -121,7 +127,7 @@ func TestCustomEnvPath_Parse_ToJson(t *testing.T) {
 		t.Fail()
 	}
 	str := values["root"]
-	require.Equal(t, `{"spec":{"dbName":"database-name"},"status":{"creds":{"pass":"database-pass","user":"database-user"}}}`, str, "root path json string is not matching")
+	require.Equal(t, `{"testCrId":{"spec":{"dbName":"database-name"},"status":{"creds":{"pass":"database-pass","user":"database-user"}}}}`, str, "root path json string is not matching")
 	str2 := values["spec"]
 	require.Equal(t, `{"dbName":"database-name"}`, str2, "spec json string is not matching")
 	str3 := values["status"]

--- a/pkg/controller/servicebindingrequest/planner.go
+++ b/pkg/controller/servicebindingrequest/planner.go
@@ -150,6 +150,7 @@ func (p *Planner) Plan() (*Plan, error) {
 			CRDDescription: crdDescription,
 			CR:             cr,
 			Id:             s.Id,
+			EnvVarPrefix:   s.EnvVarPrefix,
 		}
 		relatedResources = append(relatedResources, r)
 		p.logger.Debug("Resolved related resource", "RelatedResource", r)

--- a/pkg/controller/servicebindingrequest/planner.go
+++ b/pkg/controller/servicebindingrequest/planner.go
@@ -149,6 +149,7 @@ func (p *Planner) Plan() (*Plan, error) {
 		r := &RelatedResource{
 			CRDDescription: crdDescription,
 			CR:             cr,
+			Id:             s.Id,
 		}
 		relatedResources = append(relatedResources, r)
 		p.logger.Debug("Resolved related resource", "RelatedResource", r)

--- a/pkg/controller/servicebindingrequest/related_resources.go
+++ b/pkg/controller/servicebindingrequest/related_resources.go
@@ -10,6 +10,7 @@ type RelatedResource struct {
 	CRDDescription *v1alpha1.CRDDescription
 	CR             *unstructured.Unstructured
 	Id             string
+	EnvVarPrefix   string
 }
 
 // RelatedResources contains a collection of SBR related resources.

--- a/pkg/controller/servicebindingrequest/related_resources.go
+++ b/pkg/controller/servicebindingrequest/related_resources.go
@@ -9,6 +9,7 @@ import (
 type RelatedResource struct {
 	CRDDescription *v1alpha1.CRDDescription
 	CR             *unstructured.Unstructured
+	Id             string
 }
 
 // RelatedResources contains a collection of SBR related resources.

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -54,21 +54,6 @@ func (r *Retriever) ReadBindableResourcesData(
 			r.storeInto(rs.EnvVarPrefix, rs.CR, k, []byte(fmt.Sprintf("%v", v)))
 		}
 	}
-	// for _, cr := range crs {
-	// 	b := NewDetectBindableResources(sbr, cr, []schema.GroupVersionResource{
-	// 		{Group: "", Version: "v1", Resource: "configmaps"},
-	// 		{Group: "", Version: "v1", Resource: "services"},
-	// 		{Group: "route.openshift.io", Version: "v1", Resource: "routes"},
-	// 	}, r.client)
-
-	// 	vals, err := b.GetBindableVariables()
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	for k, v := range vals {
-	// 		r.storeInto(cr, k, []byte(fmt.Sprintf("%v", v)))
-	// 	}
-	// }
 
 	return nil
 }

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -62,25 +62,25 @@ func (r *Retriever) storeInto(cr *unstructured.Unstructured, key string, value [
 	r.store(cr, key, value)
 }
 
-func (r *Retriever) copyFrom(u *unstructured.Unstructured, path string, fieldPath string, descriptors []string) error {
-	if err := r.read(u, path, fieldPath, descriptors); err != nil {
+func (r *Retriever) copyFrom(id string, u *unstructured.Unstructured, path string, fieldPath string, descriptors []string) error {
+	if err := r.read(id, u, path, fieldPath, descriptors); err != nil {
 		return err
 	}
 	return nil
 }
 
 // ReadCRDDescriptionData reads data related to given crdDescription
-func (r *Retriever) ReadCRDDescriptionData(u *unstructured.Unstructured, crdDescription *olmv1alpha1.CRDDescription) error {
+func (r *Retriever) ReadCRDDescriptionData(id string, u *unstructured.Unstructured, crdDescription *olmv1alpha1.CRDDescription) error {
 	r.logger.Info("Looking for spec-descriptors in 'spec'...")
 	for _, specDescriptor := range crdDescription.SpecDescriptors {
-		if err := r.copyFrom(u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
+		if err := r.copyFrom(id, u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
 			return err
 		}
 	}
 
 	r.logger.Info("Looking for status-descriptors in 'status'...")
 	for _, statusDescriptor := range crdDescription.StatusDescriptors {
-		if err := r.copyFrom(u, "status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
+		if err := r.copyFrom(id, u, "status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -36,11 +36,11 @@ func (r *Retriever) Get() (map[string][]byte, error) {
 // ReadBindableResourcesData reads all related resources of a given sbr
 func (r *Retriever) ReadBindableResourcesData(
 	sbr *v1alpha1.ServiceBindingRequest,
-	crs []*unstructured.Unstructured,
+	relatedResources RelatedResources,
 ) error {
 	r.logger.Info("Detecting extra resources for binding...")
-	for _, cr := range crs {
-		b := NewDetectBindableResources(sbr, cr, []schema.GroupVersionResource{
+	for _, rs := range ([]*RelatedResource)(relatedResources) {
+		b := NewDetectBindableResources(sbr, rs.CR, []schema.GroupVersionResource{
 			{Group: "", Version: "v1", Resource: "configmaps"},
 			{Group: "", Version: "v1", Resource: "services"},
 			{Group: "route.openshift.io", Version: "v1", Resource: "routes"},
@@ -51,36 +51,51 @@ func (r *Retriever) ReadBindableResourcesData(
 			return err
 		}
 		for k, v := range vals {
-			r.storeInto(cr, k, []byte(fmt.Sprintf("%v", v)))
+			r.storeInto(rs.EnvVarPrefix, rs.CR, k, []byte(fmt.Sprintf("%v", v)))
 		}
 	}
+	// for _, cr := range crs {
+	// 	b := NewDetectBindableResources(sbr, cr, []schema.GroupVersionResource{
+	// 		{Group: "", Version: "v1", Resource: "configmaps"},
+	// 		{Group: "", Version: "v1", Resource: "services"},
+	// 		{Group: "route.openshift.io", Version: "v1", Resource: "routes"},
+	// 	}, r.client)
+
+	// 	vals, err := b.GetBindableVariables()
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	for k, v := range vals {
+	// 		r.storeInto(cr, k, []byte(fmt.Sprintf("%v", v)))
+	// 	}
+	// }
 
 	return nil
 }
 
-func (r *Retriever) storeInto(cr *unstructured.Unstructured, key string, value []byte) {
-	r.store(cr, key, value)
+func (r *Retriever) storeInto(envPrefix string, cr *unstructured.Unstructured, key string, value []byte) {
+	r.store(envPrefix, cr, key, value)
 }
 
-func (r *Retriever) copyFrom(id string, u *unstructured.Unstructured, path string, fieldPath string, descriptors []string) error {
-	if err := r.read(id, u, path, fieldPath, descriptors); err != nil {
+func (r *Retriever) copyFrom(id string, envPrefix string, u *unstructured.Unstructured, path string, fieldPath string, descriptors []string) error {
+	if err := r.read(id, envPrefix, u, path, fieldPath, descriptors); err != nil {
 		return err
 	}
 	return nil
 }
 
 // ReadCRDDescriptionData reads data related to given crdDescription
-func (r *Retriever) ReadCRDDescriptionData(id string, u *unstructured.Unstructured, crdDescription *olmv1alpha1.CRDDescription) error {
+func (r *Retriever) ReadCRDDescriptionData(id string, envPrefix string, u *unstructured.Unstructured, crdDescription *olmv1alpha1.CRDDescription) error {
 	r.logger.Info("Looking for spec-descriptors in 'spec'...")
 	for _, specDescriptor := range crdDescription.SpecDescriptors {
-		if err := r.copyFrom(id, u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
+		if err := r.copyFrom(id, envPrefix, u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
 			return err
 		}
 	}
 
 	r.logger.Info("Looking for status-descriptors in 'status'...")
 	for _, statusDescriptor := range crdDescription.StatusDescriptors {
-		if err := r.copyFrom(id, u, "status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
+		if err := r.copyFrom(id, envPrefix, u, "status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -259,21 +259,34 @@ func (r *Retriever) readConfigMap(id string, envPrefix string, cr *unstructured.
 func (r *Retriever) store(envPrefix string, u *unstructured.Unstructured, key string, value []byte) {
 	key = strings.ReplaceAll(key, ":", "_")
 	key = strings.ReplaceAll(key, ".", "_")
-	finalPrefix := ""
-	if r.bindingPrefix != "" {
-		finalPrefix = r.bindingPrefix
-		if envPrefix != "" {
-			finalPrefix = finalPrefix + "_" + envPrefix
+	// finalPrefix := ""
+	// if r.bindingPrefix != "" {
+	// 	finalPrefix = r.bindingPrefix
+	// 	if envPrefix != "" {
+	// 		finalPrefix = finalPrefix + "_" + envPrefix
+	// 	}
+	// } else {
+	// 	if envPrefix != "" {
+	// 		finalPrefix = envPrefix
+	// 	}
+	// }
+	// if finalPrefix == "" {
+	// 	key = fmt.Sprintf("%s_%s", u.GetKind(), key)
+	// } else {
+	// 	key = fmt.Sprintf("%s_%s", finalPrefix, key)
+	// }
+	if envPrefix == "" {
+		if r.bindingPrefix == "" {
+			key = fmt.Sprintf("%s_%s", u.GetKind(), key)
+		} else {
+			key = fmt.Sprintf("%s_%s_%s", r.bindingPrefix, u.GetKind(), key)
 		}
 	} else {
-		if envPrefix != "" {
-			finalPrefix = envPrefix
+		if r.bindingPrefix == "" {
+			key = fmt.Sprintf("%s_%s", envPrefix, key)
+		} else {
+			key = fmt.Sprintf("%s_%s_%s", r.bindingPrefix, envPrefix, key)
 		}
-	}
-	if finalPrefix == "" {
-		// key = fmt.Sprintf("%s_%s", u.GetKind(), key)
-	} else {
-		key = fmt.Sprintf("%s_%s", finalPrefix, key)
 	}
 	key = strings.ToUpper(key)
 	r.data[key] = value

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -259,22 +259,6 @@ func (r *Retriever) readConfigMap(id string, envPrefix string, cr *unstructured.
 func (r *Retriever) store(envPrefix string, u *unstructured.Unstructured, key string, value []byte) {
 	key = strings.ReplaceAll(key, ":", "_")
 	key = strings.ReplaceAll(key, ".", "_")
-	// finalPrefix := ""
-	// if r.bindingPrefix != "" {
-	// 	finalPrefix = r.bindingPrefix
-	// 	if envPrefix != "" {
-	// 		finalPrefix = finalPrefix + "_" + envPrefix
-	// 	}
-	// } else {
-	// 	if envPrefix != "" {
-	// 		finalPrefix = envPrefix
-	// 	}
-	// }
-	// if finalPrefix == "" {
-	// 	key = fmt.Sprintf("%s_%s", u.GetKind(), key)
-	// } else {
-	// 	key = fmt.Sprintf("%s_%s", finalPrefix, key)
-	// }
 	if envPrefix == "" {
 		if r.bindingPrefix == "" {
 			key = fmt.Sprintf("%s_%s", u.GetKind(), key)

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -15,14 +15,14 @@ import (
 
 // Retriever reads all data referred in plan instance, and store in a secret.
 type Retriever struct {
-	logger        *log.Log                     // logger instance
-	data          map[string][]byte            // data retrieved
-	Objects       []*unstructured.Unstructured // list of objects employed
-	client        dynamic.Interface            // Kubernetes API client
-	plan          *Plan                        // plan instance
-	VolumeKeys    []string                     // list of keys found
-	bindingPrefix string                       // prefix for variable names
-	cache         map[string]interface{}       // store visited paths
+	logger        *log.Log                          // logger instance
+	data          map[string][]byte                 // data retrieved
+	Objects       []*unstructured.Unstructured      // list of objects employed
+	client        dynamic.Interface                 // Kubernetes API client
+	plan          *Plan                             // plan instance
+	VolumeKeys    []string                          // list of keys found
+	bindingPrefix string                            // prefix for variable names
+	cache         map[string]map[string]interface{} // store visited paths
 }
 
 const (
@@ -51,7 +51,7 @@ func (r *Retriever) getNestedValue(key string, sectionMap interface{}) (string, 
 }
 
 // getCRKey retrieve key in section from CR object, part of the "plan" instance.
-func (r *Retriever) getCRKey(u *unstructured.Unstructured, section string, key string) (string, interface{}, error) {
+func (r *Retriever) getCRKey(id string, u *unstructured.Unstructured, section string, key string) (string, interface{}, error) {
 	obj := u.Object
 	objName := u.GetName()
 	log := r.logger.WithValues("CR.Name", objName, "CR.section", section, "CR.key", key)
@@ -61,14 +61,17 @@ func (r *Retriever) getCRKey(u *unstructured.Unstructured, section string, key s
 	if !exists {
 		return "", sectionMap, fmt.Errorf("Can't find '%s' section in CR named '%s'", section, objName)
 	}
-
+	crId := getCrId(id, u)
+	if _, ok := r.cache[crId]; !ok {
+		r.cache[crId] = make(map[string]interface{})
+	}
 	log.WithValues("SectionMap", sectionMap).Debug("Getting values from sectionmap")
 	v, _, err := r.getNestedValue(key, sectionMap)
 	for k, v := range sectionMap.(map[string]interface{}) {
-		if _, ok := r.cache[section]; !ok {
-			r.cache[section] = make(map[string]interface{})
+		if _, ok := r.cache[crId][section]; !ok {
+			r.cache[crId][section] = make(map[string]interface{})
 		}
-		r.cache[section].(map[string]interface{})[k] = v
+		r.cache[crId][section].(map[string]interface{})[k] = v
 	}
 	return v, sectionMap, err
 }
@@ -76,7 +79,7 @@ func (r *Retriever) getCRKey(u *unstructured.Unstructured, section string, key s
 // read attributes from CR, where place means which top level key name contains the "path" actual
 // value, and parsing x-descriptors in order to either directly read CR data, or read items from
 // a secret.
-func (r *Retriever) read(cr *unstructured.Unstructured, place, path string, xDescriptors []string) error {
+func (r *Retriever) read(id string, cr *unstructured.Unstructured, place, path string, xDescriptors []string) error {
 	log := r.logger.WithValues(
 		"CR.Section", place,
 		"CRDDescription.Path", path,
@@ -89,29 +92,33 @@ func (r *Retriever) read(cr *unstructured.Unstructured, place, path string, xDes
 
 	// holds the configMap name and items
 	configMaps := make(map[string][]string)
-	pathValue, _, err := r.getCRKey(cr, place, path)
+	pathValue, _, err := r.getCRKey(id, cr, place, path)
 	if err != nil {
 		return err
+	}
+	crId := getCrId(id, cr)
+	if _, ok := r.cache[crId]; !ok {
+		r.cache[crId] = make(map[string]interface{})
 	}
 	for _, xDescriptor := range xDescriptors {
 		log = log.WithValues("CRDDescription.xDescriptor", xDescriptor, "cache", r.cache)
 		log.Debug("Inspecting xDescriptor...")
 
-		if _, ok := r.cache[place].(map[string]interface{}); !ok {
-			r.cache[place] = make(map[string]interface{})
+		if _, ok := r.cache[crId][place].(map[string]interface{}); !ok {
+			r.cache[crId][place] = make(map[string]interface{})
 		}
 		if strings.HasPrefix(xDescriptor, secretPrefix) {
 			secrets[pathValue] = append(secrets[pathValue], r.extractSecretItemName(xDescriptor))
-			if _, ok := r.cache[place].(map[string]interface{})[r.extractSecretItemName(xDescriptor)]; !ok {
-				r.markVisitedPaths(r.extractSecretItemName(xDescriptor), pathValue, place)
-				r.cache[place].(map[string]interface{})[r.extractSecretItemName(xDescriptor)] = make(map[string]interface{})
+			if _, ok := r.cache[crId][place].(map[string]interface{})[r.extractSecretItemName(xDescriptor)]; !ok {
+				r.markVisitedPaths(r.extractSecretItemName(xDescriptor), pathValue, place, crId)
+				r.cache[crId][place].(map[string]interface{})[r.extractSecretItemName(xDescriptor)] = make(map[string]interface{})
 			}
 		} else if strings.HasPrefix(xDescriptor, configMapPrefix) {
 			configMaps[pathValue] = append(configMaps[pathValue], r.extractConfigMapItemName(xDescriptor))
-			r.markVisitedPaths(r.extractConfigMapItemName(xDescriptor), pathValue, place)
+			r.markVisitedPaths(r.extractConfigMapItemName(xDescriptor), pathValue, place, crId)
 		} else if strings.HasPrefix(xDescriptor, volumeMountSecretPrefix) {
 			secrets[pathValue] = append(secrets[pathValue], r.extractSecretItemName(xDescriptor))
-			r.markVisitedPaths(r.extractSecretItemName(xDescriptor), pathValue, place)
+			r.markVisitedPaths(r.extractSecretItemName(xDescriptor), pathValue, place, crId)
 			r.VolumeKeys = append(r.VolumeKeys, pathValue)
 		} else if strings.HasPrefix(xDescriptor, attributePrefix) {
 			r.store(cr, path, []byte(pathValue))
@@ -122,14 +129,14 @@ func (r *Retriever) read(cr *unstructured.Unstructured, place, path string, xDes
 
 	for name, items := range secrets {
 		// loading secret items all-at-once
-		err := r.readSecret(cr, name, items, place, path)
+		err := r.readSecret(id, cr, name, items, place, path)
 		if err != nil {
 			return err
 		}
 	}
 	for name, items := range configMaps {
 		// add the function readConfigMap
-		err := r.readConfigMap(cr, name, items, place, path)
+		err := r.readConfigMap(id, cr, name, items, place, path)
 		if err != nil {
 			return err
 		}
@@ -150,24 +157,24 @@ func (r *Retriever) extractConfigMapItemName(xDescriptor string) string {
 }
 
 // markVisitedPaths updates all visited paths in cache, This initializes the cache map
-func (r *Retriever) markVisitedPaths(name, keyPath, fromPath string) {
-	if _, ok := r.cache[fromPath]; !ok {
-		r.cache[fromPath] = make(map[string]interface{})
+func (r *Retriever) markVisitedPaths(name, keyPath, fromPath, crId string) {
+	if _, ok := r.cache[crId][fromPath]; !ok {
+		r.cache[crId][fromPath] = make(map[string]interface{})
 	}
-	if _, ok := r.cache[fromPath].(map[string]interface{})[name]; !ok {
-		r.cache[fromPath].(map[string]interface{})[name] = make(map[string]interface{})
+	if _, ok := r.cache[crId][fromPath].(map[string]interface{})[name]; !ok {
+		r.cache[crId][fromPath].(map[string]interface{})[name] = make(map[string]interface{})
 	}
-	if _, ok := r.cache[fromPath].(map[string]interface{})[name].(map[string]interface{}); !ok {
-		r.cache[fromPath].(map[string]interface{})[name] = make(map[string]interface{})
+	if _, ok := r.cache[crId][fromPath].(map[string]interface{})[name].(map[string]interface{}); !ok {
+		r.cache[crId][fromPath].(map[string]interface{})[name] = make(map[string]interface{})
 	}
-	if _, ok := r.cache[fromPath].(map[string]interface{})[name].(map[string]interface{})[keyPath]; !ok {
-		r.cache[fromPath].(map[string]interface{})[name].(map[string]interface{})[keyPath] = make(map[string]interface{})
+	if _, ok := r.cache[crId][fromPath].(map[string]interface{})[name].(map[string]interface{})[keyPath]; !ok {
+		r.cache[crId][fromPath].(map[string]interface{})[name].(map[string]interface{})[keyPath] = make(map[string]interface{})
 	}
 }
 
 // readSecret based in secret name and list of items, read a secret from the same namespace informed
 // in plan instance.
-func (r *Retriever) readSecret(cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
+func (r *Retriever) readSecret(id string, cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
 	log := r.logger.WithValues("Secret.Name", name, "Secret.Items", items)
 	log.Debug("Reading secret items...")
 
@@ -184,7 +191,10 @@ func (r *Retriever) readSecret(cr *unstructured.Unstructured, name string, items
 	if !exists {
 		return fmt.Errorf("could not find 'data' in secret")
 	}
-
+	crId := getCrId(id, cr)
+	if _, ok := r.cache[crId]; !ok {
+		r.cache[crId] = make(map[string]interface{})
+	}
 	for k, v := range data {
 		value := v.(string)
 		data, err := base64.StdEncoding.DecodeString(value)
@@ -193,9 +203,9 @@ func (r *Retriever) readSecret(cr *unstructured.Unstructured, name string, items
 		}
 		log = log.WithValues("Secret.Key.Name", k, "Secret.Key.Length", len(data))
 		log.Debug("Inspecting secret key...")
-		r.markVisitedPaths(path, k, fromPath)
+		r.markVisitedPaths(path, k, fromPath, crId)
 		// update cache after reading configmap/secret in cache
-		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = string(data)
+		r.cache[crId][fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = string(data)
 		// making sure key name has a secret reference
 		r.store(cr, fmt.Sprintf("secret_%s", k), data)
 	}
@@ -206,7 +216,7 @@ func (r *Retriever) readSecret(cr *unstructured.Unstructured, name string, items
 
 // readConfigMap based in configMap name and list of items, read a configMap from the same namespace informed
 // in plan instance.
-func (r *Retriever) readConfigMap(cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
+func (r *Retriever) readConfigMap(id string, cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
 	log := r.logger.WithValues("ConfigMap.Name", name, "ConfigMap.Items", items)
 	log.Debug("Reading ConfigMap items...")
 
@@ -215,7 +225,10 @@ func (r *Retriever) readConfigMap(cr *unstructured.Unstructured, name string, it
 	if err != nil {
 		return err
 	}
-
+	crId := getCrId(id, cr)
+	if _, ok := r.cache[crId]; !ok {
+		r.cache[crId] = make(map[string]interface{})
+	}
 	data, exists, err := unstructured.NestedMap(u.Object, []string{"data"}...)
 	if err != nil {
 		return err
@@ -231,9 +244,9 @@ func (r *Retriever) readConfigMap(cr *unstructured.Unstructured, name string, it
 			"configMap.Key.Name", k,
 			"configMap.Key.Length", len(value),
 		)
-		r.markVisitedPaths(path, k, fromPath)
+		r.markVisitedPaths(path, k, fromPath, crId)
 		// update cache after reading configmap/secret in cache
-		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = value
+		r.cache[crId][fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = value
 		// making sure key name has a configMap reference
 		r.store(cr, fmt.Sprintf("configMap_%s", k), []byte(value))
 	}
@@ -254,6 +267,13 @@ func (r *Retriever) store(u *unstructured.Unstructured, key string, value []byte
 	key = strings.ToUpper(key)
 	r.data[key] = value
 }
+func getCrId(id string, cr *unstructured.Unstructured) string {
+	if id != "" {
+		return id
+	} else {
+		return cr.GetName()
+	}
+}
 
 // NewRetriever instantiate a new retriever instance.
 func NewRetriever(client dynamic.Interface, plan *Plan, bindingPrefix string) *Retriever {
@@ -265,6 +285,6 @@ func NewRetriever(client dynamic.Interface, plan *Plan, bindingPrefix string) *R
 		plan:          plan,
 		VolumeKeys:    []string{},
 		bindingPrefix: bindingPrefix,
-		cache:         make(map[string]interface{}),
+		cache:         make(map[string]map[string]interface{}),
 	}
 }

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
-func TestRetriever(t *testing.T) {
+func TestRetrieverWithDifferentCrIds(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	var retriever *Retriever
 
@@ -22,6 +22,10 @@ func TestRetriever(t *testing.T) {
 	f := mocks.NewFake(t, ns)
 	f.AddMockedUnstructuredCSV("csv")
 	f.AddNamespacedMockedSecret("db-credentials", backingServiceNs)
+	f.AddNamespacedMockedSecretWithData("db-credentials", ns, map[string][]byte{
+		"user2":     []byte("user2"),
+		"password2": []byte("password2"),
+	})
 
 	crdDescription := mocks.CRDDescriptionMock()
 	cr, err := mocks.UnstructuredDatabaseCRMock(backingServiceNs, crName)
@@ -66,9 +70,27 @@ func TestRetriever(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		err = retriever.read(crId2, crInSameNamespace, "status", "dbCredentials", []string{
+			"binding:env:object:secret:user2",
+			"binding:env:object:secret:password2",
+		})
+		require.NoError(t, err)
+
+		t.Logf("retriever.cache '%#v'", retriever.cache)
+		require.Contains(t, retriever.cache, "testingCrId1")
+		require.Contains(t, retriever.cache, "testingCrId2")
+		require.Equal(t, len(retriever.cache), 2)
+
 		t.Logf("retriever.data '%#v'", retriever.data)
 		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
 		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER"]), "user")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD"]), "password")
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER2")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER2"]), "user2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD2"]), "password2")
 
 		// reading from spec attribute
 		err = retriever.read(crId1, cr, "spec", "image", []string{
@@ -84,6 +106,13 @@ func TestRetriever(t *testing.T) {
 	t.Run("extractSecretItemName", func(t *testing.T) {
 		require.Equal(t, "user", retriever.extractSecretItemName(
 			"binding:env:object:secret:user"))
+		require.Equal(t, "password", retriever.extractSecretItemName(
+			"binding:env:object:secret:password"))
+
+		require.Equal(t, "user2", retriever.extractSecretItemName(
+			"binding:env:object:secret:user2"))
+		require.Equal(t, "password2", retriever.extractSecretItemName(
+			"binding:env:object:secret:password2"))
 	})
 
 	t.Run("readSecret", func(t *testing.T) {
@@ -94,6 +123,306 @@ func TestRetriever(t *testing.T) {
 
 		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
 		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER"]), "user")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD"]), "password")
+
+		err = retriever.readSecret(crId2, crInSameNamespace, "db-credentials", []string{"user2", "password2"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER2")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER2"]), "user2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD2"]), "password2")
+	})
+
+	t.Run("store", func(t *testing.T) {
+		retriever.store(cr, "test", []byte("test"))
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_TEST")
+		require.Equal(t, []byte("test"), retriever.data["SERVICE_BINDING_DATABASE_TEST"])
+	})
+
+	t.Run("empty prefix", func(t *testing.T) {
+		retriever = NewRetriever(fakeDynClient, plan, "")
+		require.NotNil(t, retriever)
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readSecret(crId1, cr, "db-credentials", []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "DATABASE_SECRET_USER")
+		require.Contains(t, retriever.data, "DATABASE_SECRET_PASSWORD")
+	})
+}
+
+func TestRetrieverWithSameCrId(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	var retriever *Retriever
+
+	ns := "testing"
+	backingServiceNs := "backing-servicec-ns"
+	crName := "db-testing"
+	crId1 := "testingCrId1"
+	crId2 := "testingCrId1"
+
+	f := mocks.NewFake(t, ns)
+	f.AddMockedUnstructuredCSV("csv")
+	f.AddNamespacedMockedSecret("db-credentials", backingServiceNs)
+	f.AddNamespacedMockedSecretWithData("db-credentials", ns, map[string][]byte{
+		"user2":     []byte("user2"),
+		"password2": []byte("password2"),
+	})
+
+	crdDescription := mocks.CRDDescriptionMock()
+	cr, err := mocks.UnstructuredDatabaseCRMock(backingServiceNs, crName)
+	require.NoError(t, err)
+
+	crInSameNamespace, err := mocks.UnstructuredDatabaseCRMock(ns, crName)
+	require.NoError(t, err)
+
+	plan := &Plan{
+		Ns:   ns,
+		Name: "retriever",
+		RelatedResources: []*RelatedResource{
+			{
+				CRDDescription: &crdDescription,
+				CR:             cr,
+				Id:             crId1,
+			},
+			{
+				CRDDescription: &crdDescription,
+				CR:             crInSameNamespace,
+				Id:             crId2,
+			},
+		},
+	}
+
+	fakeDynClient := f.FakeDynClient()
+
+	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
+	require.NotNil(t, retriever)
+
+	t.Run("getCRKey", func(t *testing.T) {
+		imageName, _, err := retriever.getCRKey(crId1, cr, "spec", "imageName")
+		require.NoError(t, err)
+		require.Equal(t, "postgres", imageName)
+	})
+
+	t.Run("read", func(t *testing.T) {
+		// reading from secret, from status attribute
+		err := retriever.read(crId1, cr, "status", "dbCredentials", []string{
+			"binding:env:object:secret:user",
+			"binding:env:object:secret:password",
+		})
+		require.NoError(t, err)
+
+		err = retriever.read(crId2, crInSameNamespace, "status", "dbCredentials", []string{
+			"binding:env:object:secret:user2",
+			"binding:env:object:secret:password2",
+		})
+		require.NoError(t, err)
+		t.Logf("retriever.cache '%#v'", retriever.cache)
+
+		require.Contains(t, retriever.cache, "testingCrId1")
+		require.Equal(t, len(retriever.cache), 1)
+		t.Logf("retriever.data '%#v'", retriever.data)
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER"]), "user")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD"]), "password")
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER2")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER2"]), "user2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD2"]), "password2")
+
+		// reading from spec attribute
+		err = retriever.read(crId1, cr, "spec", "image", []string{
+			"binding:env:attribute",
+		})
+		require.NoError(t, err)
+
+		t.Logf("retriever.data '%#v'", retriever.data)
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_IMAGE")
+
+	})
+
+	t.Run("extractSecretItemName", func(t *testing.T) {
+		require.Equal(t, "user", retriever.extractSecretItemName(
+			"binding:env:object:secret:user"))
+		require.Equal(t, "password", retriever.extractSecretItemName(
+			"binding:env:object:secret:password"))
+
+		require.Equal(t, "user2", retriever.extractSecretItemName(
+			"binding:env:object:secret:user2"))
+		require.Equal(t, "password2", retriever.extractSecretItemName(
+			"binding:env:object:secret:password2"))
+	})
+
+	t.Run("readSecret", func(t *testing.T) {
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readSecret(crId1, cr, "db-credentials", []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER"]), "user")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD"]), "password")
+
+		err = retriever.readSecret(crId2, crInSameNamespace, "db-credentials", []string{"user2", "password2"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER2")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER2"]), "user2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD2"]), "password2")
+	})
+
+	t.Run("store", func(t *testing.T) {
+		retriever.store(cr, "test", []byte("test"))
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_TEST")
+		require.Equal(t, []byte("test"), retriever.data["SERVICE_BINDING_DATABASE_TEST"])
+	})
+
+	t.Run("empty prefix", func(t *testing.T) {
+		retriever = NewRetriever(fakeDynClient, plan, "")
+		require.NotNil(t, retriever)
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readSecret(crId1, cr, "db-credentials", []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "DATABASE_SECRET_USER")
+		require.Contains(t, retriever.data, "DATABASE_SECRET_PASSWORD")
+	})
+}
+
+func TestRetrieverWithEmptyCrId(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	var retriever *Retriever
+
+	ns := "testing"
+	backingServiceNs := "backing-servicec-ns"
+	crName := "db-testing"
+	crName2 := "db-testing2"
+	crId1 := ""
+	crId2 := ""
+
+	f := mocks.NewFake(t, ns)
+	f.AddMockedUnstructuredCSV("csv")
+	f.AddNamespacedMockedSecret("db-credentials", backingServiceNs)
+	f.AddNamespacedMockedSecretWithData("db-credentials", ns, map[string][]byte{
+		"user2":     []byte("user2"),
+		"password2": []byte("password2"),
+	})
+
+	crdDescription := mocks.CRDDescriptionMock()
+	cr, err := mocks.UnstructuredDatabaseCRMock(backingServiceNs, crName)
+	require.NoError(t, err)
+
+	crInSameNamespace, err := mocks.UnstructuredDatabaseCRMock(ns, crName2)
+	require.NoError(t, err)
+
+	plan := &Plan{
+		Ns:   ns,
+		Name: "retriever",
+		RelatedResources: []*RelatedResource{
+			{
+				CRDDescription: &crdDescription,
+				CR:             cr,
+				Id:             crId1,
+			},
+			{
+				CRDDescription: &crdDescription,
+				CR:             crInSameNamespace,
+				Id:             crId2,
+			},
+		},
+	}
+
+	fakeDynClient := f.FakeDynClient()
+
+	retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
+	require.NotNil(t, retriever)
+
+	t.Run("getCRKey", func(t *testing.T) {
+		imageName, _, err := retriever.getCRKey(crId1, cr, "spec", "imageName")
+		require.NoError(t, err)
+		require.Equal(t, "postgres", imageName)
+	})
+
+	t.Run("read", func(t *testing.T) {
+		// reading from secret, from status attribute
+		err := retriever.read(crId1, cr, "status", "dbCredentials", []string{
+			"binding:env:object:secret:user",
+			"binding:env:object:secret:password",
+		})
+		require.NoError(t, err)
+
+		err = retriever.read(crId2, crInSameNamespace, "status", "dbCredentials", []string{
+			"binding:env:object:secret:user2",
+			"binding:env:object:secret:password2",
+		})
+		require.NoError(t, err)
+
+		t.Logf("retriever.cache '%#v'", retriever.cache)
+		require.Contains(t, retriever.cache, "db-testing")
+		require.Contains(t, retriever.cache, "db-testing2")
+		require.Equal(t, len(retriever.cache), 2)
+
+		t.Logf("retriever.data '%#v'", retriever.data)
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER"]), "user")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD"]), "password")
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER2")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER2"]), "user2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD2"]), "password2")
+
+		// reading from spec attribute
+		err = retriever.read(crId1, cr, "spec", "image", []string{
+			"binding:env:attribute",
+		})
+		require.NoError(t, err)
+
+		t.Logf("retriever.data '%#v'", retriever.data)
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_IMAGE")
+
+	})
+
+	t.Run("extractSecretItemName", func(t *testing.T) {
+		require.Equal(t, "user", retriever.extractSecretItemName(
+			"binding:env:object:secret:user"))
+		require.Equal(t, "password", retriever.extractSecretItemName(
+			"binding:env:object:secret:password"))
+
+		require.Equal(t, "user2", retriever.extractSecretItemName(
+			"binding:env:object:secret:user2"))
+		require.Equal(t, "password2", retriever.extractSecretItemName(
+			"binding:env:object:secret:password2"))
+	})
+
+	t.Run("readSecret", func(t *testing.T) {
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readSecret(crId1, cr, "db-credentials", []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER"]), "user")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD"]), "password")
+
+		err = retriever.readSecret(crId2, crInSameNamespace, "db-credentials", []string{"user2", "password2"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER2")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_USER2"]), "user2")
+		require.Equal(t, string(retriever.data["SERVICE_BINDING_DATABASE_SECRET_PASSWORD2"]), "password2")
 	})
 
 	t.Run("store", func(t *testing.T) {

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -192,6 +192,12 @@ func (f *Fake) AddNamespacedMockedSecret(name string, namespace string) {
 	f.objs = append(f.objs, SecretMock(namespace, name))
 }
 
+// AddNamespacedMockedSecretWithData add mocked object from SecretMock in a namespace
+// which isn't necessarily same as that of the ServiceBindingRequest namespace.
+func (f *Fake) AddNamespacedMockedSecretWithData(name string, namespace string, data map[string][]byte) {
+	f.objs = append(f.objs, SecretMockWithData(namespace, name, data))
+}
+
 // AddMockedUnstructuredConfigMap add mocked object from ConfigMapMock.
 func (f *Fake) AddMockedUnstructuredConfigMap(name string) {
 	mock := ConfigMapMock(f.ns, name)

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -369,6 +369,21 @@ func SecretMock(ns, name string) *corev1.Secret {
 	}
 }
 
+// SecretMock returns a Secret based on PostgreSQL operator usage.
+func SecretMockWithData(ns, name string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Data: data,
+	}
+}
+
 // ConfigMapMock returns a dummy config-map object.
 func ConfigMapMock(ns, name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{


### PR DESCRIPTION
### Motivation

1 Current when there are multiple services in backingServiceSelectors, the last service's credential will override all the previous' which need to handle.
2 Sometimes we need a json format custom env var.

### Changes

1 Change retriever.cache from map[string]interface{} to map[string]map[string]interface{} and each backingService has an id to identify itself in the cache.
2 Add a function to_json into custom_env_parser to do the json marshal.

More details can be found in 
https://github.com/redhat-developer/service-binding-operator/issues/396


### Testing

Add the necessary unit tests for it.


```
apiVersion: apps.openshift.io/v1alpha1
kind: ServiceBindingRequest
metadata:
  name: helloworld-binding
spec:
  applicationSelector:
    resourceRef: helloworld
    group: serving.knative.dev
    version: v1
    resource: services
  backingServiceSelectors:
    - group: ibmcloud.ibm.com
      version: v1alpha1
      kind: Binding
      resourceRef: coligo-cos-service-credential
      id: coligo-cos-service-credential
  customEnvVar:
    - name: VCAP_SERVICE
      value: {
          "cloud-object-storage": [
            {
              "credentials": {
                {{to_json coligo-cos-service-credential.status.secretName}} 
              },
              "name": "coligo-cos",
              "plan": "standard"                      
            }
          ]
        }
```