### PR TITLE
Add a choice of installing SBO either from community or master in examples

### DIFF
--- a/examples/commons.mk
+++ b/examples/commons.mk
@@ -82,23 +82,55 @@ help: ## Credit: https://gist.github.com/prwhite/8168133#gistcomment-2749866
 
 ## --- Service Binding Operator ---
 
-.PHONY: install-service-binding-operator-subscription
+## ---- Community version ----
+
+.PHONY: install-service-binding-operator-subscription-community
 ## Install the Service Binding Operator Subscription
-install-service-binding-operator-subscription:
-	${Q}${EC} install_service_binding_operator_subscription
+install-service-binding-operator-subscription-community:
+	${Q}${EC} install_service_binding_operator_subscription_community
 
-.PHONY: install-service-binding-operator
+.PHONY: install-service-binding-operator-community
 ## Install the Service Binding Operator
-install-service-binding-operator: install-service-binding-operator-subscription
+install-service-binding-operator-community: install-service-binding-operator-subscription-community
 
-.PHONY: uninstall-service-binding-operator-subscription
+.PHONY: uninstall-service-binding-operator-subscription-community
 ## Uninstall the Service Binding Operator Subscription
-uninstall-service-binding-operator-subscription:
-	${Q}${EC} uninstall_service_binding_operator_subscription
+uninstall-service-binding-operator-subscription-community:
+	${Q}${EC} uninstall_service_binding_operator_subscription_community
 
-.PHONY: uninstall-service-binding-operator
+.PHONY: uninstall-service-binding-operator-community
 ## Uninstall the Service Binding Operator
-uninstall-service-binding-operator: uninstall-service-binding-operator-subscription
+uninstall-service-binding-operator-community: uninstall-service-binding-operator-subscription-community
+
+## ---- Latest master ----
+
+.PHONY: install-service-binding-operator-source-master
+## Install the Service Binding Operator Source for latest master
+install-service-binding-operator-source-master:
+	${Q}${EC} install_service_binding_operator_source_master
+
+.PHONY: uninstall-service-binding-operator-source-master
+## Uninstall the Service Binding Operator Source for latest master
+uninstall-service-binding-operator-source-master:
+	${Q}${EC} uninstall_service_binding_operator_source_master
+
+.PHONY: install-service-binding-operator-subscription-master
+## Install the Service Binding Operator Subscription for latest master
+install-service-binding-operator-subscription-master:
+	${Q}${EC} install_service_binding_operator_subscription_master
+
+.PHONY: install-service-binding-operator-master
+## Install the Service Binding Operator for latest master
+install-service-binding-operator-master: install-service-binding-operator-source-master install-service-binding-operator-subscription-master
+
+.PHONY: uninstall-service-binding-operator-subscription-master
+## Uninstall the Service Binding Operator Subscription for latest master
+uninstall-service-binding-operator-subscription-master:
+	${Q}${EC} uninstall_service_binding_operator_subscription_master
+
+.PHONY: uninstall-service-binding-operator-master
+## Uninstall the Service Binding Operator for latest master
+uninstall-service-binding-operator-master: uninstall-service-binding-operator-subscription-master uninstall-service-binding-operator-source-master
 
 ## --- Backing Service DB (PostgreSQL) Operator ---
 

--- a/examples/java_postgresql_customvar/README.md
+++ b/examples/java_postgresql_customvar/README.md
@@ -33,15 +33,46 @@ Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 
-and install a `alpha` version.
+and install the `alpha` version.
 
-Alternatively, you can perform the same task with this make command:
+Alternatively, you can perform the same task manually using the following command:
 
 ``` shell
 make install-service-binding-operator-community
 ```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
+
+##### :bulb: Latest `master` version of the operator
+
+It is also possible to install the latest `master` version of the operator instead of the one from `community-operators`. To enable that an `OperatorSource` has to be installed with the latest `master` version:
+
+``` shell
+cat <<EOS | kubectl apply -f -
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: redhat-developer-operators
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: redhat-developer
+EOS
+```
+
+Alternatively, you can perform the same task manually using the following command before going to the Operator Hub:
+
+``` shell
+make install-service-binding-operator-source-master
+```
+
+or running the following command to install the operator completely:
+
+``` shell
+make install-service-binding-operator-master
+```
 
 #### Install the DB operator using an `OperatorSource`
 

--- a/examples/java_postgresql_customvar/README.md
+++ b/examples/java_postgresql_customvar/README.md
@@ -38,7 +38,7 @@ and install a `alpha` version.
 Alternatively, you can perform the same task with this make command:
 
 ``` shell
-make install-service-binding-operator
+make install-service-binding-operator-community
 ```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.

--- a/examples/knative_postgresql_customvar/README.md
+++ b/examples/knative_postgresql_customvar/README.md
@@ -36,15 +36,46 @@ Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 
-and install a `alpha` version.
+and install the `alpha` version.
 
-Alternatively, you can perform the same task with this make command:
+Alternatively, you can perform the same task manually using the following command:
 
 ``` shell
-make install-service-binding-operator
+make install-service-binding-operator-community
 ```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
+
+##### :bulb: Latest `master` version of the operator
+
+It is also possible to install the latest `master` version of the operator instead of the one from `community-operators`. To enable that an `OperatorSource` has to be installed with the latest `master` version:
+
+``` shell
+cat <<EOS | kubectl apply -f -
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: redhat-developer-operators
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: redhat-developer
+EOS
+```
+
+Alternatively, you can perform the same task manually using the following command before going to the Operator Hub:
+
+``` shell
+make install-service-binding-operator-source-master
+```
+
+or running the following command to install the operator completely:
+
+``` shell
+make install-service-binding-operator-master
+```
 
 #### Install the backing DB (PostgreSQL) operator
 

