### PR TITLE
Delete the sbr even when application has been previously deleted 

### DIFF
--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -12,7 +12,6 @@ import (
 
 	"gotest.tools/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
-	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,15 +75,15 @@ func (b *Binder) search() (*unstructured.UnstructuredList, error) {
 
 	objList, err := b.dynClient.Resource(gvr).Namespace(ns).List(opts)
 	if err != nil {
-		return nil, err
+		err1 := errors.New("newfounderr")
+		return nil, err1
+
 	}
 
 	// Return fake NotFound error explicitly to ensure requeue when objList(^) is empty.
 	if len(objList.Items) == 0 {
-		return nil, k8serror.NewNotFound(
-			gvr.GroupResource(),
-			b.sbr.Spec.ApplicationSelector.GroupVersionResource.Resource,
-		)
+		err1 := errors.New("newfounderr")
+		return nil, err1
 	}
 	return objList, err
 }
@@ -529,7 +528,17 @@ func (b *Binder) remove(objs *unstructured.UnstructuredList) error {
 func (b *Binder) Unbind() error {
 	objs, err := b.search()
 	if err != nil {
-		return err
+		// gvr := schema.GroupVersionResource{
+		// 	Group:    b.sbr.Spec.ApplicationSelector.GroupVersionResource.Group,
+		// 	Version:  b.sbr.Spec.ApplicationSelector.GroupVersionResource.Version,
+		// 	Resource: b.sbr.Spec.ApplicationSelector.GroupVersionResource.Resource,
+		// }
+		err1 := errors.New("newfounderr")
+		fmt.Println("WARNINGGGGGGGGGGGGGGG")
+		if err != err1 {
+			return err // the resource selected for deletion was already deleted
+		}
+		return nil
 	}
 	return b.remove(objs)
 }

--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -540,7 +540,10 @@ func (b *Binder) Unbind() error {
 func (b *Binder) Bind() ([]*unstructured.Unstructured, error) {
 	objs, err := b.search()
 	if err != nil {
-		return nil, err
+		if err != ApplicationNotFound {
+			return nil, err
+		}
+		return nil, nil
 	}
 	return b.update(objs)
 }

--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -527,10 +527,10 @@ func (b *Binder) remove(objs *unstructured.UnstructuredList) error {
 func (b *Binder) Unbind() error {
 	objs, err := b.search()
 	if err != nil {
-		if err != ApplicationNotFound {
-			return err
+		if errors.Is(err, ApplicationNotFound) {
+			return nil
 		}
-		return nil
+		return err
 	}
 	return b.remove(objs)
 }
@@ -540,10 +540,10 @@ func (b *Binder) Unbind() error {
 func (b *Binder) Bind() ([]*unstructured.Unstructured, error) {
 	objs, err := b.search()
 	if err != nil {
-		if err != ApplicationNotFound {
-			return nil, err
+		if errors.Is(err, ApplicationNotFound) {
+			return nil, nil
 		}
-		return nil, nil
+		return nil, err
 	}
 	return b.update(objs)
 }

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -114,6 +114,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// fetch and validate namespaced ServiceBindingRequest instance
 	sbr, err := r.getServiceBindingRequest(request.NamespacedName)
 	if err != nil {
+		if err == ApplicationNotFound {
+			logger.Info("SBR deleted after application deletion")
+			return Done()
+		}
 		logger.Error(err, "On retrieving service-binding-request instance.")
 		return DoneOnNotFound(err)
 	}
@@ -149,6 +153,8 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 			var reason string
 			if err == EmptyBackingServiceSelectorsErr {
 				reason = "EmptyBackingServiceSelectors"
+			} else if err == ApplicationNotFound {
+				reason = "ApplicationUnavailable"
 			} else {
 				reason = "EmptyApplicationSelector"
 			}

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -1,6 +1,8 @@
 package servicebindingrequest
 
 import (
+	"errors"
+
 	v1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/redhat-developer/service-binding-operator/pkg/conditions"
 	corev1 "k8s.io/api/core/v1"
@@ -114,7 +116,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// fetch and validate namespaced ServiceBindingRequest instance
 	sbr, err := r.getServiceBindingRequest(request.NamespacedName)
 	if err != nil {
-		if err == ApplicationNotFound {
+		if errors.Is(err, ApplicationNotFound) {
 			logger.Info("SBR deleted after application deletion")
 			return Done()
 		}
@@ -151,9 +153,9 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		if err == EmptyBackingServiceSelectorsErr || err == EmptyApplicationSelectorErr {
 			// TODO: find or create an error type containing suitable information to be propagated
 			var reason string
-			if err == EmptyBackingServiceSelectorsErr {
+			if errors.Is(err, EmptyBackingServiceSelectorsErr) {
 				reason = "EmptyBackingServiceSelectors"
-			} else if err == ApplicationNotFound {
+			} else if errors.Is(err, ApplicationNotFound) {
 				reason = "ApplicationUnavailable"
 			} else {
 				reason = "EmptyApplicationSelector"

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -229,14 +229,14 @@ func TestReconcilerGenericBinding(t *testing.T) {
 	// Reconcile without deployment
 	res, err := reconciler.Reconcile(reconcileRequest())
 	require.NoError(t, err)
-	require.True(t, res.Requeue)
+	require.False(t, res.Requeue)
 
 	namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
 	sbrOutput, err := reconciler.getServiceBindingRequest(namespacedName)
 	require.NoError(t, err)
 
 	require.Equal(t, conditions.BindingReady, sbrOutput.Status.Conditions[0].Type)
-	require.Equal(t, corev1.ConditionFalse, sbrOutput.Status.Conditions[0].Status)
+	require.Equal(t, corev1.ConditionTrue, sbrOutput.Status.Conditions[0].Status)
 	require.Equal(t, 0, len(sbrOutput.Status.Applications))
 
 	// Reconcile with deployment
@@ -347,13 +347,15 @@ func TestEmptyApplicationSelector(t *testing.T) {
 
 	res, err := reconciler.Reconcile(reconcileRequest())
 	require.NoError(t, err)
-	require.True(t, res.Requeue)
+	require.False(t, res.Requeue)
 
 	namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
 	sbrOutput, err := reconciler.getServiceBindingRequest(namespacedName)
 	require.NoError(t, err)
 
 	require.Equal(t, conditions.BindingReady, sbrOutput.Status.Conditions[0].Type)
-	require.Equal(t, corev1.ConditionFalse, sbrOutput.Status.Conditions[0].Status)
+	// Currently the Conditions[0].Status would be true as application's absence won't cause error
+	// TODO New steps to conditions to be introduced - InjectionReady, CollectionReady
+	require.Equal(t, corev1.ConditionTrue, sbrOutput.Status.Conditions[0].Status)
 	require.Equal(t, 0, len(sbrOutput.Status.Applications))
 }


### PR DESCRIPTION
fix #419 
Prerequisites- have an imported app and a database CR
Create a sbr 
```
apiVersion: apps.openshift.io/v1alpha1
kind: ServiceBindingRequest
metadata:
  name: binding-request
  namespace: service-binding-demo
spec:
  applicationSelector:
    resourceRef: nodejs-rest-http-crud-git
    group: apps
    version: v1
    resource: deployments
  backingServiceSelector:
    group: postgresql.baiju.dev
    version: v1alpha1
    kind: Database
    resourceRef: db-demo
```
Now delete the imported app.
Now delete the sbr instance
`oc delete sbr binding-request -n=service-binding-demo`

The sbr will get deleted and will not error out on the unavailability of the deleted app