### PR TITLE
Revert annotation handling mechanism to not use the original config map or secret resource name location

### DIFF
--- a/pkg/controller/servicebindingrequest/annotations/configmap_test.go
+++ b/pkg/controller/servicebindingrequest/annotations/configmap_test.go
@@ -110,12 +110,8 @@ func TestConfigMapHandler(t *testing.T) {
 		},
 		expected: map[string]interface{}{
 			"configmap": map[string]interface{}{
-				"status": map[string]interface{}{
-					"dbCredentials": map[string]interface{}{
-						"username": "AzureDiamond",
-						"password": "hunter2",
-					},
-				},
+				"username": "AzureDiamond",
+				"password": "hunter2",
 			},
 		},
 	}))

--- a/pkg/controller/servicebindingrequest/annotations/errors.go
+++ b/pkg/controller/servicebindingrequest/annotations/errors.go
@@ -1,7 +1,6 @@
 package annotations
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -11,7 +10,11 @@ func (e invalidArgumentErr) Error() string {
 	return fmt.Sprintf("invalid argument value for path %q", string(e))
 }
 
-var resourceNameFieldNotFoundErr = errors.New("secret name field not found")
+type errResourceNameFieldNotFound string
+
+func (e errResourceNameFieldNotFound) Error() string {
+	return fmt.Sprintf("secret name field %q not found", string(e))
+}
 
 type unknownBindingTypeErr string
 

--- a/pkg/controller/servicebindingrequest/annotations/resource.go
+++ b/pkg/controller/servicebindingrequest/annotations/resource.go
@@ -47,7 +47,7 @@ func discoverRelatedResourceName(obj map[string]interface{}, bi *bindingInfo) (s
 		strings.Split(bi.ResourceReferencePath, ".")...,
 	)
 	if !ok {
-		return "", resourceNameFieldNotFoundErr
+		return "", errResourceNameFieldNotFound(bi.ResourceReferencePath)
 	}
 	if err != nil {
 		return "", err

--- a/pkg/controller/servicebindingrequest/annotations/secret_test.go
+++ b/pkg/controller/servicebindingrequest/annotations/secret_test.go
@@ -109,12 +109,8 @@ func TestSecretHandler(t *testing.T) {
 		},
 		expected: map[string]interface{}{
 			"secret": map[string]interface{}{
-				"status": map[string]interface{}{
-					"dbCredentials": map[string]interface{}{
-						"username": "AzureDiamond",
-						"password": "hunter2",
-					},
-				},
+				"username": "AzureDiamond",
+				"password": "hunter2",
 			},
 		},
 	}))

--- a/pkg/controller/servicebindingrequest/envvars/envvars.go
+++ b/pkg/controller/servicebindingrequest/envvars/envvars.go
@@ -67,6 +67,8 @@ func Build(obj interface{}, path ...string) (map[string]string, error) {
 		return buildString(strconv.FormatFloat(val, 'f', -1, 64), path), nil
 	case []interface{}:
 		return buildSliceOfInterface(val, path)
+	case bool:
+		return buildString(strconv.FormatBool(val), path), nil
 	default:
 		return nil, errUnsupportedType
 	}

--- a/pkg/controller/servicebindingrequest/envvars/envvars.go
+++ b/pkg/controller/servicebindingrequest/envvars/envvars.go
@@ -65,6 +65,8 @@ func Build(obj interface{}, path ...string) (map[string]string, error) {
 		return buildString(strconv.FormatInt(val, 10), path), nil
 	case float64:
 		return buildString(strconv.FormatFloat(val, 'f', -1, 64), path), nil
+	case []interface{}:
+		return buildSliceOfInterface(val, path)
 	default:
 		return nil, errUnsupportedType
 	}
