### PR TITLE
Add owner reference to secret

### DIFF
--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -4,7 +4,6 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -113,9 +112,9 @@ func init() {
 	SchemeBuilder.Register(&ServiceBindingRequest{}, &ServiceBindingRequestList{})
 }
 
-func (sbr ServiceBindingRequest) AsOwnerReference() v1.OwnerReference {
+func (sbr ServiceBindingRequest) AsOwnerReference() metav1.OwnerReference {
 	var sbrController bool = true
-	return v1.OwnerReference{
+	return metav1.OwnerReference{
 		Name:       sbr.Name,
 		UID:        sbr.UID,
 		Kind:       sbr.Kind,

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -4,6 +4,7 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -110,4 +111,15 @@ type ServiceBindingRequestList struct {
 
 func init() {
 	SchemeBuilder.Register(&ServiceBindingRequest{}, &ServiceBindingRequestList{})
+}
+
+func (sbr ServiceBindingRequest) AsOwnerReference() v1.OwnerReference {
+	var sbrController bool = true
+	return v1.OwnerReference{
+		Name:       sbr.Name,
+		UID:        sbr.UID,
+		Kind:       sbr.Kind,
+		APIVersion: sbr.APIVersion,
+		Controller: &sbrController,
+	}
 }

--- a/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
+++ b/pkg/apis/apps/v1alpha1/servicebindingrequest_types.go
@@ -113,12 +113,12 @@ func init() {
 }
 
 func (sbr ServiceBindingRequest) AsOwnerReference() metav1.OwnerReference {
-	var sbrController bool = true
+	var ownerRefController bool = true
 	return metav1.OwnerReference{
 		Name:       sbr.Name,
 		UID:        sbr.UID,
 		Kind:       sbr.Kind,
 		APIVersion: sbr.APIVersion,
-		Controller: &sbrController,
+		Controller: &ownerRefController,
 	}
 }

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -4,6 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 
@@ -27,7 +28,7 @@ func (s *secret) buildResourceClient() dynamic.ResourceInterface {
 
 // createOrUpdate will take informed payload and either create a new secret or update an existing
 // one. It can return error when Kubernetes client does.
-func (s *secret) createOrUpdate(payload map[string][]byte, secretOwnerReference SecretOwnerReference) (*unstructured.Unstructured, error) {
+func (s *secret) createOrUpdate(payload map[string][]byte, secretOwnerReference v1.OwnerReference) (*unstructured.Unstructured, error) {
 	logger := s.logger.WithValues("Namespace", s.ns, "Name", s.name)
 	reference := metav1.OwnerReference{
 		Name:       secretOwnerReference.Name,
@@ -68,7 +69,7 @@ func (s *secret) createOrUpdate(payload map[string][]byte, secretOwnerReference 
 
 // commit will store informed data as a secret, commit it against the API server. It can forward
 // errors from custom environment parser component, or from the API server itself.
-func (s *secret) commit(payload map[string][]byte, secretOwnerReference SecretOwnerReference) (*unstructured.Unstructured, error) {
+func (s *secret) commit(payload map[string][]byte, secretOwnerReference v1.OwnerReference) (*unstructured.Unstructured, error) {
 	return s.createOrUpdate(payload, secretOwnerReference)
 }
 

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -71,16 +71,6 @@ func (s *secret) get() (*unstructured.Unstructured, bool, error) {
 	return u, u != nil, nil
 }
 
-// delete the secret represented by this component. It can return error when the API server does.
-func (s *secret) delete() error {
-	resourceClient := s.buildResourceClient()
-	err := resourceClient.Delete(s.name, &metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-	return nil
-}
-
 // newSecret instantiate a new Secret.
 func newSecret(
 	client dynamic.Interface,

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -4,7 +4,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 
@@ -28,7 +27,7 @@ func (s *secret) buildResourceClient() dynamic.ResourceInterface {
 
 // createOrUpdate will take informed payload and either create a new secret or update an existing
 // one. It can return error when Kubernetes client does.
-func (s *secret) createOrUpdate(payload map[string][]byte, secretOwnerReference v1.OwnerReference) (*unstructured.Unstructured, error) {
+func (s *secret) createOrUpdate(payload map[string][]byte, secretOwnerReference metav1.OwnerReference) (*unstructured.Unstructured, error) {
 	logger := s.logger.WithValues("Namespace", s.ns, "Name", s.name)
 	reference := metav1.OwnerReference{
 		Name:       secretOwnerReference.Name,
@@ -69,7 +68,7 @@ func (s *secret) createOrUpdate(payload map[string][]byte, secretOwnerReference 
 
 // commit will store informed data as a secret, commit it against the API server. It can forward
 // errors from custom environment parser component, or from the API server itself.
-func (s *secret) commit(payload map[string][]byte, secretOwnerReference v1.OwnerReference) (*unstructured.Unstructured, error) {
+func (s *secret) commit(payload map[string][]byte, secretOwnerReference metav1.OwnerReference) (*unstructured.Unstructured, error) {
 	return s.createOrUpdate(payload, secretOwnerReference)
 }
 

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -60,12 +60,6 @@ func (s *secret) createOrUpdate(payload map[string][]byte, ownerReference metav1
 	return u, nil
 }
 
-// commit will store informed data as a secret, commit it against the API server. It can forward
-// errors from custom environment parser component, or from the API server itself.
-func (s *secret) commit(payload map[string][]byte, secretOwnerReference metav1.OwnerReference) (*unstructured.Unstructured, error) {
-	return s.createOrUpdate(payload, secretOwnerReference)
-}
-
 // get an unstructured object from the secret handled by this component. It can return errors in case
 // the API server does.
 func (s *secret) get() (*unstructured.Unstructured, bool, error) {

--- a/pkg/controller/servicebindingrequest/secret.go
+++ b/pkg/controller/servicebindingrequest/secret.go
@@ -27,19 +27,13 @@ func (s *secret) buildResourceClient() dynamic.ResourceInterface {
 
 // createOrUpdate will take informed payload and either create a new secret or update an existing
 // one. It can return error when Kubernetes client does.
-func (s *secret) createOrUpdate(payload map[string][]byte, secretOwnerReference metav1.OwnerReference) (*unstructured.Unstructured, error) {
+func (s *secret) createOrUpdate(payload map[string][]byte, ownerReference metav1.OwnerReference) (*unstructured.Unstructured, error) {
 	logger := s.logger.WithValues("Namespace", s.ns, "Name", s.name)
-	reference := metav1.OwnerReference{
-		Name:       secretOwnerReference.Name,
-		UID:        secretOwnerReference.UID,
-		Kind:       secretOwnerReference.Kind,
-		APIVersion: secretOwnerReference.APIVersion,
-	}
 	secretObj := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       s.ns,
 			Name:            s.name,
-			OwnerReferences: []metav1.OwnerReference{reference},
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
 		},
 		Data: payload,
 	}

--- a/pkg/controller/servicebindingrequest/secret_test.go
+++ b/pkg/controller/servicebindingrequest/secret_test.go
@@ -4,14 +4,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
+var secretOwnerReference = v1.OwnerReference{
+	Name:       "binding-request",
+	UID:        "c77ca1ae-72d0-4fdd-809f-58fdd37facf3",
+	Kind:       "ServiceBindingRequest",
+	APIVersion: "apps.openshift.io/v1alpha1",
+}
+
 func assertSecretNamespacedName(t *testing.T, u *unstructured.Unstructured, ns, name string) {
 	assert.Equal(t, ns, u.GetNamespace())
 	assert.Equal(t, name, u.GetName())
+	ownerReference := u.GetOwnerReferences()
+	assert.Equal(t, secretOwnerReference, ownerReference[0])
 }
 
 func TestSecretNew(t *testing.T) {
@@ -29,7 +39,7 @@ func TestSecretNew(t *testing.T) {
 	)
 
 	t.Run("createOrUpdate", func(t *testing.T) {
-		u, err := s.createOrUpdate(data)
+		u, err := s.createOrUpdate(data, secretOwnerReference)
 		assert.NoError(t, err)
 		assertSecretNamespacedName(t, u, ns, name)
 	})
@@ -40,7 +50,7 @@ func TestSecretNew(t *testing.T) {
 	})
 
 	t.Run("Commit", func(t *testing.T) {
-		u, err := s.commit(data)
+		u, err := s.commit(data, secretOwnerReference)
 		assert.NoError(t, err)
 		assertSecretNamespacedName(t, u, ns, name)
 	})

--- a/pkg/controller/servicebindingrequest/secret_test.go
+++ b/pkg/controller/servicebindingrequest/secret_test.go
@@ -50,10 +50,4 @@ func TestSecretNew(t *testing.T) {
 		assert.True(t, found)
 		assertSecretNamespacedName(t, u, ns, name)
 	})
-
-	t.Run("Delete", func(t *testing.T) {
-		err := s.delete()
-		assert.NoError(t, err)
-	})
-
 }

--- a/pkg/controller/servicebindingrequest/secret_test.go
+++ b/pkg/controller/servicebindingrequest/secret_test.go
@@ -15,6 +15,7 @@ var secretOwnerReference = v1.OwnerReference{
 	UID:        "c77ca1ae-72d0-4fdd-809f-58fdd37facf3",
 	Kind:       "ServiceBindingRequest",
 	APIVersion: "apps.openshift.io/v1alpha1",
+	Controller: true,
 }
 
 func assertSecretNamespacedName(t *testing.T, u *unstructured.Unstructured, ns, name string) {

--- a/pkg/controller/servicebindingrequest/secret_test.go
+++ b/pkg/controller/servicebindingrequest/secret_test.go
@@ -44,21 +44,16 @@ func TestSecretNew(t *testing.T) {
 		assertSecretNamespacedName(t, u, ns, name)
 	})
 
-	t.Run("Delete", func(t *testing.T) {
-		err := s.delete()
-		assert.NoError(t, err)
-	})
-
-	t.Run("Commit", func(t *testing.T) {
-		u, err := s.commit(data, secretOwnerReference)
-		assert.NoError(t, err)
-		assertSecretNamespacedName(t, u, ns, name)
-	})
-
 	t.Run("Get", func(t *testing.T) {
 		u, found, err := s.get()
 		assert.NoError(t, err)
 		assert.True(t, found)
 		assertSecretNamespacedName(t, u, ns, name)
 	})
+
+	t.Run("Delete", func(t *testing.T) {
+		err := s.delete()
+		assert.NoError(t, err)
+	})
+
 }

--- a/pkg/controller/servicebindingrequest/secret_test.go
+++ b/pkg/controller/servicebindingrequest/secret_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
+var ownerRefController bool = true
 var secretOwnerReference = v1.OwnerReference{
 	Name:       "binding-request",
 	UID:        "c77ca1ae-72d0-4fdd-809f-58fdd37facf3",
 	Kind:       "ServiceBindingRequest",
 	APIVersion: "apps.openshift.io/v1alpha1",
-	Controller: true,
+	Controller: &ownerRefController,
 }
 
 func assertSecretNamespacedName(t *testing.T, u *unstructured.Unstructured, ns, name string) {

--- a/pkg/controller/servicebindingrequest/servicebinder.go
+++ b/pkg/controller/servicebindingrequest/servicebinder.go
@@ -242,14 +242,7 @@ func (b *serviceBinder) bind() (reconcile.Result, error) {
 
 	b.logger.Info("Saving data on intermediary secret...")
 
-	secretOwnerReference := v1.OwnerReference{
-		Name:       b.sbr.Name,
-		UID:        b.sbr.UID,
-		Kind:       b.sbr.Kind,
-		APIVersion: b.sbr.APIVersion,
-	}
-
-	secretObj, err := b.secret.commit(b.envVars, secretOwnerReference)
+	secretObj, err := b.secret.createOrUpdate(b.envVars, b.sbr.AsOwnerReference())
 	if err != nil {
 		b.logger.Error(err, "On saving secret data..")
 		return b.onError(err, b.sbr, sbrStatus, nil)

--- a/pkg/controller/servicebindingrequest/servicebinder.go
+++ b/pkg/controller/servicebindingrequest/servicebinder.go
@@ -37,13 +37,6 @@ func (b *serviceBinder) message(err error) string {
 	return err.Error()
 }
 
-type SecretOwnerReference struct {
-	Name       string
-	UID        types.UID
-	Kind       string
-	APIVersion string
-}
-
 // serviceBinderOptions is BuildServiceBinder arguments.
 type serviceBinderOptions struct {
 	logger                 *log.Log
@@ -249,7 +242,7 @@ func (b *serviceBinder) bind() (reconcile.Result, error) {
 
 	b.logger.Info("Saving data on intermediary secret...")
 
-	secretOwnerReference := SecretOwnerReference{
+	secretOwnerReference := v1.OwnerReference{
 		Name:       b.sbr.Name,
 		UID:        b.sbr.UID,
 		Kind:       b.sbr.Kind,


### PR DESCRIPTION
### Github Issue

#512 

### Jira Task

https://issues.redhat.com/browse/APPSVC-610

### Motivation

[1] Sets `ownerReference` to secret, so that after SBR deletion, secret can be deleted by garbage collector.

### Changes

[1] OwnerReference information is added to intermediate secret.

### Testing

[1] Follow the steps [here](https://github.com/redhat-developer/service-binding-operator/tree/master/examples/nodejs_postgresql) to create application, DB and SBR successfully.

[2] Delete SBR:

```
➜ oc delete sbr binding-request
```

[3] Check the presence of secret `binding-request`

```
➜ oc get secret binding-request               
Error from server (NotFound): secrets "binding-request" not found
```

The secret `binding-request` should be deleted successfully.

## Tests

[1] We already have a e2e test to test successful deletion of secret after SBR is deleted -> https://github.com/redhat-developer/service-binding-operator/blob/master/test/e2e/servicebindingrequest_test.go#L607