### PR TITLE
[WIP] Update Generic Binding Status

### DIFF
--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -5,6 +5,10 @@ import (
 )
 
 const (
-	// BindingReady indicates that the binding succeeded
-	BindingReady conditionsv1.ConditionType = "Ready"
+	// CollectionReady indicates readiness for collection and persistance of intermediate manifests
+	CollectionReady conditionsv1.ConditionType = "CollectionReady"
+	// InjectionReady indicates readiness to change application manifests to use those intermediate manifests
+	InjectionReady conditionsv1.ConditionType = "InjectionReady"
+	// BindingReady indicates readiness to bind
+	BindingReady conditionsv1.ConditionType = "BindingReady"
 )

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -154,7 +154,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 			}
 
 			v1.SetStatusCondition(&sbr.Status.Conditions, v1.Condition{
-				Type:    conditions.BindingReady,
+				Type:    conditions.InjectionReady,
 				Status:  corev1.ConditionFalse,
 				Reason:  reason,
 				Message: err.Error(),


### PR DESCRIPTION
### Motivation

To fix  #381 

### Changes

Splits the `BindingReady` type into more specific types:
- CollectionReady which would be related to the collection and persistence of intermediate manifests (secrets, config maps, etc)
- InjectionReady which would be related to change the applications' manifests to use those intermediate manifests:

### How to test

1. Follow the steps given in this [example](https://github.com/redhat-developer/service-binding-operator/tree/master/examples/nodejs_postgresql) to:
- install DB operator, Service Binding Operator
- Import an application
- Create a DB instance 

2. Create the following `ServiceBindingRequest`:

```
apiVersion: apps.openshift.io/v1alpha1
kind: ServiceBindingRequest
metadata:
  name: binding-request
  namespace: service-binding-demo
spec:
 backingServiceSelector:
    group: postgresql.baiju.dev
    version: v1alpha1
    kind: Database
    resourceRef: db-demo
```

3. Use the following command to check if the status has been updated:
`oc get ServiceBindingRequest binding-request -o yaml`

The output should have `status.conditions.type` as 
-  `InjectionReady` with `status: "False"`

```
status:
  conditions:
  - lastHeartbeatTime: 2020-04-23T06:25:16Z
    lastTransitionTime: 2020-04-23T06:25:16Z
    message: application ResourceRef or MatchLabel not found
    reason: EmptyApplicationSelector
    status: "False"
    type: InjectionReady
```