@@ -98,6 +100,19 @@ func buildMap(obj map[string]interface{}, path []string) (map[string]string, err
 	envVars := make(map[string]string)
 	for k, v := range obj {
 		if err := buildInner(path, k, v, envVars); err != nil {
+			return nil, err
+		}
+	}
+	return envVars, nil
+}
+
+// buildSliceOfInterface retrurns a slice containing environment variables for
+// all the leaves present in the given 'obj' slice.
+func buildSliceOfInterface(obj []interface{}, acc []string) (map[string]string, error) {
+	envVars := make(map[string]string)
+	for i, v := range obj {
+		k := strconv.Itoa(i)
+		if err := buildInner(acc, k, v, envVars); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/controller/servicebindingrequest/nested/accumulator/accumulator.go
+++ b/pkg/controller/servicebindingrequest/nested/accumulator/accumulator.go
@@ -1,8 +1,6 @@
 package accumulator
 
 import (
-	"errors"
-
 	"github.com/imdario/mergo"
 )
 
@@ -10,9 +8,6 @@ const valuesKey = "values"
 
 // accumulator is a value accumulator.
 type accumulator map[string]interface{}
-
-// unsupportedTypeErr is returned when an unsupported type is encountered.
-var unsupportedTypeErr = errors.New("unsupported type")
 
 // Accumulate accumulates the `val` value. An error is returned in the case
 // `val` contains an unsupported type.
@@ -28,7 +23,7 @@ func (a accumulator) Accumulate(val interface{}) error {
 	case []map[string]interface{}, []string, []int:
 		b[valuesKey] = v
 	default:
-		return unsupportedTypeErr
+		b[valuesKey] = v
 	}
 	return mergo.Merge(&a, b, mergo.WithAppendSlice, mergo.WithOverride, mergo.WithTypeCheck)
 }

--- a/pkg/controller/servicebindingrequest/nested/path.go
+++ b/pkg/controller/servicebindingrequest/nested/path.go
@@ -72,6 +72,19 @@ func (p path) adjustedPath() path {
 	return p
 }
 
+// GetParts returns the path parts.
+//
+// For example, if the path contains the string 'a.b.c', returns a []string
+// containing 'a', 'b' and 'c'.
+func (p path) GetParts() []string {
+	var parts []string
+	clean := p.clean()
+	for _, f := range clean {
+		parts = append(parts, f.Name)
+	}
+	return parts
+}
+
 // lastField returns the last field from the receiver.
 func (p path) lastField() (field, bool) {
 	if len(p) > 0 {


### PR DESCRIPTION
### Motivation

After #407 an undocumented behavior regarding annotations meant to extract
config map and secret values has been unwillingly changed and needs to be
reverted.

The annotations handling mechanism after #407 extracts the whole contents of
the config map or secret to the same path where the config map or secret name
has been stored (resulting in, for example, .status.secretName.password if
.data.password is present in the associated resource) to workaround
situations where two services might have a password field within different
paths and might get shadowed, whereas before #407 it used to extract the
contents to the root of the resulting object (for example, .password),
imposing no issue whatsoever because there were only one service being
declared in the binding.

Closes #485 

### Changes

This change reverts the behavior where the source path isn't expected in the
resulting environment variable name; for example, the excerpt below shows
annotations present in a resource CRD, as a JSON object:

```json
{
  "servicebindingoperator.redhat.io/status.connectionArguments.databaseName": "binding:env:attribute",
  "servicebindingoperator.redhat.io/status.connectionArguments.host": "binding:env:attribute",
  "servicebindingoperator.redhat.io/status.connectionArguments.port": "binding:env:attribute",
  "servicebindingoperator.redhat.io/status.connectionCredentials-password": "binding:env:object:secret",
  "servicebindingoperator.redhat.io/status.connectionCredentials-username": "binding:env:object:secret",
  "servicebindingoperator.redhat.io/status.externalConnectionArguments-databaseName": "binding:env:object:configmap",
  "servicebindingoperator.redhat.io/status.externalConnectionArguments-host": "binding:env:object:configmap",
  "servicebindingoperator.redhat.io/status.externalConnectionArguments-port": "binding:env:object:configmap"
}
```

Before the changes introduced in this PR, the following environment variables
are generated and encoded in the service binding intermediate secret, where
the issue can be seen where the string `STATUS_EXTERNALCONNECTIONARGUMENTS`
and `STATUS_CONNECTIONCREDENTIALS` can be read:

```
NAME            TYPE    KEY                                                                     VALUE
service-binding Opaque  DATABASE_CONFIGMAP_STATUS_EXTERNALCONNECTIONARGUMENTS_DATABASENAME      "db-name"
service-binding Opaque  DATABASE_CONFIGMAP_STATUS_EXTERNALCONNECTIONARGUMENTS_HOST              "database.prod.example.com"
service-binding Opaque  DATABASE_CONFIGMAP_STATUS_EXTERNALCONNECTIONARGUMENTS_PORT              "5432"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_DATABASENAME                               "db-demo"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_HOST                                       "192.168.1.100"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_PORT                                       "5432"
service-binding Opaque  DATABASE_SECRET_STATUS_CONNECTIONCREDENTIALS_PASSWORD                   "hunter2"
service-binding Opaque  DATABASE_SECRET_STATUS_CONNECTIONCREDENTIALS_USERNAME                   "AzureDiamond"
```

After the changes introduced in this PR, the following environment variables
are produced (please observe the absence of the strings mentioned above):

```
NAME            TYPE    KEY                                             VALUE
service-binding Opaque  DATABASE_CONFIGMAP_DATABASENAME                 "db-name"
service-binding Opaque  DATABASE_CONFIGMAP_HOST                         "database.prod.example.com"
service-binding Opaque  DATABASE_CONFIGMAP_PORT                         "5432"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_DATABASENAME       "db-demo"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_HOST               "192.168.1.100"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_PORT               "5432"
service-binding Opaque  DATABASE_SECRET_PASSWORD                        "hunter2"
service-binding Opaque  DATABASE_SECRET_USERNAME                        "AzureDiamond"
```

The same behavior can be seen when changing the annotations to include the entire object, secret or config map as well; for example, the three annotations below should produce the same environment variables as above:

```json
{
  "servicebindingoperator.redhat.io/status.connectionArguments": "binding:env:attribute",
  "servicebindingoperator.redhat.io/status.connectionCredentials": "binding:env:object:secret",
  "servicebindingoperator.redhat.io/status.externalConnectionArguments": "binding:env:object:configmap"
}
```

As can be observed above, the same extra information is present in the resulting secret:

```
NAME            TYPE    KEY                                                                     VALUE
service-binding Opaque  DATABASE_CONFIGMAP_STATUS_EXTERNALCONNECTIONARGUMENTS_DATABASENAME      "db-name"
service-binding Opaque  DATABASE_CONFIGMAP_STATUS_EXTERNALCONNECTIONARGUMENTS_HOST              "database.prod.example.com"
service-binding Opaque  DATABASE_CONFIGMAP_STATUS_EXTERNALCONNECTIONARGUMENTS_PORT              "5432"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_DATABASENAME                               "db-demo"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_HOST                                       "192.168.1.100"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_PORT                                       "5432"
service-binding Opaque  DATABASE_SECRET_STATUS_CONNECTIONCREDENTIALS_PASSWORD                   "hunter2"
service-binding Opaque  DATABASE_SECRET_STATUS_CONNECTIONCREDENTIALS_USERNAME                   "AzureDiamond"
```

And, as expected, after the changes in this PR are applied:

```
NAME            TYPE    KEY                                             VALUE
service-binding Opaque  DATABASE_CONFIGMAP_DATABASENAME                 "db-name"
service-binding Opaque  DATABASE_CONFIGMAP_HOST                         "database.prod.example.com"
service-binding Opaque  DATABASE_CONFIGMAP_PORT                         "5432"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_DATABASENAME       "db-demo"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_HOST               "192.168.1.100"
service-binding Opaque  DATABASE_CONNECTIONARGUMENTS_PORT               "5432"
service-binding Opaque  DATABASE_SECRET_PASSWORD                        "hunter2"
service-binding Opaque  DATABASE_SECRET_USERNAME                        "AzureDiamond"
```

For further more details refer the CONTRIBUTING.md

