### PR TITLE
Separate SetSBRAnnotations/RemoveSBRAnnotations functions

### DIFF
--- a/pkg/controller/servicebindingrequest/binding.go
+++ b/pkg/controller/servicebindingrequest/binding.go
@@ -115,7 +115,7 @@ func (b *ServiceBinder) Unbind() (reconcile.Result, error) {
 	logger := b.Logger.WithName("Unbind")
 
 	logger.Info("Cleaning related objects from operator's annotations...")
-	if err := RemoveSBRAnnotations(b.DynClient, b.Objects); err != nil {
+	if err := RemoveAndUpdateSBRAnnotations(b.DynClient, b.Objects); err != nil {
 		logger.Error(err, "On removing annotations from related objects.")
 		return RequeueError(err)
 	}
@@ -236,7 +236,7 @@ func (b *ServiceBinder) Bind() (reconcile.Result, error) {
 
 	// annotating objects related to binding
 	namespacedName := types.NamespacedName{Namespace: b.SBR.GetNamespace(), Name: b.SBR.GetName()}
-	if err = SetSBRAnnotations(b.DynClient, namespacedName, append(b.Objects, secretObj)); err != nil {
+	if err = SetAndUpdateSBRAnnotations(b.DynClient, namespacedName, append(b.Objects, secretObj)); err != nil {
 		b.Logger.Error(err, "On setting annotations in related objects.")
 		return b.onError(err, b.SBR, sbrStatus, updatedObjects)
 	}


### PR DESCRIPTION
### Motivation
Part of https://github.com/redhat-developer/service-binding-operator/pull/442 as requested by @isutton  

### Changes
Seperate `SetSBRAnnotations`/`RemoveSBRAnnotations` functions.
After this change `SetSBRAnnotations`/`RemoveSBRAnnotations` is only used to modify the object without updating it using clientset. The original behaviour is changed to `SetAndUpdateSBRAnnotations`/`RemoveAndUpdateSBRAnnotations`.

This is helpful for functions which want to combine set/remove SBRAnnotations with other modifications as a single updating request.

### Testing
Test cases included.