### PR TITLE
make leader-with-lease as an option of deployment

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -101,11 +101,13 @@ func main() {
 				os.Exit(1)
 			}
 		} else {
+			leaderNS := os.Getenv("SERVICE_BINDING_OPERATOR_LEADER_ELECTION_NAMESPACE")
 			opts = manager.Options{
-				Namespace:          namespace,
-				MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-				LeaderElection:     true,
-				LeaderElectionID:   getOperatorName(),
+				Namespace:               namespace,
+				MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+				LeaderElection:          true,
+				LeaderElectionID:        getOperatorName(),
+				LeaderElectionNamespace: leaderNS,
 			}
 		}
 	} else {


### PR DESCRIPTION
### Motivation

 Per issue https://github.com/redhat-developer/service-binding-operator/issues/488 
### Changes
Make changes per 
https://github.com/operator-framework/operator-sdk/blob/c93321571d8300bb1f60f548de12e83f05d2d267/doc/user-guide.md#leader-for-life
https://github.com/operator-framework/operator-sdk/blob/c93321571d8300bb1f60f548de12e83f05d2d267/doc/user-guide.md#leader-with-lease

No change in deployment yaml , so by default the `leader-for-life` will be used. 
`leader-with-lease` is enabled only when the environment variable SERVICE_BINDING_OPERATOR_LEADER_ELECTION_OPTION is set to `leader-with-lease` explicitly 

### Testing

There is no main_test.go ..  So I didn't add test case for this yet. 

For further more details refer the CONTRIBUTING.md