### PR TITLE
Fix bug where binding data is expected to overwrite the related resource name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ endif
 
 ZAP_FLAGS = $(ZAP_ENCODER_FLAG) $(ZAP_LEVEL_FLAG)
 
+SKIP_CLEANUP_ERROR ?= true
+
 # Create output directory for artifacts and test results. ./out is supposed to
 # be a safe place for all targets to write to while knowing that all content
 # inside of ./out is wiped once "make clean" is run.
@@ -219,7 +221,7 @@ test-e2e: e2e-setup deploy-crds
 		operator-sdk --verbose test local ./test/e2e \
 			--namespace $(TEST_NAMESPACE) \
 			--up-local \
-			--skip-cleanup-error=true \
+			--skip-cleanup-error=$(SKIP_CLEANUP_ERROR) \
 			--go-test-flags "-timeout=110m" \
 			--local-operator-flags "$(ZAP_FLAGS)" \
 			$(OPERATOR_SDK_EXTRA_ARGS) \

--- a/pkg/controller/servicebindingrequest/annotations/annotations.go
+++ b/pkg/controller/servicebindingrequest/annotations/annotations.go
@@ -40,6 +40,8 @@ type result struct {
 	Type bindingType
 	// Path is the nested location the collected data can be found in the Data field.
 	Path string
+	// RawData is...
+	RawData map[string]interface{}
 }
 
 // handler should be implemented by types that want to offer a mechanism to provide binding data to

--- a/pkg/controller/servicebindingrequest/annotations/annotations.go
+++ b/pkg/controller/servicebindingrequest/annotations/annotations.go
@@ -40,7 +40,10 @@ type result struct {
 	Type bindingType
 	// Path is the nested location the collected data can be found in the Data field.
 	Path string
-	// RawData is...
+	// RawData contains the annotation data collected by an annotation handler
+	// inside a deep structure with its root being composed by the path where
+	// the external resource name was extracted and the path within the external
+	// resource.
 	RawData map[string]interface{}
 }
 

--- a/pkg/controller/servicebindingrequest/annotations/resource.go
+++ b/pkg/controller/servicebindingrequest/annotations/resource.go
@@ -149,10 +149,17 @@ func (h *resourceHandler) Handle() (result, error) {
 		h.bindingInfo.SourcePath,
 	}, ".")
 
