### PR TITLE
[Fix #447]  correctly detect multiple secret created by a service operator

### DIFF
--- a/pkg/controller/servicebindingrequest/service.go
+++ b/pkg/controller/servicebindingrequest/service.go
@@ -170,11 +170,11 @@ func getOwnedResources(
 		if err != nil {
 			return resources, err
 		}
-		for _, item := range lst.Items {
+		for idx, item := range lst.Items {
 			owners := item.GetOwnerReferences()
 			for _, owner := range owners {
 				if owner.UID == uid {
-					resources = append(resources, &item)
+					resources = append(resources, &lst.Items[idx])
 				}
 			}
 		}

--- a/pkg/controller/servicebindingrequest/servicecontext_test.go
+++ b/pkg/controller/servicebindingrequest/servicecontext_test.go
@@ -128,46 +128,69 @@ func TestFindOwnedResourcesCtxs_ConfigMap(t *testing.T) {
 	})
 }
 
-func TestFindOwnedResourcesCtxs_Secret(t *testing.T) {
-	f := mocks.NewFake(t, "test")
-	cr := mocks.DatabaseCRMock("test", "test")
-	reference := metav1.OwnerReference{
-		APIVersion:         cr.APIVersion,
-		Kind:               cr.Kind,
-		Name:               cr.Name,
-		UID:                cr.UID,
-		Controller:         &trueBool,
-		BlockOwnerDeletion: &trueBool,
+func TestFindOwnedResourcesCtxs_Secrets(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		secrets []string
+	}{
+		{
+			desc:    "backend cr creating only one secret should returns only one child",
+			secrets: []string{"test_database"},
+		},
+		{
+			desc:    "backend cr creating multiple secrets should returns only multiple children",
+			secrets: []string{"test_database", "test_database2"},
+		},
 	}
-	secret := mocks.SecretMock("test", "test_database")
-	us := &unstructured.Unstructured{}
-	uc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&secret)
-	require.NoError(t, err)
-	us.Object = uc
-	us.SetOwnerReferences([]metav1.OwnerReference{reference})
-	route, err := runtime.DefaultUnstructuredConverter.ToUnstructured(mocks.RouteCRMock("test", "test"))
-	require.NoError(t, err)
-	usRoute := &unstructured.Unstructured{Object: route}
-	usRoute.SetOwnerReferences([]metav1.OwnerReference{reference})
-	f.S.AddKnownTypes(pgv1alpha1.SchemeGroupVersion, &pgv1alpha1.Database{})
-	f.S.AddKnownTypes(routev1.SchemeGroupVersion, &routev1.Route{})
-	f.AddMockResource(cr)
-	f.AddMockResource(us)
-	f.AddMockResource(&unstructured.Unstructured{Object: route})
 
-	restMapper := testutils.BuildTestRESTMapper()
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			f := mocks.NewFake(t, "test")
+			cr := mocks.DatabaseCRMock("test", "test")
+			reference := metav1.OwnerReference{
+				APIVersion:         cr.APIVersion,
+				Kind:               cr.Kind,
+				Name:               cr.Name,
+				UID:                cr.UID,
+				Controller:         &trueBool,
+				BlockOwnerDeletion: &trueBool,
+			}
+			route, err := runtime.DefaultUnstructuredConverter.ToUnstructured(mocks.RouteCRMock("test", "test"))
+			require.NoError(t, err)
+			usRoute := &unstructured.Unstructured{Object: route}
+			usRoute.SetOwnerReferences([]metav1.OwnerReference{reference})
+			f.S.AddKnownTypes(pgv1alpha1.SchemeGroupVersion, &pgv1alpha1.Database{})
+			f.S.AddKnownTypes(routev1.SchemeGroupVersion, &routev1.Route{})
+			f.AddMockResource(cr)
+			f.AddMockResource(&unstructured.Unstructured{Object: route})
 
-	t.Run("existing selectors", func(t *testing.T) {
-		ownedResourcesCtxs, err := findOwnedResourcesCtxs(
-			f.FakeDynClient(),
-			cr.GetNamespace(),
-			cr.GetName(),
-			cr.GetUID(),
-			cr.GroupVersionKind(),
-			nil,
-			restMapper,
-		)
-		require.NoError(t, err)
-		require.NotEmpty(t, ownedResourcesCtxs)
-	})
+			restMapper := testutils.BuildTestRESTMapper()
+
+			for _, secret := range tC.secrets {
+				secret := mocks.SecretMock("test", secret)
+				us := &unstructured.Unstructured{}
+				uc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&secret)
+				require.NoError(t, err)
+				us.Object = uc
+				us.SetOwnerReferences([]metav1.OwnerReference{reference})
+				f.AddMockResource(us)
+			}
+
+			ownedResourcesCtxs, err := findOwnedResourcesCtxs(
+				f.FakeDynClient(),
+				cr.GetNamespace(),
+				cr.GetName(),
+				cr.GetUID(),
+				cr.GroupVersionKind(),
+				nil,
+				restMapper,
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, ownedResourcesCtxs)
+			require.EqualValues(t, len(tC.secrets), len(ownedResourcesCtxs))
+			for idx, resource := range ownedResourcesCtxs {
+				require.Equal(t, tC.secrets[idx], resource.service.GetName())
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Motivation
Fixes: #477 

### Changes

currently secret is being added copy by reference of `&item` var, which is being changed after each for loop iteration,
so eventually resource slice will have same address elements. 
```
for _, item := range lst.Items {
  if owner.UID == uid {
     resources = append(resources, &item)
  }
}
```

This is being changed in PR where addresses passed to slice would be different.
```
for idx, _ := range lst.Items {
  if owner.UID == uid {
      resources = append(resources, &lst.Items[idx])
  }
}
```

### Testing
Run all tests with `make test-unit`