### PR TITLE
Remove redundant checking

### DIFF
--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -150,7 +150,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	bm, err := BuildServiceBinder(options)
 	if err != nil {
 		logger.Error(err, "Creating binding context")
-		if err == EmptyBackingServiceSelectorsErr || err == EmptyApplicationSelectorErr {
+		if err == EmptyBackingServiceSelectorsErr || err == EmptyApplicationSelectorErr || err == ApplicationNotFound {
 			// TODO: find or create an error type containing suitable information to be propagated
 			var reason string
 			if errors.Is(err, EmptyBackingServiceSelectorsErr) {

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -150,13 +150,11 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	bm, err := BuildServiceBinder(options)
 	if err != nil {
 		logger.Error(err, "Creating binding context")
-		if err == EmptyBackingServiceSelectorsErr || err == EmptyApplicationSelectorErr || err == ApplicationNotFound {
+		if err == EmptyBackingServiceSelectorsErr || err == EmptyApplicationSelectorErr {
 			// TODO: find or create an error type containing suitable information to be propagated
 			var reason string
 			if errors.Is(err, EmptyBackingServiceSelectorsErr) {
 				reason = "EmptyBackingServiceSelectors"
-			} else if errors.Is(err, ApplicationNotFound) {
-				reason = "ApplicationUnavailable"
 			} else {
 				reason = "EmptyApplicationSelector"
 			}


### PR DESCRIPTION
The ApplocationNotFound is not propagated to the reconciler as an error. Remove redundant checking