### PR TITLE
Updates ServiceBindingRequestStatus.Applications documentation comment

### DIFF
--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -53,7 +53,7 @@ type ServiceBindingRequestStatus struct {
 	Conditions []conditionsv1.Condition `json:"conditions"`
 	// Secret is the name of the intermediate secret
 	Secret string `json:"secret"`
-	// ApplicationObjects contains all the application objects filtered by label
+	// Applications contain all the applications filtered by name or label
 	// +optional
 	Applications []BoundApplication `json:"applications,omitempty"`
 }


### PR DESCRIPTION
### Motivation

Updates ServiceBindingRequestStatus.Applications documentation comment to:
[1] remove the word `ApplicationObjects`
[2] specify the `name` filter criteria of applications