### PR TITLE
Remove unnecessary comment

### DIFF
--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -10,9 +10,6 @@ import (
 
 // ServiceBindingRequestSpec defines the desired state of ServiceBindingRequest
 type ServiceBindingRequestSpec struct {
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags:
-	// 	https://book.kubebuilder.io/beyond_basics/generating_crd.html
 	// MountPathPrefix is the prefix for volume mount
 	// +optional
 	MountPathPrefix string `json:"mountPathPrefix,omitempty"`


### PR DESCRIPTION
### Motivation

This cleanup is required to autogenerate CRD from the source.
Refer:
https://github.com/redhat-developer/service-binding-operator/pull/469#discussion_r425122945

### Changes

Remove unnecessary comment

### Testing

Regular tests should pass.