### PR TITLE
Validate version number against version in the community operator repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,5 +471,6 @@ dev-release:
 ## -- Target to validate release --
 .PHONY: validate-release
 ## validate the operator by installing the releases
-validate-release:
-	BUNDLE_VERSION=$(BASE_BUNDLE_VERSION) ./hack/validate-release.sh
+validate-release: setup-venv
+	$(Q)$(OUTPUT_DIR)/venv3/bin/pip install yq==2.10.0
+	BUNDLE_VERSION=$(BASE_BUNDLE_VERSION) CHANNEL="alpha" ./hack/validate-release.sh

--- a/hack/validate-release.sh
+++ b/hack/validate-release.sh
@@ -4,6 +4,7 @@ set -e
 set -u
 
 SUBSCRIPTION="./test/operator-hub/subscription2.yaml"
+BUNDLE_VERSION=`curl -s https://raw.githubusercontent.com/operator-framework/community-operators/master/community-operators/service-binding-operator/service-binding-operator.package.yaml | ./out/venv3/bin/yq -r '.channels[] | select (.name == '\"$CHANNEL\"') | .currentCSV | sub("service-binding-operator.v"; "") '`
 INSTALL_PLAN_PRIOR=service-binding-operator.v${BUNDLE_VERSION}
 
 # Subscribing to the operator
@@ -14,17 +15,19 @@ if [[ ${RUNNING_STATUS} = "Running" ]] ; then
 fi
 ./hack/check-crds.sh
 ./hack/check-csvs.sh
-INSTALL_PLAN_PRIOR=service-binding-operator.v${BUNDLE_VERSION}
-VERSION_NUMBER=`kubectl get csvs  -n=default -o jsonpath='{.items[*].spec.version}'`
+VERSION_NUMBER=`kubectl get csvs service-binding-operator.v${BUNDLE_VERSION} -n=default -o jsonpath='{.spec.version}'`
 if [ "${VERSION_NUMBER}" = "${BUNDLE_VERSION}" ] ; then
     echo -e "OLM Bundle Version validation succeeded \n ";
-	kubectl get csvs -n=default -o jsonpath='{.items[*].metadata.annotations.alm-examples}' | cut -d "[" -f 2 | cut -d "]" -f 1 > output.json;
+	rm -f ./output.json;
+	kubectl get csvs service-binding-operator.v${BUNDLE_VERSION} -n=default -o jsonpath='{.metadata.annotations.alm-examples}' | cut -d "[" -f 2 | cut -d "]" -f 1 > output.json;
 	kubectl apply -n=default -f ./output.json;
+	rm -f ./output.json;
 	if [ $? = 0 ] ; then
 		echo "CSV alm example validation succeeded"
 	fi
-	if [ `kubectl get installplans -n=openshift-operators -o jsonpath='{.items[*].status.phase}'` == "Complete" ] ; then
-		INSTALL_PLAN=`kubectl get installplans -n=openshift-operators -o jsonpath='{.items[*].spec.clusterServiceVersionNames[0]}'`
+    install_plan_name=`kubectl get subscriptions service-binding-operator -n openshift-operators -o jsonpath='{.status.installPlanRef.name}'`
+	if [ `kubectl get installplans ${install_plan_name} -n=openshift-operators -o jsonpath='{.status.phase}'` == "Complete" ] ; then
+		INSTALL_PLAN=`kubectl get installplans ${install_plan_name} -n=openshift-operators -o jsonpath='{.spec.clusterServiceVersionNames[0]}'`
 		if [ "${INSTALL_PLAN_PRIOR}" = "${INSTALL_PLAN}" ] ; then
 			echo "Install Plan validation succeeded. OLM Bundle Validation succeeded"
 		fi


### PR DESCRIPTION
## Motivation

The current version comparison is against the value in the master branch. This is not the version that is published.  The published version is available in the community operator repo.

## Changes

Compare version number against the version in the community operator repo.

## Testing

To run the validation script:
```
export KUBECONFIG=</path/to/kubeconfig>
make validate-release
```
