### PR TITLE
Add an envVarPrefix field to backingServiceSelector

### DIFF
--- a/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
+++ b/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
@@ -114,6 +114,8 @@ spec:
                   type: string
                 version:
                   type: string
+                envVarPrefix:
+                  type: string
               required:
               - group
               - kind
@@ -137,6 +139,8 @@ spec:
                   resourceRef:
                     type: string
                   version:
+                    type: string
+                  envVarPrefix:
                     type: string
                 required:
                 - group

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -66,7 +66,8 @@ type BackingServiceSelector struct {
 	metav1.GroupVersionKind `json:",inline"`
 	ResourceRef             string `json:"resourceRef"`
 	// +optional
-	Namespace *string `json:"namespace,omitempty"`
+	Namespace    *string `json:"namespace,omitempty"`
+	EnvVarPrefix string  `json:"envVarPrefix,omitempty"`
 }
 
 // BoundApplication defines the application workloads to which the binding secret has

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -67,7 +67,7 @@ type BackingServiceSelector struct {
 	ResourceRef             string `json:"resourceRef"`
 	// +optional
 	Namespace    *string `json:"namespace,omitempty"`
-	EnvVarPrefix string  `json:"envVarPrefix,omitempty"`
+	EnvVarPrefix *string `json:"envVarPrefix,omitempty"`
 }
 
 // BoundApplication defines the application workloads to which the binding secret has