+	rawDataPath := strings.Join([]string{
+		h.bindingInfo.ResourceReferencePath,
+		h.bindingInfo.SourcePath,
+	}, ".")
+
 	return result{
 		Data: nested.ComposeValue(val, nested.NewPath(outputPath)),
 		Type: typ,
 		Path: outputPath,
+
+		RawData: nested.ComposeValue(val, nested.NewPath(rawDataPath)),
 	}, nil
 }
 

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -150,6 +150,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	serviceCtxs, err := buildServiceContexts(
+		logger.WithName("buildServiceContexts"),
 		r.dynClient,
 		sbr.GetNamespace(),
 		selectors,

--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -3,6 +3,7 @@ package servicebindingrequest
 import (
 	"context"
 	"errors"
+	"sort"
 
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -67,6 +68,21 @@ func (r *reconciler) getServiceBindingRequest(
 	return sbr, nil
 }
 
+// distinctServiceSelectors returns the distinct elements from the given service selector slice.
+func distinctServiceSelectors(selectors []v1alpha1.BackingServiceSelector) []v1alpha1.BackingServiceSelector {
+	distinct := make(map[v1alpha1.BackingServiceSelector]bool)
+	for _, v := range selectors {
+		distinct[v] = true
+	}
+
+	var output []v1alpha1.BackingServiceSelector
+	for k := range distinct {
+		output = append(output, k)
+	}
+
+	return output
+}
+
 // extractServiceSelectors returns a list of all BackingServiceSelector items from a
 // ServiceBindingRequest.
 //
@@ -84,7 +100,17 @@ func extractServiceSelectors(
 	if inSelectors != nil {
 		selectors = append(selectors, *inSelectors...)
 	}
-	return selectors
+
+	// FIXME(isuttonl): sorting selectors using name and namespace can be more robust.
+	sort.Slice(selectors, func(i, j int) bool {
+		a := selectors[i].ResourceRef < selectors[j].ResourceRef
+		b := selectors[j].Namespace != nil &&
+			selectors[i].Namespace != nil &&
+			*selectors[i].Namespace < *selectors[j].Namespace
+		return a && b
+	})
+
+	return distinctServiceSelectors(selectors)
 }
 
 // Reconcile a ServiceBindingRequest by the following steps:

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -37,7 +37,7 @@ func TestRetrieverProcessServiceContexts(t *testing.T) {
 
 	f := mocks.NewFake(t, ns)
 	f.AddMockedUnstructuredCSV("csv")
-	f.AddNamespacedMockedSecret("db-credentials", backingServiceNs)
+	f.AddNamespacedMockedSecret("db-credentials", backingServiceNs, nil)
 
 	cr, err := mocks.UnstructuredDatabaseCRMock(backingServiceNs, crName)
 	require.NoError(t, err)

--- a/pkg/controller/servicebindingrequest/service.go
+++ b/pkg/controller/servicebindingrequest/service.go
@@ -191,8 +191,15 @@ func buildOwnedResourceContext(
 	outputPath string,
 ) (*serviceContext, error) {
 	svcCtx, err := buildServiceContext(
-		client, obj.GetNamespace(), obj.GetObjectKind().GroupVersionKind(), obj.GetName(),
-		ownerEnvVarPrefix, restMapper, nil)
+		reconcilerLog.WithName("buildServiceContext"),
+		client,
+		obj.GetNamespace(),
+		obj.GetObjectKind().GroupVersionKind(),
+		obj.GetName(),
+		ownerEnvVarPrefix,
+		restMapper,
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/servicebindingrequest/service_test.go
+++ b/pkg/controller/servicebindingrequest/service_test.go
@@ -50,7 +50,7 @@ func TestPlannerWithExplicitBackingServiceNamespace(t *testing.T) {
 	f.AddMockedUnstructuredDatabaseCRD()
 	f.AddMockedUnstructuredCSV("cluster-service-version")
 	db := f.AddMockedDatabaseCR(resourceRef, backingServiceNamespace)
-	f.AddNamespacedMockedSecret("db-credentials", backingServiceNamespace)
+	f.AddNamespacedMockedSecret("db-credentials", backingServiceNamespace, nil)
 
 	t.Run("findService", func(t *testing.T) {
 		cr, err := findService(

--- a/pkg/controller/servicebindingrequest/servicecontext_test.go
+++ b/pkg/controller/servicebindingrequest/servicecontext_test.go
@@ -6,6 +6,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	pgv1alpha1 "github.com/operator-backing-service-samples/postgresql-operator/pkg/apis/postgresql/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/pkg/log"
 	"github.com/redhat-developer/service-binding-operator/pkg/testutils"
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 	"github.com/stretchr/testify/require"
@@ -15,43 +16,130 @@ import (
 )
 
 func TestBuildServiceContexts(t *testing.T) {
-	ns := "planner"
-	name := "service-binding-request"
-	resourceRef := "db-testing"
-	matchLabels := map[string]string{
-		"connects-to": "database",
-		"environment": "planner",
-	}
-	f := mocks.NewFake(t, ns)
-	sbr := f.AddMockedServiceBindingRequest(name, nil, resourceRef, "", deploymentsGVR, matchLabels)
-	sbr.Spec.BackingServiceSelectors = &[]v1alpha1.BackingServiceSelector{
-		*sbr.Spec.BackingServiceSelector,
-	}
-	f.AddMockedUnstructuredCSV("cluster-service-version")
-	f.AddMockedDatabaseCR(resourceRef, ns)
-	f.AddMockedUnstructuredDatabaseCRD()
-	f.AddMockedUnstructuredSecret("db-credentials")
-
+	logger := log.NewLog("testBuildServiceContexts")
 	restMapper := testutils.BuildTestRESTMapper()
 
-	t.Run("existing selectors", func(t *testing.T) {
+	t.Run("empty selectors", func(t *testing.T) {
+		ns := "planner"
+		f := mocks.NewFake(t, ns)
 		serviceCtxs, err := buildServiceContexts(
-			nil, f.FakeDynClient(), ns, extractServiceSelectors(sbr), false, restMapper)
-		require.NoError(t, err)
-		require.NotEmpty(t, serviceCtxs)
+			logger, f.FakeDynClient(), ns, nil, false, restMapper)
+
+		require.NoError(t, err, "buildServiceContexts must execute without errors")
+		require.Empty(t, serviceCtxs, "buildServiceContexts must be empty")
 	})
 
-	t.Run("empty selectors", func(t *testing.T) {
-		serviceCtxs, err := buildServiceContexts(nil, f.FakeDynClient(), ns, nil, false, restMapper)
-		require.NoError(t, err)
-		require.Empty(t, serviceCtxs)
+	t.Run("declared and existing selectors", func(t *testing.T) {
+		sbrName := "service-binding-request"
+		firstResourceRef := "db-testing"
+		firstNamespace := "existing-namespace"
+		matchLabels := map[string]string{
+			"connects-to": "database",
+			"environment": "planner",
+		}
+
+		f := mocks.NewFake(t, firstNamespace)
+		f.AddMockedUnstructuredCSV("cluster-service-version")
+		f.AddMockedDatabaseCR(firstResourceRef, firstNamespace)
+		f.AddMockedUnstructuredDatabaseCRD()
+		f.AddNamespacedMockedSecret("db-credentials", firstNamespace, nil)
+
+		sbr := f.AddMockedServiceBindingRequest(sbrName, nil, firstResourceRef, "", deploymentsGVR, matchLabels)
+
+		serviceCtxs, err := buildServiceContexts(
+			logger, f.FakeDynClient(), firstNamespace, extractServiceSelectors(sbr), false, restMapper)
+
+		require.NoError(t, err, "buildServiceContexts must execute without errors")
+		require.Len(t, serviceCtxs, 1, "buildServiceContexts must return only one item")
+
+		serviceCtx := serviceCtxs[0]
+		expectedKeys := []string{"status", "dbCredentials"}
+		expectedDbCredentials := map[string]interface{}{
+			"username": "user",
+			"password": "password",
+		}
+
+		gotDbCredentials, ok, err :=
+			unstructured.NestedFieldCopy(serviceCtx.service.Object, expectedKeys...)
+		require.NoError(t, err, "must not return error while copying status.dbCredentials out of the context's service")
+		require.True(t, ok, "status.dbCredentials must exist")
+		require.Equal(t, expectedDbCredentials, gotDbCredentials, "status.dbCredentials in context must be equal to expected")
 	})
 
 	t.Run("services in different namespace", func(t *testing.T) {
+		sameNs := "same-ns"
+		sameNsResourceRef := "same-ns-database"
+
+		otherNs := "other-ns"
+		otherNsResourceRef := "other-ns-database"
+
+		matchLabels := map[string]string{
+			"connects-to": "database",
+			"environment": "planner",
+		}
+
+		f := mocks.NewFake(t, sameNs)
+		f.AddMockedUnstructuredDatabaseCRD()
+		f.AddMockedDatabaseCR(sameNsResourceRef, sameNs)
+		f.AddNamespacedMockedSecret("db-credentials", sameNs, map[string][]byte{
+			"username": []byte("same-ns-username"),
+			"password": []byte("same-ns-password"),
+		})
+
+		f.AddMockedDatabaseCR(otherNsResourceRef, otherNs)
+		f.AddNamespacedMockedSecret("db-credentials", otherNs, map[string][]byte{
+			"username": []byte("other-ns-username"),
+			"password": []byte("other-ns-password"),
+		})
+
+		sbrName := "services-in-different-ns"
+
+		sbr := f.AddMockedServiceBindingRequest(sbrName, &sameNs, sameNsResourceRef, "", deploymentsGVR, matchLabels)
+		sbr.Spec.BackingServiceSelectors = &[]v1alpha1.BackingServiceSelector{
+			{
+				GroupVersionKind: metav1.GroupVersionKind{
+					Group:   mocks.CRDName,
+					Version: mocks.CRDVersion,
+					Kind:    mocks.CRDKind,
+				},
+				ResourceRef: otherNsResourceRef,
+				Namespace:   &otherNs,
+			},
+		}
+
 		serviceCtxs, err := buildServiceContexts(
-			nil, f.FakeDynClient(), ns, extractServiceSelectors(sbr), false, restMapper)
-		require.NoError(t, err)
-		require.NotEmpty(t, serviceCtxs)
+			logger, f.FakeDynClient(), sameNs, extractServiceSelectors(sbr), false, restMapper)
+
+		require.NoError(t, err, "buildServiceContexts must execute without errors")
+		require.Len(t, serviceCtxs, 2, "buildServiceContexts must return both service contexts")
+
+		{
+			otherNsCtx := serviceCtxs[0]
+			expectedKeys := []string{"status", "dbCredentials"}
+			expectedDbCredentials := map[string]interface{}{
+				"username": "other-ns-username",
+				"password": "other-ns-password",
+			}
+			gotDbCredentials, ok, err :=
+				unstructured.NestedFieldCopy(otherNsCtx.service.Object, expectedKeys...)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, expectedDbCredentials, gotDbCredentials)
+		}
+
+		{
+			sameNsCtx := serviceCtxs[1]
+			expectedKeys := []string{"status", "dbCredentials"}
+			expectedDbCredentials := map[string]interface{}{
+				"username": "same-ns-username",
+				"password": "same-ns-password",
+			}
+			gotDbCredentials, ok, err :=
+				unstructured.NestedFieldCopy(sameNsCtx.service.Object, expectedKeys...)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, expectedDbCredentials, gotDbCredentials)
+		}
 	})
 }
 
@@ -120,7 +208,7 @@ func TestFindOwnedResourcesCtxs_ConfigMap(t *testing.T) {
 		expected := map[string]interface{}{
 			"": map[string]interface{}{
 				"password": "password",
-				"user":     "user",
+				"username": "user",
 			},
 		}
 		require.Equal(t, expected, got[0].envVars)

--- a/pkg/controller/servicebindingrequest/servicecontext_test.go
+++ b/pkg/controller/servicebindingrequest/servicecontext_test.go
@@ -36,20 +36,20 @@ func TestBuildServiceContexts(t *testing.T) {
 
 	t.Run("existing selectors", func(t *testing.T) {
 		serviceCtxs, err := buildServiceContexts(
-			f.FakeDynClient(), ns, extractServiceSelectors(sbr), false, restMapper)
+			nil, f.FakeDynClient(), ns, extractServiceSelectors(sbr), false, restMapper)
 		require.NoError(t, err)
 		require.NotEmpty(t, serviceCtxs)
 	})
 
 	t.Run("empty selectors", func(t *testing.T) {
-		serviceCtxs, err := buildServiceContexts(f.FakeDynClient(), ns, nil, false, restMapper)
+		serviceCtxs, err := buildServiceContexts(nil, f.FakeDynClient(), ns, nil, false, restMapper)
 		require.NoError(t, err)
 		require.Empty(t, serviceCtxs)
 	})
 
 	t.Run("services in different namespace", func(t *testing.T) {
 		serviceCtxs, err := buildServiceContexts(
-			f.FakeDynClient(), ns, extractServiceSelectors(sbr), false, restMapper)
+			nil, f.FakeDynClient(), ns, extractServiceSelectors(sbr), false, restMapper)
 		require.NoError(t, err)
 		require.NotEmpty(t, serviceCtxs)
 	})
@@ -167,7 +167,7 @@ func TestFindOwnedResourcesCtxs_Secrets(t *testing.T) {
 			restMapper := testutils.BuildTestRESTMapper()
 
 			for _, secret := range tC.secrets {
-				secret := mocks.SecretMock("test", secret)
+				secret := mocks.SecretMock("test", secret, nil)
 				us := &unstructured.Unstructured{}
 				uc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&secret)
 				require.NoError(t, err)

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -306,7 +306,7 @@ func CreateDB(
 	}, 10*time.Second, 1*time.Second)
 
 	t.Log("Creating Database credentials secret mock object...")
-	dbSecret := mocks.SecretMock(ns, secretName)
+	dbSecret := mocks.SecretMock(ns, secretName, nil)
 	require.NoError(t, f.Client.Create(ctx, dbSecret, cleanupOpts))
 
 	return db

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -94,15 +94,19 @@ func TestAddSchemesToFramework(t *testing.T) {
 			ServiceBindingRequest(t, []Step{AppStep, DBStep, SBRStep})
 		})
 		t.Run("scenario-db-sbr-app", func(t *testing.T) {
+			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{DBStep, SBRStep, AppStep})
 		})
 		t.Run("scenario-app-sbr-db", func(t *testing.T) {
+			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{AppStep, SBRStep, DBStep})
 		})
 		t.Run("scenario-sbr-db-app", func(t *testing.T) {
+			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{SBRStep, DBStep, AppStep})
 		})
 		t.Run("scenario-sbr-app-db", func(t *testing.T) {
+			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{SBRStep, AppStep, DBStep})
 		})
 		t.Run("scenario-csv-db-app-sbr", func(t *testing.T) {

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -50,7 +50,7 @@ var (
 	// Intermediate secret should have following data
 	// for postgres operator
 	postgresSecretAssertion = map[string]string{
-		"DATABASE_SECRET_USER":     "user",
+		"DATABASE_SECRET_USERNAME": "user",
 		"DATABASE_SECRET_PASSWORD": "password",
 	}
 

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -288,6 +288,14 @@ func CreateDB(
 	ns := namespacedName.Namespace
 	resourceRef := namespacedName.Name
 
+	// order is important: the operator will follow first the database resource,
+	// then the secret holding the credential; in the case the secret is not
+	// there, default values will be set for each of the contributed
+	// configuration values declared in the Database custom resource definition.
+	t.Log("Creating Database credentials secret mock object...")
+	dbSecret := mocks.SecretMock(ns, secretName, nil)
+	require.NoError(t, f.Client.Create(ctx, dbSecret, cleanupOpts))
+
 	db := mocks.DatabaseCRMock(ns, resourceRef)
 	require.NoError(t, f.Client.Create(ctx, db, cleanupOpts))
 
@@ -304,10 +312,6 @@ func CreateDB(
 		}
 		return true
 	}, 10*time.Second, 1*time.Second)
-
-	t.Log("Creating Database credentials secret mock object...")
-	dbSecret := mocks.SecretMock(ns, secretName, nil)
-	require.NoError(t, f.Client.Create(ctx, dbSecret, cleanupOpts))
 
 	return db
 }

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -189,8 +189,8 @@ func (f *Fake) AddMockedUnstructuredSecret(name string) *unstructured.Unstructur
 
 // AddNamespacedMockedSecret add mocked object from SecretMock in a namespace
 // which isn't necessarily same as that of the ServiceBindingRequest namespace.
-func (f *Fake) AddNamespacedMockedSecret(name string, namespace string) {
-	f.objs = append(f.objs, SecretMock(namespace, name))
+func (f *Fake) AddNamespacedMockedSecret(name string, namespace string, data map[string][]byte) {
+	f.objs = append(f.objs, SecretMock(namespace, name, data))
 }
 
 // AddMockedUnstructuredConfigMap add mocked object from ConfigMapMock.

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -160,7 +160,7 @@ func PostgresDatabaseCRMock(ns, name string) PostgresDatabase {
 }
 
 func UnstructuredSecretMock(ns, name string) (*unstructured.Unstructured, error) {
-	s := SecretMock(ns, name)
+	s := SecretMock(ns, name, nil)
 	return converter.ToUnstructured(&s)
 }
 
@@ -353,7 +353,14 @@ func UnstructuredDatabaseCRMock(ns, name string) (*unstructured.Unstructured, er
 }
 
 // SecretMock returns a Secret based on PostgreSQL operator usage.
-func SecretMock(ns, name string) *corev1.Secret {
+func SecretMock(ns, name string, data map[string][]byte) *corev1.Secret {
+	if data == nil {
+		data = map[string][]byte{
+			"username": []byte("user"),
+			"password": []byte("password"),
+		}
+	}
+
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -363,10 +370,7 @@ func SecretMock(ns, name string) *corev1.Secret {
 			Namespace: ns,
 			Name:      name,
 		},
-		Data: map[string][]byte{
-			"username": []byte("user"),
-			"password": []byte("password"),
-		},
+		Data: data,
 	}
 }
 

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -98,7 +98,7 @@ func DatabaseCRDMock(ns string) apiextensionv1beta1.CustomResourceDefinition {
 	FullCRDName := CRDPlural + "." + CRDName
 	annotations := map[string]string{
 		"servicebindingoperator.redhat.io/status.dbCredentials-password": "binding:env:object:secret",
-		"servicebindingoperator.redhat.io/status.dbCredentials-user":     "binding:env:object:secret",
+		"servicebindingoperator.redhat.io/status.dbCredentials-username": "binding:env:object:secret",
 	}
 
 	crd := apiextensionv1beta1.CustomResourceDefinition{
@@ -364,7 +364,7 @@ func SecretMock(ns, name string) *corev1.Secret {
 			Name:      name,
 		},
 		Data: map[string][]byte{
-			"user":     []byte("user"),
+			"username": []byte("user"),
 			"password": []byte("password"),
 		},
 	}
@@ -382,7 +382,7 @@ func ConfigMapMock(ns, name string) *corev1.ConfigMap {
 			Name:      name,
 		},
 		Data: map[string]string{
-			"user":     "user",
+			"username": "user",
 			"password": "password",
 		},
 	}

--- a/test/third-party-crds/postgresql_v1alpha1_database_crd.yaml
+++ b/test/third-party-crds/postgresql_v1alpha1_database_crd.yaml
@@ -12,7 +12,7 @@ metadata:
     servicebindingoperator.redhat.io/status.dbConnectionIP: binding:env:attribute
     servicebindingoperator.redhat.io/status.dbConnectionPort: binding:env:attribute
     servicebindingoperator.redhat.io/status.dbCredentials-password: binding:env:object:secret
-    servicebindingoperator.redhat.io/status.dbCredentials-user: binding:env:object:secret
+    servicebindingoperator.redhat.io/status.dbCredentials-username: binding:env:object:secret
     servicebindingoperator.redhat.io/status.dbName: binding:env:attribute
 spec:
   group: postgresql.baiju.dev


### PR DESCRIPTION
### Motivation

A bug has been introduced in #407, changing the existing behavior where the data collected from the resource indicated by the annotation (either a `corev1.ConfigMap` or `corev1.Secret`) should also replace the field indicating the resource name with the collected data.

Let's take a look in the following example resource:

```yaml
metadata:
  annotations:
    servicebindingoperator.redhat.io/status.secretName: binding:env:object:secret
status:
  secretName: the-secret
```

Before #407, when `status.secretName` was used in a custom environment variable template, it would contain the whole `data` section of the related Secret, as the following excerpt from #475:

```
"status": {
  "secretName": {
    "apikey": "XXXX",
    "iam_apikey_description": "Auto-generated for key 0aef56aa-fbb2-4dd7-8bc7-972302e14573",
    "iam_apikey_name": "thetranslator5",
    "iam_role_crn": "crn:v1:bluemix:public:iam::::serviceRole:Manager",
    "iam_serviceid_crn": "crn:v1:bluemix:public:iam-identity::a/ef6a34810cbcd892507d3ebe01e3d95a::serviceid:ServiceId-71e18dc7-1d02-4704-b167-be29f4172044",
    "url": "https://api.us-south.language-translator.watson.cloud.ibm.com/instances/78abe198-feb8-41c9-b293-38b21beb8973"
  },
}
```

And after #407, the following results were obtained instead:

```
"status": {
  "secretName": "thetranslator5",
}
```

Closes #475 

### Changes

The contents of a related resource are collected, grouped and made available to the custom environment variable template engine; as an example, if the field path `.status.dbCredentials` represents a resource name, it is expected the related resource contents (more specifically the `.data` field) to be available under the same `.status.dbCredentials` path when composing a custom environment variable template in a Service Binding Request.

Below there is an example of what the input object (the service resource that contains the reference to the related resource) and the output object (the resource that is available to the custom environment template context):

```go
// inputObj is whatever object containing both annotations (either directly in it or through its 
// CRD or CSV.
inputObj := map[string]interface{}{
    "metadata": map[string]interface{}{
        // annotations create the relationship of .status.secretName to a secret
        "annotations": map[string]string{....},
    },
    "status": map[string]interface{}{
        // secretName contains the name of a resource living in the same namespace as the 
        // Service Binding Request.
        "secretName": "thetranslator5",
    },
}

// outputObj is inputPath with '.status.dbCredentials' 
outputObj := map[string]interface{}{
    "status": map[string]interface{}{
        "secretName": map[string]interface{}{
          "apikey": "XXXX",
          "iam_apikey_description": "Auto-generated for key 0aef56aa-fbb2-4dd7-8bc7-972302e14573",
          "iam_apikey_name": "thetranslator5",
          "iam_role_crn": "crn:v1:bluemix:public:iam::::serviceRole:Manager",
          "iam_serviceid_crn": "crn:v1:bluemix:public:iam-identity::a/ef6a34810cbcd892507d3ebe01e3d95a::serviceid:ServiceId-71e18dc7-1d02-4704-b167-be29f4172044",
          "url": "https://api.us-south.language-translator.watson.cloud.ibm.com/instances/78abe198-feb8-41c9-b293-38b21beb8973",
        },
    },
}
```

For further more details refer the CONTRIBUTING.md