### PR TITLE
use 0.0.23 CSV version as template when generating a new one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ merge-to-master-release:
 push-to-manifest-repo:
 	@rm -rf $(MANIFESTS_TMP) || true
 	@mkdir -p ${MANIFESTS_TMP}/${BUNDLE_VERSION}
-	operator-sdk generate csv --csv-version $(BUNDLE_VERSION) --from-version=$(BASE_BUNDLE_VERSION)
+	operator-sdk generate csv --csv-version $(BUNDLE_VERSION) --from-version=0.0.23
 	cp -vrf $(OLM_CATALOG_DIR)/$(GO_PACKAGE_REPO_NAME)/$(BUNDLE_VERSION)/* $(MANIFESTS_TMP)/$(BUNDLE_VERSION)/
 	cp -vrf $(OLM_CATALOG_DIR)/$(GO_PACKAGE_REPO_NAME)/*package.yaml $(MANIFESTS_TMP)/
 	cp -vrf $(CRDS_DIR)/*_crd.yaml $(MANIFESTS_TMP)/${BUNDLE_VERSION}/


### PR DESCRIPTION
### Motivation

Generated CSV does not contain the following fields:

* categories
* description
* icon

and they are required for publishing the operator to community hub. Hence, we are adding them manually.

### Changes

Use 0.0.23 CSV version as template when generating a new one. `service-binding-operator.v0.0.23.clusterserviceversion.yaml` contains a curated set of fields like proper description, maintainer list, icon, etc.

### Testing

```
make push-to-manifest-repo
```
The generated manifest can be submitted to community-operator project without manual editing.