--- a/examples/nodejs_awsrds_varprefix/README.md
+++ b/examples/nodejs_awsrds_varprefix/README.md
@@ -33,7 +33,7 @@ and install a `alpha` version.
 Alternatively, you can perform the same task with this make command:
 
 ``` shell
-make install-service-binding-operator
+make install-service-binding-operator-community
 ```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.

--- a/examples/nodejs_awsrds_varprefix/README.md
+++ b/examples/nodejs_awsrds_varprefix/README.md
@@ -28,15 +28,46 @@ Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 
-and install a `alpha` version.
+and install the `alpha` version.
 
-Alternatively, you can perform the same task with this make command:
+Alternatively, you can perform the same task manually using the following command:
 
 ``` shell
 make install-service-binding-operator-community
 ```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
+
+##### :bulb: Latest `master` version of the operator
+
+It is also possible to install the latest `master` version of the operator instead of the one from `community-operators`. To enable that an `OperatorSource` has to be installed with the latest `master` version:
+
+``` shell
+cat <<EOS | kubectl apply -f -
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: redhat-developer-operators
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: redhat-developer
+EOS
+```
+
+Alternatively, you can perform the same task manually using the following command before going to the Operator Hub:
+
+``` shell
+make install-service-binding-operator-source-master
+```
+
+or running the following command to install the operator completely:
+
+``` shell
+make install-service-binding-operator-master
+```
 
 #### Install the DB operator using an `OperatorSource`
 

--- a/examples/nodejs_ibmcloud_operator/README.md
+++ b/examples/nodejs_ibmcloud_operator/README.md
@@ -24,13 +24,51 @@ but we can use the same operator to create any other service on the IBM Cloud.  
 manage off-cluster service instances on IBM Cloud.
 
 #### Install the Service Binding Operator
-Navigate to `Operators`->`OperatorHub` in the OpenShift console; in the `Developer Tools` category select `Service Binding Operator`
+
+Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `Developer Tools` category select the `Service Binding Operator` operator
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 
-and install an `alpha` version.
+and install the `alpha` version.
 
-This makes the `ServiceBindingRequest` custom resource available for the application developer.
+Alternatively, you can perform the same task manually using the following command:
+
+``` shell
+make install-service-binding-operator-community
+```
+
+This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
+
+##### :bulb: Latest `master` version of the operator
+
+It is also possible to install the latest `master` version of the operator instead of the one from `community-operators`. To enable that an `OperatorSource` has to be installed with the latest `master` version:
+
+``` shell
+cat <<EOS | kubectl apply -f -
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: redhat-developer-operators
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: redhat-developer
+EOS
+```
+
+Alternatively, you can perform the same task manually using the following command before going to the Operator Hub:
+
+``` shell
+make install-service-binding-operator-source-master
+```
+
+or running the following command to install the operator completely:
+
+``` shell
+make install-service-binding-operator-master
+```
 
 #### Install the IBM Cloud operator
 

--- a/examples/nodejs_postgresql/README.md
+++ b/examples/nodejs_postgresql/README.md
@@ -33,15 +33,46 @@ Navigate to the `Operators`->`OperatorHub` in the OpenShift console and in the `
 
 ![Service Binding Operator as shown in OperatorHub](../../assets/operator-hub-sbo-screenshot.png)
 
-and install a `alpha` version.
+and install the `alpha` version.
 
-Alternatively, you can perform the same task with this make command:
+Alternatively, you can perform the same task manually using the following command:
 
 ``` shell
 make install-service-binding-operator-community
 ```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.
+
+##### :bulb: Latest `master` version of the operator
+
+It is also possible to install the latest `master` version of the operator instead of the one from `community-operators`. To enable that an `OperatorSource` has to be installed with the latest `master` version:
+
+``` shell
+cat <<EOS | kubectl apply -f -
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: redhat-developer-operators
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: redhat-developer
+EOS
+```
+
+Alternatively, you can perform the same task manually using the following command before going to the Operator Hub:
+
+``` shell
+make install-service-binding-operator-source-master
+```
+
+or running the following command to install the operator completely:
+
+``` shell
+make install-service-binding-operator-master
+```
 
 #### Install the DB operator using an `OperatorSource`
 

--- a/examples/nodejs_postgresql/README.md
+++ b/examples/nodejs_postgresql/README.md
@@ -38,7 +38,7 @@ and install a `alpha` version.
 Alternatively, you can perform the same task with this make command:
 
 ``` shell
-make install-service-binding-operator
+make install-service-binding-operator-community
 ```
 
 This makes the `ServiceBindingRequest` custom resource available, that the application developer will use later.


### PR DESCRIPTION
### Motivation

Currently, the examples use the version of the SBO installed from `community-operators`. I was not easy to try those examples with the latest version of the examples that are built from `master`.

Providing means to run those examples with the latest `master` version of SBO also supports automated tests that implement the example's scenarios.

This is a dependency for #441.

### Changes

This PR adds make target for installing the latest SBO version from `master` using a custom `OperatorSource` and renames the current make targets (for the community version) by adding `community` suffix.

### Testing

Tests introduced in #441 use this update.
