### PR TITLE
Introduce id field in service selector to be used as shortcut in custom environment variables

### DIFF
--- a/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
+++ b/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
@@ -116,6 +116,8 @@ spec:
                   type: string
                 envVarPrefix:
                   type: string
+                id:
+                  type: string
               required:
               - group
               - kind
@@ -141,6 +143,8 @@ spec:
                   version:
                     type: string
                   envVarPrefix:
+                    type: string
+                  id:
                     type: string
                 required:
                 - group

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -65,6 +65,7 @@ type BackingServiceSelector struct {
 	// +optional
 	Namespace    *string `json:"namespace,omitempty"`
 	EnvVarPrefix *string `json:"envVarPrefix,omitempty"`
+	Id           *string `json:"id,omitempty"`
 }
 
 // BoundApplication defines the application workloads to which the binding secret has

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -58,6 +58,16 @@ func (in *BackingServiceSelector) DeepCopyInto(out *BackingServiceSelector) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.EnvVarPrefix != nil {
+		in, out := &in.EnvVarPrefix, &out.EnvVarPrefix
+		*out = new(string)
+		**out = **in
+	}
+	if in.Id != nil {
+		in, out := &in.Id, &out.Id
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -85,6 +85,20 @@ func (r *retriever) processServiceContext(
 		return nil, nil, err
 	}
 
+	// add an entry in the custom environment variable context with the informed 'id'.
+	//
+	// `{{ .db_testing.status.connectionUrl }}`
+	if svcCtx.id != nil {
+		err = unstructured.SetNestedField(
+			customEnvVarCtx,
+			svcCtx.service.Object,
+			*svcCtx.id,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	envVars := make(map[string][]byte, len(svcEnvVars))
 	for k, v := range svcEnvVars {
 		envVars[k] = []byte(v)

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -2,22 +2,38 @@ package servicebindingrequest
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
-func TestRetriever(t *testing.T) {
+func toIndexTemplate(obj *unstructured.Unstructured, fieldPath string) string {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	name := obj.GetName()
+	parts := strings.Split(fieldPath, ".")
+	var newParts []string
+	for _, part := range parts {
+		newParts = append(newParts, fmt.Sprintf(`%q`, part))
+	}
+	indexArg := strings.Join(newParts, " ")
+	return fmt.Sprintf(
+		`{{ index . %q %q %q %q %s }}`, gvk.Version, gvk.Group, gvk.Kind, name, indexArg)
+}
+
+func TestRetrieverProcessServiceContexts(t *testing.T) {
+
 	logf.SetLogger(logf.ZapLogger(true))
 
 	ns := "testing"
-	backingServiceNs := "backing-servicec-ns"
+	backingServiceNs := "backing-service-ns"
 	crName := "db-testing"
+	crId := "db_testing"
 
 	f := mocks.NewFake(t, ns)
 	f.AddMockedUnstructuredCSV("csv")
@@ -26,41 +42,93 @@ func TestRetriever(t *testing.T) {
 	cr, err := mocks.UnstructuredDatabaseCRMock(backingServiceNs, crName)
 	require.NoError(t, err)
 
-	crInSameNamespace, err := mocks.UnstructuredDatabaseCRMock(ns, crName)
-	require.NoError(t, err)
-
-	serviceCtxs := serviceContextList{
-		{
-			service: cr,
-		},
-		{
-			service: crInSameNamespace,
-		},
-	}
-
 	fakeDynClient := f.FakeDynClient()
 
-	toTmpl := func(obj *unstructured.Unstructured) string {
-		gvk := obj.GetObjectKind().GroupVersionKind()
-		name := obj.GetName()
-		return fmt.Sprintf(`{{ index . %q %q %q %q "metadata" "name" }}`, gvk.Version, gvk.Group, gvk.Kind, name)
+	type testCase struct {
+		dataMapping  []corev1.EnvVar
+		envVarPrefix string
+		expected     map[string][]byte
+		name         string
+		svcCtxs      serviceContextList
 	}
 
-	actual, _, err := NewRetriever(fakeDynClient).ProcessServiceContexts(
-		"SERVICE_BINDING",
-		serviceCtxs,
-		[]v1.EnvVar{
-			{Name: "SAME_NAMESPACE", Value: toTmpl(crInSameNamespace)},
-			{Name: "OTHER_NAMESPACE", Value: toTmpl(cr)},
-			{Name: "DIRECT_ACCESS", Value: `{{ .v1alpha1.postgresql_baiju_dev.Database.db_testing.metadata.name }}`},
+	testCases := []testCase{
+		{
+			name:         "access with index should return correct value",
+			envVarPrefix: "SERVICE_BINDING",
+			svcCtxs: serviceContextList{
+				{service: cr},
+			},
+			dataMapping: []corev1.EnvVar{
+				{Name: "SAME_NAMESPACE", Value: toIndexTemplate(cr, "metadata.name")},
+			},
+			expected: map[string][]byte{
+				"SERVICE_BINDING_SAME_NAMESPACE": []byte(cr.GetName()),
+			},
 		},
-	)
-	require.NoError(t, err)
-	require.Equal(t, map[string][]byte{
-		"SERVICE_BINDING_SAME_NAMESPACE":  []byte(crInSameNamespace.GetName()),
-		"SERVICE_BINDING_OTHER_NAMESPACE": []byte(cr.GetName()),
-		"SERVICE_BINDING_DIRECT_ACCESS":   []byte(cr.GetName()),
-	}, actual)
+		{
+			name:         "direct access with apiVersion and kind should return correct value",
+			envVarPrefix: "SERVICE_BINDING",
+			svcCtxs: serviceContextList{
+				{service: cr},
+			},
+			dataMapping: []corev1.EnvVar{
+				{
+					Name:  "DIRECT_ACCESS",
+					Value: `{{ .v1alpha1.postgresql_baiju_dev.Database.db_testing.metadata.name }}`,
+				},
+			},
+			expected: map[string][]byte{
+				"SERVICE_BINDING_DIRECT_ACCESS": []byte(cr.GetName()),
+			},
+		},
+		{
+			name:         "direct access with declared id should return correct value",
+			envVarPrefix: "SERVICE_BINDING",
+			svcCtxs: serviceContextList{
+				{
+					service: cr,
+					id:      &crId,
+				},
+			},
+			dataMapping: []corev1.EnvVar{
+				{
+					Name:  "ID_ACCESS",
+					Value: `{{ .db_testing.metadata.name }}`,
+				},
+			},
+			expected: map[string][]byte{
+				"SERVICE_BINDING_ID_ACCESS": []byte(cr.GetName()),
+			},
+		},
+		{
+			name:         "direct access without declared id should return <no value>",
+			envVarPrefix: "SERVICE_BINDING",
+			svcCtxs: serviceContextList{
+				{
+					service: cr,
+				},
+			},
+			dataMapping: []corev1.EnvVar{
+				{
+					Name:  "ID_ACCESS",
+					Value: `{{ .db_testing.metadata.name }}`,
+				},
+			},
+			expected: map[string][]byte{
+				"SERVICE_BINDING_ID_ACCESS": []byte("<no value>"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, err := NewRetriever(fakeDynClient).ProcessServiceContexts(
+				tc.envVarPrefix, tc.svcCtxs, tc.dataMapping)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
 }
 
 func TestBuildServiceEnvVars(t *testing.T) {

--- a/pkg/controller/servicebindingrequest/service.go
+++ b/pkg/controller/servicebindingrequest/service.go
@@ -192,7 +192,7 @@ func buildOwnedResourceContext(
 ) (*serviceContext, error) {
 	svcCtx, err := buildServiceContext(
 		client, obj.GetNamespace(), obj.GetObjectKind().GroupVersionKind(), obj.GetName(),
-		ownerEnvVarPrefix, restMapper)
+		ownerEnvVarPrefix, restMapper, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/servicebindingrequest/servicecontext.go
+++ b/pkg/controller/servicebindingrequest/servicecontext.go
@@ -23,6 +23,8 @@ type serviceContext struct {
 	volumeKeys []string
 	// envVarPrefix indicates the prefix to use in environment variables.
 	envVarPrefix *string
+	// Id indicates a name the service can be referred in custom environment variables.
+	id *string
 }
 
 // serviceContextList is a list of ServiceContext values.
@@ -58,7 +60,7 @@ func buildServiceContexts(
 		ns := stringValueOrDefault(s.Namespace, defaultNs)
 		gvk := schema.GroupVersionKind{Kind: s.Kind, Version: s.Version, Group: s.Group}
 		svcCtx, err := buildServiceContext(
-			client, ns, gvk, s.ResourceRef, s.EnvVarPrefix, restMapper)
+			client, ns, gvk, s.ResourceRef, s.EnvVarPrefix, restMapper, s.Id)
 		if err != nil {
 			return nil, err
 		}
@@ -127,6 +129,7 @@ func buildServiceContext(
 	resourceRef string,
 	envVarPrefix *string,
 	restMapper meta.RESTMapper,
+	id *string,
 ) (*serviceContext, error) {
 	obj, err := findService(client, ns, gvk, resourceRef)
 	if err != nil {
@@ -202,6 +205,7 @@ func buildServiceContext(
 		envVars:      envVars,
 		volumeKeys:   volumeKeys,
 		envVarPrefix: envVarPrefix,
+		id:           id,
 	}
 
 	return serviceCtx, nil


### PR DESCRIPTION
### Motivation

With the configuration values collection and aggregation solved in #407, this change introduces the `id` field in backing service selectors to be used as alias while composing custom environment variables.

Solves #396 

### Changes

#407 has grouped service configuration values in the template context using the following the version, api group, kind and name (for example `{{ .v1alpha1.postgresql_baiju_dev.Database.db_testing.status.dbConnection }}`).

This change groups service configuration values in the template context using the optional `id` field declared by the user, allowing the user to write `{{ .db_testing.status.dbConnection }}` instead.

For further more details refer the CONTRIBUTING.md