### PR TITLE
Add watching for workloads

### DIFF
--- a/pkg/controller/servicebindingrequest/controller.go
+++ b/pkg/controller/servicebindingrequest/controller.go
@@ -22,7 +22,7 @@ func Add(mgr manager.Manager) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, client dynamic.Interface) (reconcile.Reconciler, error) {
+func newReconciler(mgr manager.Manager, client dynamic.Interface) (*Reconciler, error) {
 	return &Reconciler{
 		dynClient:  client,
 		scheme:     mgr.GetScheme(),
@@ -31,12 +31,13 @@ func newReconciler(mgr manager.Manager, client dynamic.Interface) (reconcile.Rec
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler.
-func add(mgr manager.Manager, r reconcile.Reconciler, client dynamic.Interface) error {
+func add(mgr manager.Manager, r *Reconciler, client dynamic.Interface) error {
 	opts := controller.Options{Reconciler: r}
 	c, err := NewSBRController(mgr, opts, client)
 	if err != nil {
 		return err
 	}
+	r.resourceWatcher = c
 	return c.Watch()
 }
 


### PR DESCRIPTION
### Motivation
Fix issue https://github.com/redhat-developer/service-binding-operator/issues/422

### Changes
Besically align https://github.com/redhat-developer/service-binding-operator/issues/422#issuecomment-619260714 Except:
Instead of hard-coded watching typical workloads at starting, this change will add watching for GVKs defined in application selector at runtime. As for typical workloads with status as subresources,  the existing predicate function which checks the`metadata.generation` is able to avoid noises.

Also split `Set/Remove SBRAnnotations` function into two seperate functions. It is useful to combine the updating for application CR. 

### Testing
Unit tests added and manual testing passed.
