### PR TITLE
fixes generic binding

### DIFF
--- a/pkg/controller/servicebindingrequest/binding_test.go
+++ b/pkg/controller/servicebindingrequest/binding_test.go
@@ -545,7 +545,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 			SBR:                    sbrEmptyAppSelector,
 			Client:                 f.FakeClient(),
 		},
-		wantBuildErr: EmptyApplicationSelectorErr,
+		wantErr: EmptyApplicationSelectorErr,
 		wantConditions: []wantedCondition{
 			{
 				Type:    conditions.BindingReady,

--- a/pkg/controller/servicebindingrequest/planner.go
+++ b/pkg/controller/servicebindingrequest/planner.go
@@ -79,11 +79,6 @@ var EmptyBackingServiceSelectorsErr = errors.New("backing service selectors are 
 func (p *Planner) Plan() (*Plan, error) {
 	ns := p.sbr.GetNamespace()
 
-	var emptyApplication v1alpha1.ApplicationSelector
-	if p.sbr.Spec.ApplicationSelector == emptyApplication {
-		return nil, EmptyApplicationSelectorErr
-	}
-
 	var selectors []v1alpha1.BackingServiceSelector
 	if p.sbr.Spec.BackingServiceSelector != nil {
 		selectors = append(selectors, *p.sbr.Spec.BackingServiceSelector)


### PR DESCRIPTION
### Motivation

- Fixes generic binding bug
- Refer -> https://github.com/redhat-developer/service-binding-operator/pull/414/files#r407707455

### Changes

- Reverts some changes introduced in this PR ->  https://github.com/redhat-developer/service-binding-operator/pull/414

### How to test

1. Follow the steps given in this [example](https://github.com/redhat-developer/service-binding-operator/tree/master/examples/nodejs_postgresql) to:
- install DB operator, Service Binding Operator
- Import an application
- Create a DB instance 

2. Create the following `ServiceBindingRequest`:

```
apiVersion: apps.openshift.io/v1alpha1
kind: ServiceBindingRequest
metadata:
  name: binding-request
  namespace: service-binding-demo
spec:
 backingServiceSelector:
    group: postgresql.baiju.dev
    version: v1alpha1
    kind: Database
    resourceRef: db-demo
```

3. Use the following command to check if the binding secret has been generated:
`oc get ServiceBindingRequest binding-request -o yaml`

The output should have:

```
  secret: binding-request
```