--- a/pkg/controller/servicebindingrequest/binding.go
+++ b/pkg/controller/servicebindingrequest/binding.go
@@ -328,7 +328,7 @@ func BuildServiceBinder(options *ServiceBinderOptions) (*ServiceBinder, error) {
 
 	// read bindable data from the specified resources
 	if options.DetectBindingResources {
-		err := retriever.ReadBindableResourcesData(&plan.SBR, rs)
+		err := retriever.ReadBindableResourcesData(&plan.SBR, plan.GetRelatedResources())
 		if err != nil {
 			return nil, err
 		}
@@ -336,7 +336,7 @@ func BuildServiceBinder(options *ServiceBinderOptions) (*ServiceBinder, error) {
 
 	// read bindable data from the CRDDescription found by the planner
 	for _, r := range plan.GetRelatedResources() {
-		err = retriever.ReadCRDDescriptionData(r.CR, r.CRDDescription)
+		err = retriever.ReadCRDDescriptionData(r.EnvVarPrefix, r.CR, r.CRDDescription)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/servicebindingrequest/planner.go
+++ b/pkg/controller/servicebindingrequest/planner.go
@@ -149,6 +149,7 @@ func (p *Planner) Plan() (*Plan, error) {
 		r := &RelatedResource{
 			CRDDescription: crdDescription,
 			CR:             cr,
+			EnvVarPrefix:   s.EnvVarPrefix,
 		}
 		relatedResources = append(relatedResources, r)
 		p.logger.Debug("Resolved related resource", "RelatedResource", r)

--- a/pkg/controller/servicebindingrequest/related_resources.go
+++ b/pkg/controller/servicebindingrequest/related_resources.go
@@ -9,6 +9,7 @@ import (
 type RelatedResource struct {
 	CRDDescription *v1alpha1.CRDDescription
 	CR             *unstructured.Unstructured
+	EnvVarPrefix   string
 }
 
 // RelatedResources contains a collection of SBR related resources.

--- a/pkg/controller/servicebindingrequest/related_resources.go
+++ b/pkg/controller/servicebindingrequest/related_resources.go
@@ -9,7 +9,7 @@ import (
 type RelatedResource struct {
 	CRDDescription *v1alpha1.CRDDescription
 	CR             *unstructured.Unstructured
-	EnvVarPrefix   string
+	EnvVarPrefix   *string
 }
 
 // RelatedResources contains a collection of SBR related resources.

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -36,11 +36,11 @@ func (r *Retriever) Get() (map[string][]byte, error) {
 // ReadBindableResourcesData reads all related resources of a given sbr
 func (r *Retriever) ReadBindableResourcesData(
 	sbr *v1alpha1.ServiceBindingRequest,
-	crs []*unstructured.Unstructured,
+	relatedResources RelatedResources,
 ) error {
 	r.logger.Info("Detecting extra resources for binding...")
-	for _, cr := range crs {
-		b := NewDetectBindableResources(sbr, cr, []schema.GroupVersionResource{
+	for _, rs := range ([]*RelatedResource)(relatedResources) {
+		b := NewDetectBindableResources(sbr, rs.CR, []schema.GroupVersionResource{
 			{Group: "", Version: "v1", Resource: "configmaps"},
 			{Group: "", Version: "v1", Resource: "services"},
 			{Group: "route.openshift.io", Version: "v1", Resource: "routes"},
@@ -51,36 +51,36 @@ func (r *Retriever) ReadBindableResourcesData(
 			return err
 		}
 		for k, v := range vals {
-			r.storeInto(cr, k, []byte(fmt.Sprintf("%v", v)))
+			r.storeInto(rs.EnvVarPrefix, rs.CR, k, []byte(fmt.Sprintf("%v", v)))
 		}
 	}
 
 	return nil
 }
 
-func (r *Retriever) storeInto(cr *unstructured.Unstructured, key string, value []byte) {
-	r.store(cr, key, value)
+func (r *Retriever) storeInto(envPrefix string, cr *unstructured.Unstructured, key string, value []byte) {
+	r.store(envPrefix, cr, key, value)
 }
 
-func (r *Retriever) copyFrom(u *unstructured.Unstructured, path string, fieldPath string, descriptors []string) error {
-	if err := r.read(u, path, fieldPath, descriptors); err != nil {
+func (r *Retriever) copyFrom(envPrefix string, u *unstructured.Unstructured, path string, fieldPath string, descriptors []string) error {
+	if err := r.read(envPrefix, u, path, fieldPath, descriptors); err != nil {
 		return err
 	}
 	return nil
 }
 
 // ReadCRDDescriptionData reads data related to given crdDescription
-func (r *Retriever) ReadCRDDescriptionData(u *unstructured.Unstructured, crdDescription *olmv1alpha1.CRDDescription) error {
+func (r *Retriever) ReadCRDDescriptionData(envPrefix string, u *unstructured.Unstructured, crdDescription *olmv1alpha1.CRDDescription) error {
 	r.logger.Info("Looking for spec-descriptors in 'spec'...")
 	for _, specDescriptor := range crdDescription.SpecDescriptors {
-		if err := r.copyFrom(u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
+		if err := r.copyFrom(envPrefix, u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
 			return err
 		}
 	}
 
 	r.logger.Info("Looking for status-descriptors in 'status'...")
 	for _, statusDescriptor := range crdDescription.StatusDescriptors {
-		if err := r.copyFrom(u, "status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
+		if err := r.copyFrom(envPrefix, u, "status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/servicebindingrequest/retrieve_decoupled.go
+++ b/pkg/controller/servicebindingrequest/retrieve_decoupled.go
@@ -58,29 +58,29 @@ func (r *Retriever) ReadBindableResourcesData(
 	return nil
 }
 
-func (r *Retriever) storeInto(envPrefix string, cr *unstructured.Unstructured, key string, value []byte) {
-	r.store(envPrefix, cr, key, value)
+func (r *Retriever) storeInto(envVarPrefix *string, cr *unstructured.Unstructured, key string, value []byte) {
+	r.store(envVarPrefix, cr, key, value)
 }
 
-func (r *Retriever) copyFrom(envPrefix string, u *unstructured.Unstructured, path string, fieldPath string, descriptors []string) error {
-	if err := r.read(envPrefix, u, path, fieldPath, descriptors); err != nil {
+func (r *Retriever) copyFrom(envVarPrefix *string, u *unstructured.Unstructured, path string, fieldPath string, descriptors []string) error {
+	if err := r.read(envVarPrefix, u, path, fieldPath, descriptors); err != nil {
 		return err
 	}
 	return nil
 }
 
 // ReadCRDDescriptionData reads data related to given crdDescription
-func (r *Retriever) ReadCRDDescriptionData(envPrefix string, u *unstructured.Unstructured, crdDescription *olmv1alpha1.CRDDescription) error {
+func (r *Retriever) ReadCRDDescriptionData(envVarPrefix *string, u *unstructured.Unstructured, crdDescription *olmv1alpha1.CRDDescription) error {
 	r.logger.Info("Looking for spec-descriptors in 'spec'...")
 	for _, specDescriptor := range crdDescription.SpecDescriptors {
-		if err := r.copyFrom(envPrefix, u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
+		if err := r.copyFrom(envVarPrefix, u, "spec", specDescriptor.Path, specDescriptor.XDescriptors); err != nil {
 			return err
 		}
 	}
 
 	r.logger.Info("Looking for status-descriptors in 'status'...")
 	for _, statusDescriptor := range crdDescription.StatusDescriptors {
-		if err := r.copyFrom(envPrefix, u, "status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
+		if err := r.copyFrom(envVarPrefix, u, "status", statusDescriptor.Path, statusDescriptor.XDescriptors); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -76,7 +76,7 @@ func (r *Retriever) getCRKey(u *unstructured.Unstructured, section string, key s
 // read attributes from CR, where place means which top level key name contains the "path" actual
 // value, and parsing x-descriptors in order to either directly read CR data, or read items from
 // a secret.
-func (r *Retriever) read(envPrefix string, cr *unstructured.Unstructured, place, path string, xDescriptors []string) error {
+func (r *Retriever) read(envVarPrefix *string, cr *unstructured.Unstructured, place, path string, xDescriptors []string) error {
 	log := r.logger.WithValues(
 		"CR.Section", place,
 		"CRDDescription.Path", path,
@@ -114,7 +114,7 @@ func (r *Retriever) read(envPrefix string, cr *unstructured.Unstructured, place,
 			r.markVisitedPaths(r.extractSecretItemName(xDescriptor), pathValue, place)
 			r.VolumeKeys = append(r.VolumeKeys, pathValue)
 		} else if strings.HasPrefix(xDescriptor, attributePrefix) {
-			r.store(envPrefix, cr, path, []byte(pathValue))
+			r.store(envVarPrefix, cr, path, []byte(pathValue))
 		} else {
 			log.Debug("Defaulting....")
 		}
@@ -122,14 +122,14 @@ func (r *Retriever) read(envPrefix string, cr *unstructured.Unstructured, place,
 
 	for name, items := range secrets {
 		// loading secret items all-at-once
-		err := r.readSecret(envPrefix, cr, name, items, place, path)
+		err := r.readSecret(envVarPrefix, cr, name, items, place, path)
 		if err != nil {
 			return err
 		}
 	}
 	for name, items := range configMaps {
 		// add the function readConfigMap
-		err := r.readConfigMap(envPrefix, cr, name, items, place, path)
+		err := r.readConfigMap(envVarPrefix, cr, name, items, place, path)
 		if err != nil {
 			return err
 		}
@@ -167,7 +167,7 @@ func (r *Retriever) markVisitedPaths(name, keyPath, fromPath string) {
 
 // readSecret based in secret name and list of items, read a secret from the same namespace informed
 // in plan instance.
-func (r *Retriever) readSecret(envPrefix string, cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
+func (r *Retriever) readSecret(envVarPrefix *string, cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
 	log := r.logger.WithValues("Secret.Name", name, "Secret.Items", items)
 	log.Debug("Reading secret items...")
 
@@ -197,7 +197,7 @@ func (r *Retriever) readSecret(envPrefix string, cr *unstructured.Unstructured, 
 		// update cache after reading configmap/secret in cache
 		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = string(data)
 		// making sure key name has a secret reference
-		r.store(envPrefix, cr, fmt.Sprintf("secret_%s", k), data)
+		r.store(envVarPrefix, cr, fmt.Sprintf("secret_%s", k), data)
 	}
 
 	r.Objects = append(r.Objects, secret)
@@ -206,7 +206,7 @@ func (r *Retriever) readSecret(envPrefix string, cr *unstructured.Unstructured, 
 
 // readConfigMap based in configMap name and list of items, read a configMap from the same namespace informed
 // in plan instance.
-func (r *Retriever) readConfigMap(envPrefix string, cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
+func (r *Retriever) readConfigMap(envVarPrefix *string, cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
 	log := r.logger.WithValues("ConfigMap.Name", name, "ConfigMap.Items", items)
 	log.Debug("Reading ConfigMap items...")
 
@@ -235,7 +235,7 @@ func (r *Retriever) readConfigMap(envPrefix string, cr *unstructured.Unstructure
 		// update cache after reading configmap/secret in cache
 		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = value
 		// making sure key name has a configMap reference
-		r.store(envPrefix, cr, fmt.Sprintf("configMap_%s", k), []byte(value))
+		r.store(envVarPrefix, cr, fmt.Sprintf("configMap_%s", k), []byte(value))
 	}
 
 	r.Objects = append(r.Objects, u)
@@ -243,20 +243,24 @@ func (r *Retriever) readConfigMap(envPrefix string, cr *unstructured.Unstructure
 }
 
 // store key and value, formatting key to look like an environment variable.
-func (r *Retriever) store(envPrefix string, u *unstructured.Unstructured, key string, value []byte) {
+func (r *Retriever) store(envVarPrefix *string, u *unstructured.Unstructured, key string, value []byte) {
 	key = strings.ReplaceAll(key, ":", "_")
 	key = strings.ReplaceAll(key, ".", "_")
-	if envPrefix == "" {
+	if envVarPrefix == nil {
 		if r.bindingPrefix == "" {
 			key = fmt.Sprintf("%s_%s", u.GetKind(), key)
 		} else {
 			key = fmt.Sprintf("%s_%s_%s", r.bindingPrefix, u.GetKind(), key)
 		}
+	} else if *envVarPrefix == "" {
+		if r.bindingPrefix != "" {
+			key = fmt.Sprintf("%s_%s", r.bindingPrefix, key)
+		}
 	} else {
-		if r.bindingPrefix == "" {
-			key = fmt.Sprintf("%s_%s", envPrefix, key)
+		if r.bindingPrefix != "" {
+			key = fmt.Sprintf("%s_%s_%s", r.bindingPrefix, *envVarPrefix, key)
 		} else {
-			key = fmt.Sprintf("%s_%s_%s", r.bindingPrefix, envPrefix, key)
+			key = fmt.Sprintf("%s_%s", *envVarPrefix, key)
 		}
 	}
 	key = strings.ToUpper(key)

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -76,7 +76,7 @@ func (r *Retriever) getCRKey(u *unstructured.Unstructured, section string, key s
 // read attributes from CR, where place means which top level key name contains the "path" actual
 // value, and parsing x-descriptors in order to either directly read CR data, or read items from
 // a secret.
-func (r *Retriever) read(cr *unstructured.Unstructured, place, path string, xDescriptors []string) error {
+func (r *Retriever) read(envPrefix string, cr *unstructured.Unstructured, place, path string, xDescriptors []string) error {
 	log := r.logger.WithValues(
 		"CR.Section", place,
 		"CRDDescription.Path", path,
@@ -114,7 +114,7 @@ func (r *Retriever) read(cr *unstructured.Unstructured, place, path string, xDes
 			r.markVisitedPaths(r.extractSecretItemName(xDescriptor), pathValue, place)
 			r.VolumeKeys = append(r.VolumeKeys, pathValue)
 		} else if strings.HasPrefix(xDescriptor, attributePrefix) {
-			r.store(cr, path, []byte(pathValue))
+			r.store(envPrefix, cr, path, []byte(pathValue))
 		} else {
 			log.Debug("Defaulting....")
 		}
@@ -122,14 +122,14 @@ func (r *Retriever) read(cr *unstructured.Unstructured, place, path string, xDes
 
 	for name, items := range secrets {
 		// loading secret items all-at-once
-		err := r.readSecret(cr, name, items, place, path)
+		err := r.readSecret(envPrefix, cr, name, items, place, path)
 		if err != nil {
 			return err
 		}
 	}
 	for name, items := range configMaps {
 		// add the function readConfigMap
-		err := r.readConfigMap(cr, name, items, place, path)
+		err := r.readConfigMap(envPrefix, cr, name, items, place, path)
 		if err != nil {
 			return err
 		}
@@ -167,7 +167,7 @@ func (r *Retriever) markVisitedPaths(name, keyPath, fromPath string) {
 
 // readSecret based in secret name and list of items, read a secret from the same namespace informed
 // in plan instance.
-func (r *Retriever) readSecret(cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
+func (r *Retriever) readSecret(envPrefix string, cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
 	log := r.logger.WithValues("Secret.Name", name, "Secret.Items", items)
 	log.Debug("Reading secret items...")
 
@@ -197,7 +197,7 @@ func (r *Retriever) readSecret(cr *unstructured.Unstructured, name string, items
 		// update cache after reading configmap/secret in cache
 		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = string(data)
 		// making sure key name has a secret reference
-		r.store(cr, fmt.Sprintf("secret_%s", k), data)
+		r.store(envPrefix, cr, fmt.Sprintf("secret_%s", k), data)
 	}
 
 	r.Objects = append(r.Objects, secret)
@@ -206,7 +206,7 @@ func (r *Retriever) readSecret(cr *unstructured.Unstructured, name string, items
 
 // readConfigMap based in configMap name and list of items, read a configMap from the same namespace informed
 // in plan instance.
-func (r *Retriever) readConfigMap(cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
+func (r *Retriever) readConfigMap(envPrefix string, cr *unstructured.Unstructured, name string, items []string, fromPath string, path string) error {
 	log := r.logger.WithValues("ConfigMap.Name", name, "ConfigMap.Items", items)
 	log.Debug("Reading ConfigMap items...")
 
@@ -235,7 +235,7 @@ func (r *Retriever) readConfigMap(cr *unstructured.Unstructured, name string, it
 		// update cache after reading configmap/secret in cache
 		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = value
 		// making sure key name has a configMap reference
-		r.store(cr, fmt.Sprintf("configMap_%s", k), []byte(value))
+		r.store(envPrefix, cr, fmt.Sprintf("configMap_%s", k), []byte(value))
 	}
 
 	r.Objects = append(r.Objects, u)
@@ -243,13 +243,21 @@ func (r *Retriever) readConfigMap(cr *unstructured.Unstructured, name string, it
 }
 
 // store key and value, formatting key to look like an environment variable.
-func (r *Retriever) store(u *unstructured.Unstructured, key string, value []byte) {
+func (r *Retriever) store(envPrefix string, u *unstructured.Unstructured, key string, value []byte) {
 	key = strings.ReplaceAll(key, ":", "_")
 	key = strings.ReplaceAll(key, ".", "_")
-	if r.bindingPrefix == "" {
-		key = fmt.Sprintf("%s_%s", u.GetKind(), key)
+	if envPrefix == "" {
+		if r.bindingPrefix == "" {
+			key = fmt.Sprintf("%s_%s", u.GetKind(), key)
+		} else {
+			key = fmt.Sprintf("%s_%s_%s", r.bindingPrefix, u.GetKind(), key)
+		}
 	} else {
-		key = fmt.Sprintf("%s_%s_%s", r.bindingPrefix, u.GetKind(), key)
+		if r.bindingPrefix == "" {
+			key = fmt.Sprintf("%s_%s", envPrefix, key)
+		} else {
+			key = fmt.Sprintf("%s_%s_%s", r.bindingPrefix, envPrefix, key)
+		}
 	}
 	key = strings.ToUpper(key)
 	r.data[key] = value

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -197,7 +197,13 @@ func (r *Retriever) readSecret(envVarPrefix *string, cr *unstructured.Unstructur
 		// update cache after reading configmap/secret in cache
 		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = string(data)
 		// making sure key name has a secret reference
-		r.store(envVarPrefix, cr, fmt.Sprintf("secret_%s", k), data)
+		if envVarPrefix != nil && *envVarPrefix == "" {
+			r.store(envVarPrefix, cr, k, data)
+
+		} else {
+			r.store(envVarPrefix, cr, fmt.Sprintf("secret_%s", k), data)
+
+		}
 	}
 
 	r.Objects = append(r.Objects, secret)
@@ -235,7 +241,11 @@ func (r *Retriever) readConfigMap(envVarPrefix *string, cr *unstructured.Unstruc
 		// update cache after reading configmap/secret in cache
 		r.cache[fromPath].(map[string]interface{})[path].(map[string]interface{})[k] = value
 		// making sure key name has a configMap reference
-		r.store(envVarPrefix, cr, fmt.Sprintf("configMap_%s", k), []byte(value))
+		if envVarPrefix != nil && *envVarPrefix == "" {
+			r.store(envVarPrefix, cr, k, []byte(value))
+		} else {
+			r.store(envVarPrefix, cr, fmt.Sprintf("configMap_%s", k), []byte(value))
+		}
 	}
 
 	r.Objects = append(r.Objects, u)

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -142,8 +142,8 @@ func TestRetriever(t *testing.T) {
 		err := retriever.readSecret(&emptyEnvVarPrefix, cr, "db-credentials", []string{"user", "password"}, "spec", "dbConfigMap")
 		require.NoError(t, err)
 
-		require.Contains(t, retriever.data, "SERVICE_BINDING_SECRET_USER")
-		require.Contains(t, retriever.data, "SERVICE_BINDING_SECRET_PASSWORD")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_PASSWORD")
 	})
 	t.Run("empty SBR prefix and non-empty service prefix", func(t *testing.T) {
 		retriever = NewRetriever(fakeDynClient, plan, "")
@@ -164,8 +164,8 @@ func TestRetriever(t *testing.T) {
 		err := retriever.readSecret(&emptyEnvVarPrefix, cr, "db-credentials", []string{"user", "password"}, "spec", "dbConfigMap")
 		require.NoError(t, err)
 
-		require.Contains(t, retriever.data, "SECRET_USER")
-		require.Contains(t, retriever.data, "SECRET_PASSWORD")
+		require.Contains(t, retriever.data, "USER")
+		require.Contains(t, retriever.data, "PASSWORD")
 	})
 }
 
@@ -227,6 +227,7 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 	ns := "testing"
 	crName := "db-testing"
 	testEnvVarPrefix := "TEST_PREFIX"
+	emptyEnvVarPrefix := ""
 
 	f := mocks.NewFake(t, ns)
 	f.AddMockedUnstructuredCSV("csv")
@@ -280,5 +281,73 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 
 		require.Contains(t, retriever.data, ("SERVICE_BINDING_TEST_PREFIX_CONFIGMAP_USER"))
 		require.Contains(t, retriever.data, ("SERVICE_BINDING_TEST_PREFIX_CONFIGMAP_PASSWORD"))
+	})
+
+	t.Run("non-empty SBR prefix and nil service prefix", func(t *testing.T) {
+		retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
+		require.NotNil(t, retriever)
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readConfigMap(nil, cr, crName, []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_CONFIGMAP_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_CONFIGMAP_PASSWORD")
+	})
+	t.Run("empty SBR prefix and nil service prefix", func(t *testing.T) {
+		retriever = NewRetriever(fakeDynClient, plan, "")
+		require.NotNil(t, retriever)
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readConfigMap(nil, cr, crName, []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "DATABASE_CONFIGMAP_USER")
+		require.Contains(t, retriever.data, "DATABASE_CONFIGMAP_PASSWORD")
+	})
+
+	t.Run("non-empty SBR prefix and non-empty service prefix", func(t *testing.T) {
+		retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
+		require.NotNil(t, retriever)
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readConfigMap(&testEnvVarPrefix, cr, crName, []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_TEST_PREFIX_CONFIGMAP_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_TEST_PREFIX_CONFIGMAP_PASSWORD")
+	})
+	t.Run("non-empty SBR prefix and empty service prefix", func(t *testing.T) {
+		retriever = NewRetriever(fakeDynClient, plan, "SERVICE_BINDING")
+		require.NotNil(t, retriever)
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readConfigMap(&emptyEnvVarPrefix, cr, crName, []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "SERVICE_BINDING_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_PASSWORD")
+	})
+	t.Run("empty SBR prefix and non-empty service prefix", func(t *testing.T) {
+		retriever = NewRetriever(fakeDynClient, plan, "")
+		require.NotNil(t, retriever)
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readConfigMap(&testEnvVarPrefix, cr, crName, []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "TEST_PREFIX_CONFIGMAP_USER")
+		require.Contains(t, retriever.data, "TEST_PREFIX_CONFIGMAP_PASSWORD")
+	})
+	t.Run("empty SBR prefix and empty service prefix", func(t *testing.T) {
+		retriever = NewRetriever(fakeDynClient, plan, "")
+		require.NotNil(t, retriever)
+		retriever.data = make(map[string][]byte)
+
+		err := retriever.readConfigMap(&emptyEnvVarPrefix, cr, crName, []string{"user", "password"}, "spec", "dbConfigMap")
+		require.NoError(t, err)
+
+		require.Contains(t, retriever.data, "USER")
+		require.Contains(t, retriever.data, "PASSWORD")
 	})
 }


### PR DESCRIPTION
### Motivation

According to issue https://github.com/redhat-developer/service-binding-operator/issues/387, an envVarPrefix will be added to backingServiceSelector to support multiple service binding as below shows:

  ```
backingServiceSelectors:
    - group: groupname
      version: v1alpha1
      kind: Binding
      resourceRef: resourceName
      envVarPrefix: testprefix
```

### Changes

Add a field envVarPrefix.

