### PR TITLE
make custom_env_var can reference the whole secret/configmap without using a slash

### DIFF
--- a/pkg/controller/servicebindingrequest/annotations/attribute.go
+++ b/pkg/controller/servicebindingrequest/annotations/attribute.go
@@ -47,6 +47,10 @@ func newAttributeHandler(
 	if len(bi.ResourceReferencePath) > 0 {
 		outputPath = bi.ResourceReferencePath
 	}
+	inputPath := bi.SourcePath
+	if inputPath == "" {
+		inputPath = bi.ResourceReferencePath
+	}
 
 	// the current implementation removes "status." and "spec." from fields exported through
 	// annotations.
@@ -57,7 +61,7 @@ func newAttributeHandler(
 	}
 
 	return &attributeHandler{
-		inputPath:  bi.SourcePath,
+		inputPath:  inputPath,
 		outputPath: outputPath,
 		resource:   resource,
 	}

--- a/pkg/controller/servicebindingrequest/annotations/bindinginfo.go
+++ b/pkg/controller/servicebindingrequest/annotations/bindinginfo.go
@@ -38,21 +38,24 @@ func NewBindingInfo(name string, value string) (*bindingInfo, error) {
 	if len(cleanName) == 0 {
 		return nil, ErrEmptyAnnotationName
 	}
-
 	parts := strings.SplitN(cleanName, "-", 2)
 
 	resourceReferencePath := parts[0]
-	sourcePath := parts[0]
-
+	// sourcePath := parts[0]
+	sourcePath := ""
+	descriptor := ""
 	// the annotation is a reference to another manifest
 	if len(parts) == 2 {
 		sourcePath = parts[1]
+		descriptor = strings.Join([]string{value, sourcePath}, ":")
+	} else {
+		descriptor = strings.Join([]string{value, resourceReferencePath}, ":")
 	}
 
 	return &bindingInfo{
 		ResourceReferencePath: resourceReferencePath,
 		SourcePath:            sourcePath,
-		Descriptor:            strings.Join([]string{value, sourcePath}, ":"),
+		Descriptor:            descriptor,
 		Value:                 value,
 	}, nil
 }

--- a/pkg/controller/servicebindingrequest/annotations/bindinginfo_test.go
+++ b/pkg/controller/servicebindingrequest/annotations/bindinginfo_test.go
@@ -39,7 +39,7 @@ func TestNewBindingInfo(t *testing.T) {
 			want: &bindingInfo{
 				Descriptor:            "binding:status.connectionString",
 				ResourceReferencePath: "status.connectionString",
-				SourcePath:            "status.connectionString",
+				SourcePath:            "",
 				Value:                 "binding",
 			},
 			name:    "{path} annotation",

--- a/pkg/controller/servicebindingrequest/annotations/configmap_test.go
+++ b/pkg/controller/servicebindingrequest/annotations/configmap_test.go
@@ -16,11 +16,12 @@ import (
 
 func TestConfigMapHandler(t *testing.T) {
 	type args struct {
-		name      string
-		value     string
-		service   map[string]interface{}
-		resources []runtime.Object
-		expected  map[string]interface{}
+		name            string
+		value           string
+		service         map[string]interface{}
+		resources       []runtime.Object
+		expectedData    map[string]interface{}
+		expectedRawData map[string]interface{}
 	}
 
 	assertHandler := func(args args) func(*testing.T) {
@@ -45,7 +46,8 @@ func TestConfigMapHandler(t *testing.T) {
 			got, err := handler.Handle()
 			require.NoError(t, err)
 			require.NotNil(t, got)
-			require.Equal(t, args.expected, got.Data)
+			require.Equal(t, args.expectedData, got.Data)
+			require.Equal(t, args.expectedRawData, got.RawData)
 		}
 	}
 
@@ -75,9 +77,16 @@ func TestConfigMapHandler(t *testing.T) {
 				},
 			},
 		},
-		expected: map[string]interface{}{
+		expectedData: map[string]interface{}{
 			"configmap": map[string]interface{}{
 				"password": "hunter2",
+			},
+		},
+		expectedRawData: map[string]interface{}{
+			"status": map[string]interface{}{
+				"dbCredentials": map[string]interface{}{
+					"password": "hunter2",
+				},
 			},
 		},
 	}))
@@ -108,10 +117,18 @@ func TestConfigMapHandler(t *testing.T) {
 				},
 			},
 		},
-		expected: map[string]interface{}{
+		expectedData: map[string]interface{}{
 			"configmap": map[string]interface{}{
 				"username": "AzureDiamond",
 				"password": "hunter2",
+			},
+		},
+		expectedRawData: map[string]interface{}{
+			"status": map[string]interface{}{
+				"dbCredentials": map[string]interface{}{
+					"username": "AzureDiamond",
+					"password": "hunter2",
+				},
 			},
 		},
 	}))

