### PR TITLE
Fix infinite reconcile loop

### DIFF
--- a/pkg/controller/servicebindingrequest/annotations.go
+++ b/pkg/controller/servicebindingrequest/annotations.go
@@ -123,7 +123,7 @@ func setAndUpdateSBRAnnotations(
 ) error {
 	for _, obj := range objs {
 		newObj := setSBRAnnotations(namespacedName, obj)
-		equal, err := nestedMapComparison(obj, newObj, []string{"metadata", "annotations"}...)
+		equal, err := nestedUnstructuredComparison(obj, newObj, []string{"metadata", "annotations"}...)
 		if err != nil {
 			return err
 		}
@@ -154,7 +154,7 @@ func removeSBRAnnotations(obj *unstructured.Unstructured) *unstructured.Unstruct
 func removeAndUpdateSBRAnnotations(client dynamic.Interface, objs []*unstructured.Unstructured) error {
 	for _, obj := range objs {
 		newObj := removeSBRAnnotations(obj)
-		equal, err := nestedMapComparison(obj, newObj, []string{"metadata", "annotations"}...)
+		equal, err := nestedUnstructuredComparison(obj, newObj, []string{"metadata", "annotations"}...)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/servicebindingrequest/annotations_test.go
+++ b/pkg/controller/servicebindingrequest/annotations_test.go
@@ -109,11 +109,11 @@ func TestAnnotationsSetAndRemoveSBRAnnotations(t *testing.T) {
 		newObj := setSBRAnnotations(namespacedName, u)
 
 		// we are not modifying the origin object
-		equal, err := nestedMapComparison(u, originCopy)
+		equal, err := nestedUnstructuredComparison(u, originCopy)
 		require.NoError(t, err)
 		require.True(t, equal)
 
-		equal, err = nestedMapComparison(u, newObj, []string{"metadata", "annotations"}...)
+		equal, err = nestedUnstructuredComparison(u, newObj, []string{"metadata", "annotations"}...)
 		require.NoError(t, err)
 		require.False(t, equal)
 
@@ -123,7 +123,7 @@ func TestAnnotationsSetAndRemoveSBRAnnotations(t *testing.T) {
 
 		// assert nothing else is changed
 		newObj.SetAnnotations(nil)
-		equal, err = nestedMapComparison(u, newObj)
+		equal, err = nestedUnstructuredComparison(u, newObj)
 		require.NoError(t, err)
 		require.True(t, equal)
 	})
@@ -133,11 +133,11 @@ func TestAnnotationsSetAndRemoveSBRAnnotations(t *testing.T) {
 		newObj := removeSBRAnnotations(u)
 
 		// we are not modifying the origin object
-		equal, err := nestedMapComparison(u, originCopy)
+		equal, err := nestedUnstructuredComparison(u, originCopy)
 		require.NoError(t, err)
 		require.True(t, equal)
 
-		equal, err = nestedMapComparison(u, newObj, []string{"metadata", "annotations"}...)
+		equal, err = nestedUnstructuredComparison(u, newObj, []string{"metadata", "annotations"}...)
 		require.NoError(t, err)
 		require.False(t, equal)
 
@@ -147,7 +147,7 @@ func TestAnnotationsSetAndRemoveSBRAnnotations(t *testing.T) {
 
 		// assert nothing else is changed
 		newObj.SetAnnotations(u.GetAnnotations())
-		equal, err = nestedMapComparison(u, newObj)
+		equal, err = nestedUnstructuredComparison(u, newObj)
 		require.NoError(t, err)
 		require.True(t, equal)
 	})

--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -454,8 +454,8 @@ func (b *binder) removeVolumeMounts(volumeMounts []corev1.VolumeMount) []corev1.
 	return cleanVolumeMounts
 }
 
-// nestedMapComparison compares a nested field from two objects.
-func nestedMapComparison(a, b *unstructured.Unstructured, fields ...string) (bool, error) {
+// nestedUnstructuredComparison compares a nested field from two objects.
+func nestedUnstructuredComparison(a, b *unstructured.Unstructured, fields ...string) (bool, error) {
 	var (
 		aMap map[string]interface{}
 		bMap map[string]interface{}
@@ -476,9 +476,14 @@ func nestedMapComparison(a, b *unstructured.Unstructured, fields ...string) (boo
 		return false, nil
 	}
 
-	result := cmp.DeepEqual(aMap, bMap)()
+	result := nestedMapComparison(aMap, bMap)
+	return result, nil
+}
 
-	return result.Success(), nil
+func nestedMapComparison(a, b map[string]interface{}) bool {
+	val := cmp.DeepEqual(a, b)()
+	return val.Success()
+
 }
 
 // update the list of objects informed as unstructured, looking for "containers" entry. This method
@@ -508,7 +513,7 @@ func (b *binder) update(objs *unstructured.UnstructuredList) ([]*unstructured.Un
 			}
 		}
 
-		if specsAreEqual, err := nestedMapComparison(&obj, updatedObj); err != nil {
+		if specsAreEqual, err := nestedUnstructuredComparison(&obj, updatedObj); err != nil {
 			log.Error(err, "")
 			continue
 		} else if specsAreEqual {

--- a/pkg/controller/servicebindingrequest/binder.go
+++ b/pkg/controller/servicebindingrequest/binder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -386,10 +385,15 @@ func (b *binder) updateContainer(container interface{}) (map[string]interface{},
 	// effectively binding the application with intermediary secret
 	c.EnvFrom = b.appendEnvFrom(c.EnvFrom, b.sbr.GetName())
 
+	secretRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	existingSecret, err := b.dynClient.Resource(secretRes).Namespace(b.sbr.GetNamespace()).Get(b.sbr.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
 	// add a special environment variable that is only used to trigger a change in the declaration,
 	// attempting to force a side effect (in case of a Deployment, it would result in its Pods to be
 	// restarted)
-	c.Env = b.appendEnvVar(c.Env, changeTriggerEnv, time.Now().Format(time.RFC3339))
+	c.Env = b.appendEnvVar(c.Env, changeTriggerEnv, existingSecret.GetResourceVersion())
 
 	if len(b.volumeKeys) > 0 {
 		// and adding volume mount entries

--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -56,7 +56,7 @@ func TestBinderNew(t *testing.T) {
 		map[string]string{},
 	)
 
-	f.AddMockedUnstructuredSecret(name)
+	f.AddMockedUnstructuredSecretRV(name)
 	fakeDynClient := f.FakeDynClient()
 
 	t.Run("search-using-resourceref", func(t *testing.T) {

--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -172,7 +172,6 @@ func TestBinderNew(t *testing.T) {
 		envVar := getEnvVar(c.Env, changeTriggerEnv)
 		require.NotNil(t, envVar)
 		require.NotEmpty(t, envVar.Value)
-		require.NoError(t, err)
 
 		uSecret, err := fakeDynClient.Resource(secretsGVR).Get(name, metav1.GetOptions{})
 		require.NoError(t, err)

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -332,14 +332,7 @@ func TestReconcilerUpdateCredentials(t *testing.T) {
 	r := &reconciler{dynClient: fakeDynClient, restMapper: mapper, scheme: f.S}
 	r.resourceWatcher = newFakeResourceWatcher(mapper)
 
-	u, err := fakeDynClient.Resource(deploymentsGVR).Get(reconcilerName, metav1.GetOptions{})
-	require.NoError(t, err)
-
-	d := appsv1.Deployment{}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &d)
-	require.NoError(t, err)
-
-	u, err = fakeDynClient.Resource(secretsGVR).Get("db-credentials", metav1.GetOptions{})
+	u, err := fakeDynClient.Resource(secretsGVR).Get("db-credentials", metav1.GetOptions{})
 	require.NoError(t, err)
 	s := corev1.Secret{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &s)
@@ -362,13 +355,6 @@ func TestReconcilerUpdateCredentials(t *testing.T) {
 
 	namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
 	sbrOutput3, err := r.getServiceBindingRequest(namespacedName)
-	require.NoError(t, err)
-
-	u, err = fakeDynClient.Resource(deploymentsGVR).Get(reconcilerName, metav1.GetOptions{})
-	require.NoError(t, err)
-
-	d = appsv1.Deployment{}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &d)
 	require.NoError(t, err)
 
 	requireConditionPresentAndTrue(t, CollectionReady, sbrOutput3.Status.Conditions)

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -347,7 +347,7 @@ func TestReconcilerUpdateCredentials(t *testing.T) {
 
 	// Update Credentials
 	s.Data["password"] = []byte("abc123")
-	// Update resourceVersion
+	// Update resourceVersion for postgresdb
 	s.ObjectMeta.ResourceVersion = "112200"
 	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&s)
 	require.NoError(t, err)
@@ -376,6 +376,12 @@ func TestReconcilerUpdateCredentials(t *testing.T) {
 
 	require.Equal(t, reconcilerName, sbrOutput3.Status.Secret)
 	require.Equal(t, s.Data["password"], []byte("abc123"))
+	require.Equal(t, 1, len(sbrOutput3.Status.Applications))
+	require.Equal(t, reconcilerName, sbrOutput3.Status.Secret)
+	fetchSecret, err := fakeDynClient.Resource(secretsGVR).Namespace(updated.GetNamespace()).Get(reconcilerName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, fetchSecret.GetName(), reconcilerName)
+	require.Equal(t, fetchSecret.GetResourceVersion(), "")
 	require.Equal(t, 1, len(sbrOutput3.Status.Applications))
 }
 

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -303,7 +303,6 @@ func TestApplicationNotFound(t *testing.T) {
 	d := appsv1.Deployment{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &d)
 	require.NoError(t, err)
-
 	sbrOutput2, err := r.getServiceBindingRequest(namespacedName)
 	require.NoError(t, err)
 
@@ -321,11 +320,14 @@ func TestApplicationNotFound(t *testing.T) {
 
 	// Update Credentials
 	s.Data["password"] = []byte("abc123")
+	// Update resourceVersion
+	s.ObjectMeta.ResourceVersion = "112200"
 	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&s)
 	require.NoError(t, err)
 	updated := unstructured.Unstructured{Object: obj}
 	_, err = fakeDynClient.Resource(secretsGVR).Namespace(updated.GetNamespace()).Update(&updated, metav1.UpdateOptions{})
 	require.NoError(t, err)
+
 	time.Sleep(1 * time.Second)
 	r = &reconciler{dynClient: fakeDynClient, restMapper: testutils.BuildTestRESTMapper(), scheme: f.S}
 	r.resourceWatcher = newFakeResourceWatcher(mapper)

--- a/pkg/controller/servicebindingrequest/sbrcontroller.go
+++ b/pkg/controller/servicebindingrequest/sbrcontroller.go
@@ -54,7 +54,7 @@ func compareObjectFields(objOld, objNew runtime.Object, fields ...string) (bool,
 		return false, err
 	}
 
-	return nestedMapComparison(
+	return nestedUnstructuredComparison(
 		&unstructured.Unstructured{Object: mapNew},
 		&unstructured.Unstructured{Object: mapOld},
 		fields...,

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -59,15 +59,15 @@ func (s *secret) createOrUpdate(payload map[string][]byte, ownerReference metav1
 		return nil, err
 	}
 	existingSecretData, _, _ := unstructured.NestedMap(existingSecret.Object, "data")
-	existingSecretDataStr := make(map[string]string)
-	for k, v := range existingSecretData {
-		existingSecretDataStr[k] = v.(string)
-	}
 	payloadStr := make(map[string]string)
 	for k, v := range payload {
 		payloadStr[k] = base64.StdEncoding.EncodeToString(v)
 	}
-	eq := reflect.DeepEqual(existingSecretDataStr, payloadStr)
+	payloadInterim := make(map[string]interface{})
+	for k, v := range payloadStr {
+		payloadInterim[k] = reflect.ValueOf(v).Interface()
+	}
+	eq := nestedMapComparison(existingSecretData, payloadInterim)
 	if eq {
 		logger.Debug("Secret data is same. Skip Update")
 	} else {

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -50,11 +50,14 @@ func (s *secret) createOrUpdate(payload map[string][]byte, ownerReference metav1
 	resourceClient := s.buildResourceClient()
 
 	logger.Debug("Attempt to create secret...")
-	existingSecret, err := resourceClient.Get(s.name, metav1.GetOptions{})
+	existingSecret, err := s.get()
 	if err != nil {
 		if errors.IsNotFound(err) {
 			_, err := resourceClient.Create(u, metav1.CreateOptions{})
-			return u, err
+			if err != nil {
+				return nil, err
+			}
+			return u, nil
 		}
 		return nil, err
 	}
@@ -82,13 +85,13 @@ func (s *secret) createOrUpdate(payload map[string][]byte, ownerReference metav1
 
 // get an unstructured object from the secret handled by this component. It can return errors in case
 // the API server does.
-func (s *secret) get() (*unstructured.Unstructured, bool, error) {
+func (s *secret) get() (*unstructured.Unstructured, error) {
 	resourceClient := s.buildResourceClient()
 	u, err := resourceClient.Get(s.name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, false, err
+	if err != nil {
+		return nil, err
 	}
-	return u, u != nil, nil
+	return u, nil
 }
 
 // newSecret instantiate a new Secret.

--- a/pkg/controller/servicebindingrequest/secret_test.go
+++ b/pkg/controller/servicebindingrequest/secret_test.go
@@ -47,9 +47,8 @@ func TestSecretNew(t *testing.T) {
 	})
 
 	t.Run("Get", func(t *testing.T) {
-		u, found, err := s.get()
+		u, err := s.get()
 		assert.NoError(t, err)
-		assert.True(t, found)
 		assertSecretNamespacedName(t, u, ns, name)
 	})
 }

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -187,6 +187,14 @@ func (f *Fake) AddMockedUnstructuredSecret(name string) *unstructured.Unstructur
 	return s
 }
 
+// AddMockedUnstructuredSecret add mocked object from SecretMock. This secret is created with a resourceVersion
+func (f *Fake) AddMockedUnstructuredSecretRV(name string) *unstructured.Unstructured {
+	s, err := UnstructuredSecretMockRV(f.ns, name)
+	require.NoError(f.t, err)
+	f.objs = append(f.objs, s)
+	return s
+}
+
 // AddNamespacedMockedSecret add mocked object from SecretMock in a namespace
 // which isn't necessarily same as that of the ServiceBindingRequest namespace.
 func (f *Fake) AddNamespacedMockedSecret(name string, namespace string) {

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -360,8 +360,9 @@ func SecretMock(ns, name string) *corev1.Secret {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
+			Namespace:       ns,
+			Name:            name,
+			ResourceVersion: "116076",
 		},
 		Data: map[string][]byte{
 			"user":     []byte("user"),

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -164,6 +164,11 @@ func UnstructuredSecretMock(ns, name string) (*unstructured.Unstructured, error)
 	return converter.ToUnstructured(&s)
 }
 
+func UnstructuredSecretMockRV(ns, name string) (*unstructured.Unstructured, error) {
+	s := SecretMockRV(ns, name)
+	return converter.ToUnstructured(&s)
+}
+
 func UnstructuredPostgresDatabaseCRMock(ns, name string) (*unstructured.Unstructured, error) {
 	c := PostgresDatabaseCRMock(ns, name)
 	return converter.ToUnstructured(&c)
@@ -354,6 +359,24 @@ func UnstructuredDatabaseCRMock(ns, name string) (*unstructured.Unstructured, er
 
 // SecretMock returns a Secret based on PostgreSQL operator usage.
 func SecretMock(ns, name string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Data: map[string][]byte{
+			"user":     []byte("user"),
+			"password": []byte("password"),
+		},
+	}
+}
+
+// SecretMockRV returns a Secret with a resourceVersion.
+func SecretMockRV(ns, name string) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",


### PR DESCRIPTION
### Motivation

To resolve issue #509 

### Changes

Initially the resourceVersion of the secret used to get updated even without any change in the data field. In this refactor we would only update the secret after fetching the already existing secret and comparing it's data with the payload(new data to be injected). If secret exists then we go further to check the contents with which the secret needs to be updated. If data is same we skip the update, if data is diff we go further with updating the secret resource.

### Testing

`make test-unit`

Import an app
create a db
create a sbr

Check the reosurceVersion of the secret and the in the envVar of the deployment. Both should be the same. 
Update the backing service, now the intermediate secret reourceVersion should change and further change envVar in the deployment

For further more details refer the CONTRIBUTING.md