### PR TITLE
Use dynamic client to interact with the API server

### DIFF
--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -17,9 +17,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/log"
@@ -40,11 +38,11 @@ const ChangeTriggerEnv = "ServiceBindingOperatorChangeTriggerEnvVar"
 // secret. Those secrets should be offered as environment variables.
 type Binder struct {
 	ctx        context.Context                 // request context
-	client     client.Client                   // kubernetes API client
 	dynClient  dynamic.Interface               // kubernetes dynamic api client
 	sbr        *v1alpha1.ServiceBindingRequest // instantiated service binding request
 	volumeKeys []string                        // list of key names used in volume mounts
 	modifier   ExtraFieldsModifier             // extra modifier for CRDs before updating
+	restMapper meta.RESTMapper                 // RESTMapper to convert GVR from GVK
 	logger     *log.Log                        // logger instance
 }
 
@@ -67,7 +65,7 @@ var EmptyApplicationSelectorErr = errors.New("application ResourceRef or MatchLa
 var ApplicationNotFound = errors.New("Application is already deleted")
 
 // search objects based in Kind/APIVersion, which contain the labels defined in ApplicationSelector.
-func (b *Binder) search() (*unstructured.UnstructuredList, error) {
+func (b *Binder) search() ([]*unstructured.Unstructured, error) {
 	ns := b.sbr.GetNamespace()
 	gvr := schema.GroupVersionResource{
 		Group:    b.sbr.Spec.ApplicationSelector.GroupVersionResource.Group,
@@ -75,15 +73,18 @@ func (b *Binder) search() (*unstructured.UnstructuredList, error) {
 		Resource: b.sbr.Spec.ApplicationSelector.GroupVersionResource.Resource,
 	}
 
+	var result []*unstructured.Unstructured
 	var opts metav1.ListOptions
-
 	// If Application name is present
 	if b.sbr.Spec.ApplicationSelector.ResourceRef != "" {
-		fieldName := make(map[string]string)
-		fieldName["metadata.name"] = b.sbr.Spec.ApplicationSelector.ResourceRef
-		opts = metav1.ListOptions{
-			FieldSelector: fields.Set(fieldName).String(),
+		object, err := b.dynClient.Resource(gvr).Namespace(ns).
+			Get(b.sbr.Spec.ApplicationSelector.ResourceRef, metav1.GetOptions{})
+
+		if err != nil {
+			return nil, err
 		}
+		result = append(result, object)
+		return result, nil
 	} else if b.sbr.Spec.ApplicationSelector.LabelSelector != nil {
 		matchLabels := b.sbr.Spec.ApplicationSelector.LabelSelector.MatchLabels
 		opts = metav1.ListOptions{
@@ -95,11 +96,12 @@ func (b *Binder) search() (*unstructured.UnstructuredList, error) {
 
 	objList, err := b.dynClient.Resource(gvr).Namespace(ns).List(opts)
 	if err != nil {
-		return nil, ApplicationNotFound
-
+		return nil, err
 	}
-
-	return objList, err
+	for idx := range objList.Items {
+		result = append(result, &objList.Items[idx])
+	}
+	return result, nil
 }
 
 // extractSpecVolumes based on volume path, extract it unstructured. It can return error on trying
@@ -465,28 +467,28 @@ func nestedMapComparison(a, b *unstructured.Unstructured, fields ...string) (boo
 // update the list of objects informed as unstructured, looking for "containers" entry. This method
 // loops over each container to inspect "envFrom" and append the intermediary secret, having the same
 // name than original ServiceBindingRequest.
-func (b *Binder) update(objs *unstructured.UnstructuredList) ([]*unstructured.Unstructured, error) {
+func (b *Binder) update(objs []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
 	updatedObjs := []*unstructured.Unstructured{}
 
-	for _, obj := range objs.Items {
-		// store a copy of the original object to later be used in a comparison
-		originalObj := obj.DeepCopy()
+	for _, obj := range objs {
+		// modify the copy of the original object and use the original one later for comparison
+		updatedObj := obj.DeepCopy()
 		name := obj.GetName()
 		log := b.logger.WithValues("Obj.Name", name, "Obj.Kind", obj.GetKind())
 		log.Debug("Inspecting object...")
 
-		updatedObj, err := b.updateSpecContainers(&obj)
+		updatedObj, err := b.updateSpecContainers(updatedObj)
 		if err != nil {
 			return nil, err
 		}
 
 		if len(b.volumeKeys) > 0 {
-			if updatedObj, err = b.updateSpecVolumes(&obj); err != nil {
+			if updatedObj, err = b.updateSpecVolumes(updatedObj); err != nil {
 				return nil, err
 			}
 		}
 
-		if specsAreEqual, err := nestedMapComparison(originalObj, updatedObj, "spec"); err != nil {
+		if specsAreEqual, err := nestedMapComparison(obj, updatedObj, "spec"); err != nil {
 			log.Error(err, "")
 			continue
 		} else if specsAreEqual {
@@ -501,48 +503,56 @@ func (b *Binder) update(objs *unstructured.UnstructuredList) ([]*unstructured.Un
 		}
 
 		log.Debug("Updating object...")
-		if err := b.client.Update(b.ctx, updatedObj); err != nil {
+		gk := updatedObj.GroupVersionKind().GroupKind()
+		version := updatedObj.GroupVersionKind().Version
+		mapping, err := b.restMapper.RESTMapping(gk, version)
+		if err != nil {
 			return nil, err
 		}
+		updated, err := b.dynClient.Resource(mapping.Resource).
+			Namespace(updatedObj.GetNamespace()).
+			Update(updatedObj, metav1.UpdateOptions{})
 
-		log.Debug("Reading back updated object...")
-		// reading object back again, to comply with possible modifications
-		namespacedName := types.NamespacedName{
-			Namespace: updatedObj.GetNamespace(),
-			Name:      updatedObj.GetName(),
-		}
-		if err = b.client.Get(b.ctx, namespacedName, updatedObj); err != nil {
+		if err != nil {
 			return nil, err
 		}
-
-		updatedObjs = append(updatedObjs, updatedObj)
+		updatedObjs = append(updatedObjs, updated)
 	}
 
 	return updatedObjs, nil
 }
 
 // remove attempts to update each given object without any service binding related information.
-func (b *Binder) remove(objs *unstructured.UnstructuredList) error {
-	for _, obj := range objs.Items {
+func (b *Binder) remove(objs []*unstructured.Unstructured) error {
+	for _, obj := range objs {
 		name := obj.GetName()
 		logger := b.logger.WithValues("Obj.Name", name, "Obj.Kind", obj.GetKind())
 		logger.Debug("Inspecting object...")
-
-		updatedObj, err := b.removeSpecContainers(&obj)
+		updatedObj, err := b.removeSpecContainers(obj)
 		if err != nil {
 			return err
 		}
-
 		if len(b.volumeKeys) > 0 {
-			if updatedObj, err = b.removeSpecVolumes(&obj); err != nil {
+			if updatedObj, err = b.removeSpecVolumes(updatedObj); err != nil {
 				return err
 			}
 		}
 
-		logger.Debug("Updating object...")
-		if err = b.client.Update(b.ctx, updatedObj); err != nil {
+		gk := updatedObj.GroupVersionKind().GroupKind()
+		version := updatedObj.GroupVersionKind().Version
+		mapping, err := b.restMapper.RESTMapping(gk, version)
+		if err != nil {
 			return err
 		}
+
+		_, err = b.dynClient.Resource(mapping.Resource).
+			Namespace(updatedObj.GetNamespace()).
+			Update(updatedObj, metav1.UpdateOptions{})
+
+		if err != nil {
+			return err
+		}
+
 	}
 	return nil
 }
@@ -575,10 +585,10 @@ func (b *Binder) Bind() ([]*unstructured.Unstructured, error) {
 // NewBinder returns a new Binder instance.
 func NewBinder(
 	ctx context.Context,
-	client client.Client,
 	dynClient dynamic.Interface,
 	sbr *v1alpha1.ServiceBindingRequest,
 	volumeKeys []string,
+	restMapper meta.RESTMapper,
 ) *Binder {
 
 	logger := log.NewLog("binder")
@@ -586,11 +596,11 @@ func NewBinder(
 
 	return &Binder{
 		ctx:        ctx,
-		client:     client,
 		dynClient:  dynClient,
 		sbr:        sbr,
 		volumeKeys: volumeKeys,
 		modifier:   modifier,
+		restMapper: restMapper,
 		logger:     logger,
 	}
 }

--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -74,6 +74,7 @@ func (b *Binder) search() (*unstructured.UnstructuredList, error) {
 	}
 
 	var opts metav1.ListOptions
+
 	// If Application name is present
 	if b.sbr.Spec.ApplicationSelector.ResourceRef != "" {
 		object, err := b.dynClient.Resource(gvr).Namespace(ns).

--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -15,6 +15,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/redhat-developer/service-binding-operator/pkg/converter"
+	"github.com/redhat-developer/service-binding-operator/pkg/testutils"
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
@@ -43,16 +44,6 @@ func TestBinderNew(t *testing.T) {
 	sbr := f.AddMockedServiceBindingRequest(name, nil, "ref", "", deploymentsGVR, matchLabels)
 	f.AddMockedUnstructuredDeployment("ref", matchLabels)
 
-	binder := NewBinder(
-		context.TODO(),
-		f.FakeClient(),
-		f.FakeDynClient(),
-		sbr,
-		[]string{},
-	)
-
-	require.NotNil(t, binder)
-
 	sbrWithResourceRef := f.AddMockedServiceBindingRequest(
 		"service-binding-request-with-ref",
 		nil,
@@ -62,29 +53,46 @@ func TestBinderNew(t *testing.T) {
 		map[string]string{},
 	)
 
-	binderForSBRWithResourceRef := NewBinder(
-		context.TODO(),
-		f.FakeClient(),
-		f.FakeDynClient(),
-		sbrWithResourceRef,
-		[]string{},
-	)
-
-	require.NotNil(t, binderForSBRWithResourceRef)
-
 	t.Run("search-using-resourceref", func(t *testing.T) {
+		binderForSBRWithResourceRef := NewBinder(
+			context.TODO(),
+			f.FakeDynClient(),
+			sbrWithResourceRef,
+			[]string{},
+			testutils.BuildTestRESTMapper(),
+		)
+
+		require.NotNil(t, binderForSBRWithResourceRef)
 		list, err := binderForSBRWithResourceRef.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list.Items))
+		require.Equal(t, 1, len(list))
 	})
 
 	t.Run("search", func(t *testing.T) {
+		binder := NewBinder(
+			context.TODO(),
+			f.FakeDynClient(),
+			sbr,
+			[]string{},
+			testutils.BuildTestRESTMapper(),
+		)
+
+		require.NotNil(t, binder)
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list.Items))
+		require.Equal(t, 1, len(list))
 	})
 
 	t.Run("appendEnvFrom-removeEnvFrom", func(t *testing.T) {
+		binder := NewBinder(
+			context.TODO(),
+			f.FakeDynClient(),
+			sbr,
+			[]string{},
+			testutils.BuildTestRESTMapper(),
+		)
+
+		require.NotNil(t, binder)
 		secretName := "secret"
 		d := mocks.DeploymentMock("binder", "binder", map[string]string{})
 		envFrom := d.Spec.Template.Spec.Containers[0].EnvFrom
@@ -98,6 +106,16 @@ func TestBinderNew(t *testing.T) {
 	})
 
 	t.Run("appendEnv", func(t *testing.T) {
+
+		binder := NewBinder(
+			context.TODO(),
+			f.FakeDynClient(),
+			sbr,
+			[]string{},
+			testutils.BuildTestRESTMapper(),
+		)
+
+		require.NotNil(t, binder)
 		d := mocks.DeploymentMock("binder", "binder", map[string]string{})
 		list := binder.appendEnvVar(d.Spec.Template.Spec.Containers[0].Env, "name", "value")
 		require.Equal(t, 1, len(list))
@@ -106,15 +124,25 @@ func TestBinderNew(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
+
+		binder := NewBinder(
+			context.TODO(),
+			f.FakeDynClient(),
+			sbr,
+			[]string{},
+			testutils.BuildTestRESTMapper(),
+		)
+
+		require.NotNil(t, binder)
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list.Items))
+		require.Equal(t, 1, len(list))
 
 		updatedObjects, err := binder.update(list)
 		require.NoError(t, err)
 		require.Len(t, updatedObjects, 1)
 
-		containers, found, err := unstructured.NestedSlice(list.Items[0].Object, containersPath...)
+		containers, found, err := unstructured.NestedSlice(updatedObjects[0].Object, containersPath...)
 		require.NoError(t, err)
 		require.True(t, found)
 		require.Len(t, containers, 1)
@@ -134,6 +162,16 @@ func TestBinderNew(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, parsedTime.Before(time.Now()))
 
+	})
+
+	t.Run("update with extra modifier present", func(t *testing.T) {
+		binder := NewBinder(
+			context.TODO(),
+			f.FakeDynClient(),
+			sbr,
+			[]string{},
+			testutils.BuildTestRESTMapper(),
+		)
 		// test binder with extra modifier present
 		ch := make(chan struct{})
 		binder.modifier = ExtraFieldsModifierFunc(func(u *unstructured.Unstructured) error {
@@ -141,26 +179,35 @@ func TestBinderNew(t *testing.T) {
 			return nil
 		})
 
-		list, err = binder.search()
+		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list.Items))
+		require.Equal(t, 1, len(list))
 
-		updatedObjects, err = binder.update(list)
+		updatedObjects, err := binder.update(list)
 		require.NoError(t, err)
 		require.Len(t, updatedObjects, 1)
 		<-ch
 
 		// call another update as object is already updated, modifier func should not be called
-		updatedObjects, err = binder.update(list)
+		updatedObjects, err = binder.update(updatedObjects)
 		require.NoError(t, err)
 		require.Len(t, updatedObjects, 0)
-		binder.modifier = nil
 	})
 
 	t.Run("remove", func(t *testing.T) {
+
+		binder := NewBinder(
+			context.TODO(),
+			f.FakeDynClient(),
+			sbr,
+			[]string{},
+			testutils.BuildTestRESTMapper(),
+		)
+
+		require.NotNil(t, binder)
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list.Items))
+		require.Equal(t, 1, len(list))
 
 		updatedObjects, err := binder.update(list)
 		require.NoError(t, err)
@@ -169,7 +216,9 @@ func TestBinderNew(t *testing.T) {
 		err = binder.remove(list)
 		require.NoError(t, err)
 
-		containers, found, err := unstructured.NestedSlice(list.Items[0].Object, containersPath...)
+		list, err = binder.search()
+		require.NoError(t, err)
+		containers, found, err := unstructured.NestedSlice(list[0].Object, containersPath...)
 		require.NoError(t, err)
 		require.True(t, found)
 		require.Len(t, containers, 1)
@@ -210,14 +259,14 @@ func TestBinderApplicationName(t *testing.T) {
 	name := "service-binding-request"
 	f := mocks.NewFake(t, ns)
 	sbr := f.AddMockedServiceBindingRequest(name, nil, "backingServiceResourceRef", "applicationResourceRef", deploymentsGVR, nil)
-	f.AddMockedUnstructuredDeployment("ref", nil)
+	f.AddMockedUnstructuredDeployment("applicationResourceRef", nil)
 
 	binder := NewBinder(
 		context.TODO(),
-		f.FakeClient(),
 		f.FakeDynClient(),
 		sbr,
 		[]string{},
+		testutils.BuildTestRESTMapper(),
 	)
 
 	require.NotNil(t, binder)
@@ -225,7 +274,7 @@ func TestBinderApplicationName(t *testing.T) {
 	t.Run("search by application name", func(t *testing.T) {
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list.Items))
+		require.Equal(t, 1, len(list))
 	})
 }
 
@@ -234,14 +283,14 @@ func TestBindingWithDeploymentConfig(t *testing.T) {
 	name := "service-binding-request"
 	f := mocks.NewFake(t, ns)
 	sbr := f.AddMockedServiceBindingRequest(name, nil, "backingServiceResourceRef", "applicationResourceRef", deploymentConfigsGVR, nil)
-	f.AddMockedUnstructuredDeploymentConfig("ref", nil)
+	f.AddMockedUnstructuredDeploymentConfig("applicationResourceRef", nil)
 
 	binder := NewBinder(
 		context.TODO(),
-		f.FakeClient(),
 		f.FakeDynClient(),
 		sbr,
 		[]string{},
+		testutils.BuildTestRESTMapper(),
 	)
 
 	require.NotNil(t, binder)
@@ -249,8 +298,8 @@ func TestBindingWithDeploymentConfig(t *testing.T) {
 	t.Run("deploymentconfig", func(t *testing.T) {
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list.Items))
-		require.Equal(t, "DeploymentConfig", list.Items[0].Object["kind"])
+		require.Equal(t, 1, len(list))
+		require.Equal(t, "DeploymentConfig", list[0].Object["kind"])
 	})
 
 }
@@ -268,10 +317,10 @@ func TestBindTwoApplications(t *testing.T) {
 	sbr1 := f.AddMockedServiceBindingRequest(name1, nil, "backingServiceResourceRef", "", deploymentsGVR, matchLabels1)
 	binder1 := NewBinder(
 		context.TODO(),
-		f.FakeClient(),
 		f.FakeDynClient(),
 		sbr1,
 		[]string{},
+		testutils.BuildTestRESTMapper(),
 	)
 	require.NotNil(t, binder1)
 
@@ -284,21 +333,21 @@ func TestBindTwoApplications(t *testing.T) {
 	sbr2 := f.AddMockedServiceBindingRequest(name2, nil, "backingServiceResourceRef", "", deploymentsGVR, matchLabels2)
 	binder2 := NewBinder(
 		context.TODO(),
-		f.FakeClient(),
 		f.FakeDynClient(),
 		sbr2,
 		[]string{},
+		testutils.BuildTestRESTMapper(),
 	)
 	require.NotNil(t, binder2)
 
 	t.Run("two applications with one backing service", func(t *testing.T) {
 		list1, err := binder1.search()
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list1.Items))
+		assert.Equal(t, 1, len(list1))
 
 		list2, err := binder2.search()
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list2.Items))
+		assert.Equal(t, 1, len(list2))
 	})
 }
 
@@ -317,10 +366,10 @@ func TestKnativeServicesContractWithBinder(t *testing.T) {
 
 	binder := NewBinder(
 		context.TODO(),
-		f.FakeClient(),
 		f.FakeDynClient(),
 		sbr,
 		[]string{},
+		testutils.BuildTestRESTMapper(),
 	)
 
 	require.NotNil(t, binder)
@@ -329,7 +378,7 @@ func TestKnativeServicesContractWithBinder(t *testing.T) {
 	t.Run("Knative service contract with service binding operator", func(t *testing.T) {
 		list, err := binder.search()
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list.Items))
+		assert.Equal(t, 1, len(list))
 
 	})
 
@@ -351,10 +400,10 @@ func Test_extraFieldsModifier(t *testing.T) {
 	sbr := mocks.ServiceBindingRequestMock(ns, name, nil, "", deploy.Name, deploymentsGVR, matchLabels)
 	binder := NewBinder(
 		context.TODO(),
-		f.FakeClient(),
 		f.FakeDynClient(),
 		sbr,
 		[]string{},
+		testutils.BuildTestRESTMapper(),
 	)
 
 	require.NotNil(t, binder)
@@ -366,10 +415,10 @@ func Test_extraFieldsModifier(t *testing.T) {
 
 	binder = NewBinder(
 		context.TODO(),
-		f.FakeClient(),
 		f.FakeDynClient(),
 		sbr,
 		[]string{},
+		testutils.BuildTestRESTMapper(),
 	)
 
 	require.NotNil(t, binder)

--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -189,6 +189,7 @@ func TestBinderNew(t *testing.T) {
 		<-ch
 
 		list, err = binder.search()
+		require.NoError(t, err)
 		// call another update as object is already updated, modifier func should not be called
 		updatedObjects, err = binder.update(list)
 		require.NoError(t, err)

--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -65,7 +65,7 @@ func TestBinderNew(t *testing.T) {
 		require.NotNil(t, binderForSBRWithResourceRef)
 		list, err := binderForSBRWithResourceRef.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list))
+		require.Equal(t, 1, len(list.Items))
 	})
 
 	t.Run("search", func(t *testing.T) {
@@ -80,7 +80,7 @@ func TestBinderNew(t *testing.T) {
 		require.NotNil(t, binder)
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list))
+		require.Equal(t, 1, len(list.Items))
 	})
 
 	t.Run("appendEnvFrom-removeEnvFrom", func(t *testing.T) {
@@ -136,7 +136,7 @@ func TestBinderNew(t *testing.T) {
 		require.NotNil(t, binder)
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list))
+		require.Equal(t, 1, len(list.Items))
 
 		updatedObjects, err := binder.update(list)
 		require.NoError(t, err)
@@ -181,15 +181,16 @@ func TestBinderNew(t *testing.T) {
 
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list))
+		require.Equal(t, 1, len(list.Items))
 
 		updatedObjects, err := binder.update(list)
 		require.NoError(t, err)
 		require.Len(t, updatedObjects, 1)
 		<-ch
 
+		list, err = binder.search()
 		// call another update as object is already updated, modifier func should not be called
-		updatedObjects, err = binder.update(updatedObjects)
+		updatedObjects, err = binder.update(list)
 		require.NoError(t, err)
 		require.Len(t, updatedObjects, 0)
 	})
@@ -207,7 +208,7 @@ func TestBinderNew(t *testing.T) {
 		require.NotNil(t, binder)
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list))
+		require.Equal(t, 1, len(list.Items))
 
 		updatedObjects, err := binder.update(list)
 		require.NoError(t, err)
@@ -218,7 +219,7 @@ func TestBinderNew(t *testing.T) {
 
 		list, err = binder.search()
 		require.NoError(t, err)
-		containers, found, err := unstructured.NestedSlice(list[0].Object, containersPath...)
+		containers, found, err := unstructured.NestedSlice(list.Items[0].Object, containersPath...)
 		require.NoError(t, err)
 		require.True(t, found)
 		require.Len(t, containers, 1)
@@ -274,7 +275,7 @@ func TestBinderApplicationName(t *testing.T) {
 	t.Run("search by application name", func(t *testing.T) {
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list))
+		require.Equal(t, 1, len(list.Items))
 	})
 }
 
@@ -298,8 +299,8 @@ func TestBindingWithDeploymentConfig(t *testing.T) {
 	t.Run("deploymentconfig", func(t *testing.T) {
 		list, err := binder.search()
 		require.NoError(t, err)
-		require.Equal(t, 1, len(list))
-		require.Equal(t, "DeploymentConfig", list[0].Object["kind"])
+		require.Equal(t, 1, len(list.Items))
+		require.Equal(t, "DeploymentConfig", list.Items[0].Object["kind"])
 	})
 
 }
@@ -343,11 +344,11 @@ func TestBindTwoApplications(t *testing.T) {
 	t.Run("two applications with one backing service", func(t *testing.T) {
 		list1, err := binder1.search()
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list1))
+		assert.Equal(t, 1, len(list1.Items))
 
 		list2, err := binder2.search()
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list2))
+		assert.Equal(t, 1, len(list2.Items))
 	})
 }
 
@@ -378,7 +379,7 @@ func TestKnativeServicesContractWithBinder(t *testing.T) {
 	t.Run("Knative service contract with service binding operator", func(t *testing.T) {
 		list, err := binder.search()
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list))
+		assert.Equal(t, 1, len(list.Items))
 
 	})
 

--- a/pkg/controller/servicebindingrequest/controller.go
+++ b/pkg/controller/servicebindingrequest/controller.go
@@ -24,7 +24,6 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, client dynamic.Interface) (reconcile.Reconciler, error) {
 	return &Reconciler{
-		client:     mgr.GetClient(),
 		dynClient:  client,
 		scheme:     mgr.GetScheme(),
 		RestMapper: mgr.GetRESTMapper(),

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
@@ -28,10 +27,9 @@ const (
 
 // Reconciler reconciles a ServiceBindingRequest object
 type Reconciler struct {
-	client     client.Client     // kubernetes api client
 	dynClient  dynamic.Interface // kubernetes dynamic api client
-	scheme     *runtime.Scheme   // api scheme
 	RestMapper meta.RESTMapper   // restMapper to convert GVK and GVR
+	scheme     *runtime.Scheme   // api scheme
 }
 
 // reconcilerLog local logger instance
@@ -171,13 +169,13 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	options := &ServiceBinderOptions{
-		Client:                 r.client,
 		DynClient:              r.dynClient,
 		DetectBindingResources: sbr.Spec.DetectBindingResources,
 		SBR:                    sbr,
 		Logger:                 logger,
 		Objects:                serviceCtxs.GetServices(),
 		Binding:                binding,
+		RESTMapper:             r.RestMapper,
 	}
 
 	sb, err := BuildServiceBinder(ctx, options)

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -28,8 +28,8 @@ const (
 // Reconciler reconciles a ServiceBindingRequest object
 type Reconciler struct {
 	dynClient  dynamic.Interface // kubernetes dynamic api client
-	RestMapper meta.RESTMapper   // restMapper to convert GVK and GVR
 	scheme     *runtime.Scheme   // api scheme
+	RestMapper meta.RESTMapper   // restMapper to convert GVK and GVR
 }
 
 // reconcilerLog local logger instance

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -1,16 +1,19 @@
 package servicebindingrequest
 
 import (
-	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/testutils"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -27,6 +30,7 @@ const (
 )
 
 var (
+	secretsGVR           = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 	deploymentsGVR       = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	deploymentConfigsGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deploymentconfigs"}
 )
@@ -54,19 +58,11 @@ func TestApplicationSelectorByName(t *testing.T) {
 	f.AddMockedUnstructuredCSV("cluster-service-version-list")
 	f.AddMockedUnstructuredDatabaseCRD()
 	f.AddMockedUnstructuredDatabaseCR(backingServiceResourceRef)
-	f.AddMockedUnstructuredDeployment(reconcilerName, nil)
+	f.AddMockedUnstructuredDeployment(applicationResourceRef, nil)
 	f.AddMockedUnstructuredSecret("db-credentials")
 
-	restMapper := testutils.BuildTestRESTMapper()
-
-	fakeClient := f.FakeClient()
 	fakeDynClient := f.FakeDynClient()
-	reconciler := &Reconciler{
-		RestMapper: restMapper,
-		client:     fakeClient,
-		dynClient:  fakeDynClient,
-		scheme:     f.S,
-	}
+	reconciler := &Reconciler{dynClient: fakeDynClient, RestMapper: testutils.BuildTestRESTMapper(), scheme: f.S}
 
 	t.Run("test-application-selector-by-name", func(t *testing.T) {
 
@@ -88,7 +84,7 @@ func TestApplicationSelectorByName(t *testing.T) {
 				Kind:    "Deployment",
 			},
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: namespacedName.Name,
+				Name: applicationResourceRef,
 			},
 		}
 		require.True(t, reflect.DeepEqual(expectedStatus, sbrOutput.Status.Applications[0]))
@@ -98,30 +94,21 @@ func TestApplicationSelectorByName(t *testing.T) {
 // TestReconcilerReconcileUsingSecret test the reconciliation process using a secret, expected to be
 // the regular approach.
 func TestReconcilerReconcileUsingSecret(t *testing.T) {
-	ctx := context.TODO()
 	backingServiceResourceRef := "test-using-secret"
 	matchLabels := map[string]string{
 		"connects-to": "database",
 		"environment": "reconciler",
 	}
 	f := mocks.NewFake(t, reconcilerNs)
-	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, backingServiceResourceRef, "", deploymentsGVR, matchLabels)
+	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, backingServiceResourceRef, reconcilerName, deploymentsGVR, matchLabels)
 	f.AddMockedUnstructuredCSV("cluster-service-version-list")
 	f.AddMockedUnstructuredDatabaseCRD()
 	f.AddMockedUnstructuredDatabaseCR(backingServiceResourceRef)
 	f.AddMockedUnstructuredDeployment(reconcilerName, matchLabels)
 	f.AddMockedUnstructuredSecret("db-credentials")
 
-	restMapper := testutils.BuildTestRESTMapper()
-
-	fakeClient := f.FakeClient()
 	fakeDynClient := f.FakeDynClient()
-	reconciler := &Reconciler{
-		RestMapper: restMapper,
-		client:     fakeClient,
-		dynClient:  fakeDynClient,
-		scheme:     f.S,
-	}
+	reconciler := &Reconciler{dynClient: fakeDynClient, RestMapper: testutils.BuildTestRESTMapper(), scheme: f.S}
 
 	t.Run("reconcile-using-secret", func(t *testing.T) {
 		res, err := reconciler.Reconcile(reconcileRequest())
@@ -129,8 +116,13 @@ func TestReconcilerReconcileUsingSecret(t *testing.T) {
 		require.False(t, res.Requeue)
 
 		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+
+		u, err := fakeDynClient.Resource(deploymentsGVR).Get(reconcilerName, metav1.GetOptions{})
+		require.NoError(t, err)
+
 		d := appsv1.Deployment{}
-		require.NoError(t, fakeClient.Get(ctx, namespacedName, &d))
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &d)
+		require.NoError(t, err)
 
 		containers := d.Spec.Template.Spec.Containers
 		require.Equal(t, 1, len(containers))
@@ -162,41 +154,35 @@ func TestReconcilerReconcileUsingSecret(t *testing.T) {
 }
 
 func TestReconcilerReconcileUsingVolumes(t *testing.T) {
-	ctx := context.TODO()
 	backingServiceResourceRef := "test-using-volumes"
 	matchLabels := map[string]string{
 		"connects-to": "database",
 		"environment": "reconciler",
 	}
 	f := mocks.NewFake(t, reconcilerNs)
-	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, backingServiceResourceRef, "", deploymentsGVR, matchLabels)
+	f.AddMockedUnstructuredServiceBindingRequest(reconcilerName, backingServiceResourceRef, reconcilerName, deploymentsGVR, matchLabels)
 	f.AddMockedUnstructuredCSVWithVolumeMount("cluster-service-version-list")
 	f.AddMockedUnstructuredDatabaseCRD()
 	f.AddMockedUnstructuredDatabaseCR(backingServiceResourceRef)
 	f.AddMockedUnstructuredDeployment(reconcilerName, matchLabels)
 	f.AddMockedUnstructuredSecret("db-credentials")
 
-	restMapper := testutils.BuildTestRESTMapper()
-
-	fakeClient := f.FakeClient()
-	reconciler := &Reconciler{
-		RestMapper: restMapper,
-		client:     fakeClient,
-		dynClient:  f.FakeDynClient(),
-		scheme:     f.S,
-	}
+	fakeDynClient := f.FakeDynClient()
+	reconciler := &Reconciler{dynClient: fakeDynClient, RestMapper: testutils.BuildTestRESTMapper(), scheme: f.S}
 
 	t.Run("reconcile-using-volume", func(t *testing.T) {
 		res, err := reconciler.Reconcile(reconcileRequest())
 		require.NoError(t, err)
 		require.False(t, res.Requeue)
 
-		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
+		u, err := fakeDynClient.Resource(deploymentsGVR).Get(reconcilerName, metav1.GetOptions{})
+		require.NoError(t, err)
+
 		d := appsv1.Deployment{}
-		require.NoError(t, fakeClient.Get(ctx, namespacedName, &d))
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &d)
+		require.NoError(t, err)
 
 		containers := d.Spec.Template.Spec.Containers
-
 		require.Equal(t, 1, len(containers[0].VolumeMounts))
 		require.Equal(t, "/var/redhat", containers[0].VolumeMounts[0].MountPath)
 		require.Equal(t, reconcilerName, containers[0].VolumeMounts[0].Name)
@@ -209,7 +195,6 @@ func TestReconcilerReconcileUsingVolumes(t *testing.T) {
 }
 
 func TestReconcilerGenericBinding(t *testing.T) {
-	ctx := context.TODO()
 	backingServiceResourceRef := "backingService1"
 	matchLabels := map[string]string{
 		"connects-to": "database",
@@ -222,15 +207,8 @@ func TestReconcilerGenericBinding(t *testing.T) {
 	f.AddMockedUnstructuredDatabaseCR(backingServiceResourceRef)
 	f.AddMockedUnstructuredSecret("db-credentials")
 
-	restMapper := testutils.BuildTestRESTMapper()
-
-	fakeClient := f.FakeClient()
-	reconciler := &Reconciler{
-		RestMapper: restMapper,
-		client:     fakeClient,
-		dynClient:  f.FakeDynClient(),
-		scheme:     f.S,
-	}
+	fakeDynClient := f.FakeDynClient()
+	reconciler := &Reconciler{dynClient: fakeDynClient, RestMapper: testutils.BuildTestRESTMapper(), scheme: f.S}
 
 	// Reconcile without deployment
 	res, err := reconciler.Reconcile(reconcileRequest())
@@ -254,20 +232,18 @@ func TestReconcilerGenericBinding(t *testing.T) {
 
 	// Reconcile with deployment
 	f.AddMockedUnstructuredDeployment(reconcilerName, matchLabels)
-
-	fakeClient = f.FakeClient()
-	reconciler = &Reconciler{
-		RestMapper: restMapper,
-		client:     fakeClient,
-		dynClient:  f.FakeDynClient(),
-		scheme:     f.S,
-	}
+	fakeDynClient = f.FakeDynClient()
+	reconciler = &Reconciler{dynClient: fakeDynClient, RestMapper: testutils.BuildTestRESTMapper(), scheme: f.S}
 	res, err = reconciler.Reconcile(reconcileRequest())
 	require.NoError(t, err)
 	require.False(t, res.Requeue)
 
+	u, err := fakeDynClient.Resource(deploymentsGVR).Get(reconcilerName, metav1.GetOptions{})
+	require.NoError(t, err)
+
 	d := appsv1.Deployment{}
-	require.NoError(t, fakeClient.Get(ctx, namespacedName, &d))
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &d)
+	require.NoError(t, err)
 
 	sbrOutput2, err := reconciler.getServiceBindingRequest(namespacedName)
 	require.NoError(t, err)
@@ -277,30 +253,27 @@ func TestReconcilerGenericBinding(t *testing.T) {
 	require.Equal(t, reconcilerName, sbrOutput2.Status.Secret)
 	require.Equal(t, 1, len(sbrOutput2.Status.Applications))
 
-	// Update Credentials
+	u, err = fakeDynClient.Resource(secretsGVR).Get("db-credentials", metav1.GetOptions{})
+	require.NoError(t, err)
 	s := corev1.Secret{}
-	secretNamespaced := types.NamespacedName{Namespace: reconcilerNs, Name: "db-credentials"}
-	require.NoError(t, fakeClient.Get(ctx, secretNamespaced, &s))
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &s)
+	require.NoError(t, err)
+
+	// Update Credentials
 	s.Data["password"] = []byte("abc123")
-	require.NoError(t, fakeClient.Update(ctx, &s))
-
-	reconciler = &Reconciler{
-		RestMapper: restMapper,
-		client:     fakeClient,
-		dynClient:  f.FakeDynClient(),
-		scheme:     f.S,
-	}
-
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&s)
+	require.NoError(t, err)
+	updated := unstructured.Unstructured{Object: obj}
+	_, err = fakeDynClient.Resource(secretsGVR).Namespace(updated.GetNamespace()).Update(&updated, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	time.Sleep(1 * time.Second)
+	reconciler = &Reconciler{dynClient: fakeDynClient, RestMapper: testutils.BuildTestRESTMapper(), scheme: f.S}
 	res, err = reconciler.Reconcile(reconcileRequest())
 	require.NoError(t, err)
 	require.False(t, res.Requeue)
 
 	sbrOutput3, err := reconciler.getServiceBindingRequest(namespacedName)
 	require.NoError(t, err)
-
-	d = appsv1.Deployment{}
-	require.NoError(t, fakeClient.Get(ctx, namespacedName, &d))
-
 	require.Equal(t, BindingReady, sbrOutput3.Status.Conditions[0].Type)
 	require.Equal(t, corev1.ConditionTrue, sbrOutput3.Status.Conditions[0].Status)
 	require.Equal(t, reconcilerName, sbrOutput3.Status.Secret)
@@ -327,13 +300,11 @@ func TestReconcilerReconcileWithConflictingAppSelc(t *testing.T) {
 	f.AddMockedUnstructuredDatabaseCR(backingServiceResourceRef)
 	f.AddMockedUnstructuredSecret("db-credentials")
 
-	fakeClient := f.FakeClient()
 	fakeDynClient := f.FakeDynClient()
 
 	restMapper := testutils.BuildTestRESTMapper()
 
 	reconciler := &Reconciler{
-		client:     fakeClient,
 		dynClient:  fakeDynClient,
 		scheme:     f.S,
 		RestMapper: restMapper,
@@ -363,6 +334,7 @@ func TestReconcilerReconcileWithConflictingAppSelc(t *testing.T) {
 		require.Equal(t, BindingReady, sbrOutput.Status.Conditions[0].Type)
 		require.Equal(t, corev1.ConditionTrue, sbrOutput.Status.Conditions[0].Status)
 		require.Equal(t, reconcilerName, sbrOutput.Status.Secret)
+		require.Len(t, sbrOutput.Status.Applications, 1)
 		require.True(t, reflect.DeepEqual(expectedStatus, sbrOutput.Status.Applications[0]))
 	})
 }
@@ -374,15 +346,7 @@ func TestEmptyApplicationSelector(t *testing.T) {
 	f.AddMockedUnstructuredServiceBindingRequestWithoutApplication(reconcilerName, backingServiceResourceRef)
 	f.AddMockedUnstructuredDatabaseCR(backingServiceResourceRef)
 
-	restMapper := testutils.BuildTestRESTMapper()
-
-	fakeClient := f.FakeClient()
-	reconciler := &Reconciler{
-		RestMapper: restMapper,
-		client:     fakeClient,
-		dynClient:  f.FakeDynClient(),
-		scheme:     f.S,
-	}
+	reconciler := &Reconciler{dynClient: f.FakeDynClient(), RestMapper: testutils.BuildTestRESTMapper(), scheme: f.S}
 
 	res, err := reconciler.Reconcile(reconcileRequest())
 	require.NoError(t, err)

--- a/pkg/controller/servicebindingrequest/servicebinder.go
+++ b/pkg/controller/servicebindingrequest/servicebinder.go
@@ -7,12 +7,12 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"gotest.tools/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
@@ -45,11 +45,11 @@ type ServiceBinderOptions struct {
 	DynClient              dynamic.Interface
 	DetectBindingResources bool
 	SBR                    *v1alpha1.ServiceBindingRequest
-	Client                 client.Client
 	Objects                []*unstructured.Unstructured
 	EnvVars                map[string][]byte
 	EnvVarPrefix           string
 	Binding                *Binding
+	RESTMapper             meta.RESTMapper
 }
 
 // ErrInvalidServiceBinderOptions is returned when ServiceBinderOptions contains an invalid value.
@@ -69,12 +69,12 @@ func (o *ServiceBinderOptions) Valid() error {
 		return ErrInvalidServiceBinderOptions("DynClient")
 	}
 
-	if o.Client == nil {
-		return ErrInvalidServiceBinderOptions("Client")
-	}
-
 	if o.Binding == nil {
 		return ErrInvalidServiceBinderOptions("Binding")
+	}
+
+	if o.RESTMapper == nil {
+		return ErrInvalidServiceBinderOptions("RESTMapper")
 	}
 
 	return nil
@@ -339,10 +339,10 @@ func BuildServiceBinder(
 	// consider renaming to ResourceBinder
 	binder := NewBinder(
 		ctx,
-		options.Client,
 		options.DynClient,
 		options.SBR,
 		options.Binding.VolumeKeys,
+		options.RESTMapper,
 	)
 
 	return &ServiceBinder{

--- a/pkg/controller/servicebindingrequest/servicebinder_test.go
+++ b/pkg/controller/servicebindingrequest/servicebinder_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/log"
+	"github.com/redhat-developer/service-binding-operator/pkg/testutils"
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
@@ -400,11 +401,11 @@ func TestServiceBinder_Bind(t *testing.T) {
 			DynClient:              f.FakeDynClient(),
 			DetectBindingResources: false,
 			SBR:                    sbrSingleService,
-			Client:                 f.FakeClient(),
 			Binding: &Binding{
 				EnvVars:    map[string][]byte{},
 				VolumeKeys: []string{},
 			},
+			RESTMapper: testutils.BuildTestRESTMapper(),
 		},
 		wantConditions: []wantedCondition{
 			{
@@ -437,13 +438,13 @@ func TestServiceBinder_Bind(t *testing.T) {
 			DynClient:              f.FakeDynClient(),
 			DetectBindingResources: false,
 			SBR:                    sbrSingleServiceWithCustomEnvVar,
-			Client:                 f.FakeClient(),
 			Binding: &Binding{
 				EnvVars: map[string][]byte{
 					"MY_DB_NAME": []byte("db1"),
 				},
 				VolumeKeys: []string{},
 			},
+			RESTMapper: testutils.BuildTestRESTMapper(),
 		},
 		wantConditions: []wantedCondition{
 			{
@@ -479,11 +480,11 @@ func TestServiceBinder_Bind(t *testing.T) {
 			DynClient:              f.FakeDynClient(),
 			DetectBindingResources: true,
 			SBR:                    sbrSingleService,
-			Client:                 f.FakeClient(),
 			Binding: &Binding{
 				EnvVars:    map[string][]byte{},
 				VolumeKeys: []string{},
 			},
+			RESTMapper: testutils.BuildTestRESTMapper(),
 		},
 		wantConditions: []wantedCondition{
 			{
@@ -499,11 +500,11 @@ func TestServiceBinder_Bind(t *testing.T) {
 			DynClient:              f.FakeDynClient(),
 			DetectBindingResources: true,
 			SBR:                    sbrEmptyAppSelector,
-			Client:                 f.FakeClient(),
 			Binding: &Binding{
 				EnvVars:    map[string][]byte{},
 				VolumeKeys: []string{},
 			},
+			RESTMapper: testutils.BuildTestRESTMapper(),
 		},
 		wantErr: EmptyApplicationSelectorErr,
 		wantConditions: []wantedCondition{
@@ -523,7 +524,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 			DynClient:              f.FakeDynClient(),
 			DetectBindingResources: false,
 			SBR:                    nil,
-			Client:                 f.FakeClient(),
+			RESTMapper:             testutils.BuildTestRESTMapper(),
 		},
 		wantBuildErr: ErrInvalidServiceBinderOptions("SBR"),
 	}))
@@ -534,11 +535,11 @@ func TestServiceBinder_Bind(t *testing.T) {
 			DynClient:              f.FakeDynClient(),
 			DetectBindingResources: false,
 			SBR:                    sbrMultipleServices,
-			Client:                 f.FakeClient(),
 			Binding: &Binding{
 				EnvVars:    map[string][]byte{},
 				VolumeKeys: []string{},
 			},
+			RESTMapper: testutils.BuildTestRESTMapper(),
 		},
 		wantConditions: []wantedCondition{
 			{

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -19,5 +19,9 @@ func BuildTestRESTMapper() meta.RESTMapper {
 		schema.GroupVersionKind{Kind: "ConfigMap", Version: "v1"},
 		meta.RESTScopeNamespace,
 	)
+	restMapper.Add(
+		schema.GroupVersionKind{Kind: "Deployment", Version: "v1", Group: "apps"},
+		meta.RESTScopeNamespace,
+	)
 	return restMapper
 }

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ocav1 "github.com/openshift/api/apps/v1"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -205,11 +203,6 @@ func (f *Fake) AddMockedUnstructuredConfigMap(name string) {
 
 func (f *Fake) AddMockResource(resource runtime.Object) {
 	f.objs = append(f.objs, resource)
-}
-
-// FakeClient returns fake structured api client.
-func (f *Fake) FakeClient() client.Client {
-	return fake.NewFakeClientWithScheme(f.S, f.objs...)
 }
 
 // FakeDynClient returns fake dynamic api client.


### PR DESCRIPTION
### Motivation
Discussion https://github.com/redhat-developer/service-binding-operator/issues/450
Mixed using of clientsets will cause trouble for testing. As dynamic client is enough for binder to  interact with the API server, it is better to use a single dynamic client.
### Changes

- Remove dependency of client.Client in binder.
- Change the search behavior of binder for cases that `ResourceRef` is defined expilictly. Fake client will not filter objects by fieldselector.
- Add RESTMapper to binder to convert GVK and GVR


### Testing
Fixed potential test issues.