--- a/pkg/controller/servicebindingrequest/annotations/resource.go
+++ b/pkg/controller/servicebindingrequest/annotations/resource.go
@@ -85,7 +85,7 @@ func discoverBindingType(val string) (bindingType, error) {
 // the resulting slice.
 func getInputPathFields(bi *bindingInfo, inputPathPrefix *string) []string {
 	inputPathFields := []string{}
-	if bi.ResourceReferencePath != bi.SourcePath {
+	if bi.SourcePath != "" {
 		inputPathFields = append(inputPathFields, bi.SourcePath)
 	}
 	if inputPathPrefix != nil && len(*inputPathPrefix) > 0 {
@@ -105,7 +105,6 @@ func (h *resourceHandler) Handle() (result, error) {
 	if err != nil {
 		return result{}, err
 	}
-
 	inputPathFields := getInputPathFields(h.bindingInfo, h.inputPathRoot)
 	val, ok, err := unstructured.NestedFieldCopy(resource.Object, inputPathFields...)
 	if !ok {
@@ -147,18 +146,27 @@ func (h *resourceHandler) Handle() (result, error) {
 	}
 
 	// prefix the output path with the kind of the resource.
-	outputPath := strings.Join(outputPathParts, ".")
+	outputPath := ""
+	rawDataPath := ""
 
-	rawDataPath := strings.Join([]string{
-		h.bindingInfo.ResourceReferencePath,
-		h.bindingInfo.SourcePath,
-	}, ".")
+	if h.bindingInfo.SourcePath == "" {
+		outputPath = strings.ToLower(gvk.Kind)
+		rawDataPath = h.bindingInfo.ResourceReferencePath
+	} else {
+		outputPath = strings.Join([]string{
+			strings.ToLower(gvk.Kind),
+			h.bindingInfo.SourcePath,
+		}, ".")
+		rawDataPath = strings.Join([]string{
+			h.bindingInfo.ResourceReferencePath,
+			h.bindingInfo.SourcePath,
+		}, ".")
+	}
 
 	return result{
-		Data: nested.ComposeValue(val, nested.NewPath(outputPath)),
-		Type: typ,
-		Path: outputPath,
-
+		Data:    nested.ComposeValue(val, nested.NewPath(outputPath)),
+		Type:    typ,
+		Path:    outputPath,
 		RawData: nested.ComposeValue(val, nested.NewPath(rawDataPath)),
 	}, nil
 }
@@ -187,10 +195,6 @@ func NewResourceHandler(
 
 	if bi == nil {
 		return nil, invalidArgumentErr("bi")
-	}
-
-	if len(bi.SourcePath) == 0 {
-		return nil, invalidArgumentErr("bi.Path")
 	}
 
 	if len(bi.ResourceReferencePath) == 0 {

--- a/pkg/controller/servicebindingrequest/annotations/resource.go
+++ b/pkg/controller/servicebindingrequest/annotations/resource.go
@@ -120,8 +120,6 @@ func (h *resourceHandler) Handle() (result, error) {
 		return result{}, err
 	}
 
-	outputPathParts := []string{strings.ToLower(gvk.Kind)}
-
 	if mapVal, ok := val.(map[string]interface{}); ok {
 		tmpVal := make(map[string]interface{})
 		for k, v := range mapVal {
@@ -137,7 +135,6 @@ func (h *resourceHandler) Handle() (result, error) {
 		if err != nil {
 			return result{}, err
 		}
-		outputPathParts = append(outputPathParts, nested.NewPath(h.bindingInfo.SourcePath).GetParts()...)
 	}
 
 	typ, err := discoverBindingType(h.bindingInfo.Value)

--- a/pkg/controller/servicebindingrequest/annotations/secret_test.go
+++ b/pkg/controller/servicebindingrequest/annotations/secret_test.go
@@ -16,11 +16,12 @@ import (
 
 func TestSecretHandler(t *testing.T) {
 	type args struct {
-		name      string
-		value     string
-		service   map[string]interface{}
-		resources []runtime.Object
-		expected  map[string]interface{}
+		name            string
+		value           string
+		service         map[string]interface{}
+		resources       []runtime.Object
+		expectedData    map[string]interface{}
+		expectedRawData map[string]interface{}
 	}
 
 	assertHandler := func(args args) func(*testing.T) {
@@ -45,7 +46,8 @@ func TestSecretHandler(t *testing.T) {
 			got, err := handler.Handle()
 			require.NoError(t, err)
 			require.NotNil(t, got)
-			require.Equal(t, args.expected, got.Data)
+			require.Equal(t, args.expectedData, got.Data)
+			require.Equal(t, args.expectedRawData, got.RawData)
 		}
 	}
 
@@ -74,9 +76,16 @@ func TestSecretHandler(t *testing.T) {
 				},
 			},
 		},
-		expected: map[string]interface{}{
+		expectedData: map[string]interface{}{
 			"secret": map[string]interface{}{
 				"password": "hunter2",
+			},
+		},
+		expectedRawData: map[string]interface{}{
+			"status": map[string]interface{}{
+				"dbCredentials": map[string]interface{}{
+					"password": "hunter2",
+				},
 			},
 		},
 	}))
@@ -107,10 +116,18 @@ func TestSecretHandler(t *testing.T) {
 				},
 			},
 		},
-		expected: map[string]interface{}{
+		expectedData: map[string]interface{}{
 			"secret": map[string]interface{}{
 				"username": "AzureDiamond",
 				"password": "hunter2",
+			},
+		},
+		expectedRawData: map[string]interface{}{
+			"status": map[string]interface{}{
+				"dbCredentials": map[string]interface{}{
+					"username": "AzureDiamond",
+					"password": "hunter2",
+				},
 			},
 		},
 	}))

--- a/pkg/controller/servicebindingrequest/nested/path.go
+++ b/pkg/controller/servicebindingrequest/nested/path.go
@@ -129,6 +129,9 @@ func (p path) clean() path {
 
 // NewPath creates a new path with the given string in the format 'a.b.c'.
 func NewPath(s string) path {
+	if s == "" {
+		return path{}
+	}
 	parts := strings.Split(s, ".")
 	return newPathWithParts(parts)
 }


### PR DESCRIPTION
This PR is to fix the issue we reported in https://github.com/redhat-developer/service-binding-operator/issues/475#issuecomment-646114247.
@isutton 
Could you take a look at this PR? It need to be rebased after your PR https://github.com/redhat-developer/service-binding-operator/pull/515 is merged.