### PR TITLE
Status should be updated when application selector is missing

### DIFF
--- a/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
+++ b/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
@@ -315,7 +315,6 @@ spec:
               description: Secret is the name of the intermediate secret
               type: string
           required:
-          - applications
           - bindingStatus
           - conditions
           - secret

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -59,7 +59,8 @@ type ServiceBindingRequestStatus struct {
 	// Secret is the name of the intermediate secret
 	Secret string `json:"secret"`
 	// ApplicationObjects contains all the application objects filtered by label
-	Applications []BoundApplication `json:"applications"`
+	// +optional
+	Applications []BoundApplication `json:"applications,omitempty"`
 }
 
 // BackingServiceSelector defines the selector based on resource name, version, and resource kind

--- a/pkg/controller/servicebindingrequest/binding_test.go
+++ b/pkg/controller/servicebindingrequest/binding_test.go
@@ -504,7 +504,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 			SBR:                    sbrEmptyAppSelector,
 			Client:                 f.FakeClient(),
 		},
-		wantErr: EmptyApplicationSelectorErr,
+		wantBuildErr: EmptyApplicationSelectorErr,
 		wantConditions: []wantedCondition{
 			{
 				Type:    conditions.BindingReady,

--- a/pkg/controller/servicebindingrequest/planner.go
+++ b/pkg/controller/servicebindingrequest/planner.go
@@ -78,6 +78,12 @@ var EmptyBackingServiceSelectorsErr = errors.New("backing service selectors are 
 // Plan by retrieving the necessary resources related to binding a service backend.
 func (p *Planner) Plan() (*Plan, error) {
 	ns := p.sbr.GetNamespace()
+
+	var emptyApplication v1alpha1.ApplicationSelector
+	if p.sbr.Spec.ApplicationSelector == emptyApplication {
+		return nil, EmptyApplicationSelectorErr
+	}
+
 	var selectors []v1alpha1.BackingServiceSelector
 	if p.sbr.Spec.BackingServiceSelector != nil {
 		selectors = append(selectors, *p.sbr.Spec.BackingServiceSelector)

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -60,6 +60,19 @@ func (f *Fake) AddMockedServiceBindingRequestWithUnannotated(
 	return sbr
 }
 
+// AddMockedUnstructuredServiceBindingRequestWithoutApplication creates a mock ServiceBindingRequest object
+func (f *Fake) AddMockedUnstructuredServiceBindingRequestWithoutApplication(
+	name string,
+	backingServiceResourceRef string,
+) *unstructured.Unstructured {
+	f.S.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.ServiceBindingRequest{})
+	var emptyGVR = schema.GroupVersionResource{}
+	sbr, err := UnstructuredServiceBindingRequestMock(f.ns, name, backingServiceResourceRef, "", emptyGVR, nil)
+	require.NoError(f.t, err)
+	f.objs = append(f.objs, sbr)
+	return sbr
+}
+
 // AddMockedUnstructuredServiceBindingRequest creates a mock ServiceBindingRequest object
 func (f *Fake) AddMockedUnstructuredServiceBindingRequest(
 	name string,


### PR DESCRIPTION
fixes #408 

## Motivation

When `applicationSelector` was missing from SBR, the `status` field would not get updated. This PR fixes this issue.

Sample SBR:

```
apiVersion: apps.openshift.io/v1alpha1
kind: ServiceBindingRequest
metadata:
  name: binding-request
  namespace: sbo-try-1
spec:
  backingServiceSelectors:
        - resourceRef: db-demo
          group: postgresql.baiju.dev
          version: v1alpha1
          kind: Database
```