### PR TITLE
fixed CI unit jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,6 @@ GOLANGCI_LINT_BIN=$(OUTPUT_DIR)/golangci-lint
 # -- Variables for uploading code coverage reports to Codecov.io --
 # This default path is set by the OpenShift CI
 CODECOV_TOKEN_PATH ?= "/usr/local/redhat-developer-service-binding-operator-codecov-token/token"
-CODECOV_TOKEN ?= @$(CODECOV_TOKEN_PATH)
 REPO_OWNER := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].org')
 REPO_NAME := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].repo')
 BASE_COMMIT := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].base_sha')
@@ -396,7 +395,7 @@ upload-codecov-report:
 ifneq ($(PR_COMMIT), null)
 	@echo "uploading test coverage report for pull-request #$(PULL_NUMBER)..."
 	@/bin/bash <(curl -s https://codecov.io/bash) \
-		-t $(CODECOV_TOKEN) \
+		-t $(shell tr -d ' \n' <$CODECOV_TOKEN_PATH) \
 		-f $(GOCOV_DIR)/*.txt \
 		-C $(PR_COMMIT) \
 		-r $(REPO_OWNER)/$(REPO_NAME) \
@@ -405,7 +404,7 @@ ifneq ($(PR_COMMIT), null)
 else
 	@echo "uploading test coverage report after PR was merged..."
 	@/bin/bash <(curl -s https://codecov.io/bash) \
-		-t $(CODECOV_TOKEN) \
+		-t $(shell tr -d ' \n' <$CODECOV_TOKEN_PATH) \
 		-f $(GOCOV_DIR)/*.txt \
 		-C $(BASE_COMMIT) \
 		-r $(REPO_OWNER)/$(REPO_NAME) \


### PR DESCRIPTION
it looks like that recently codecov bash script we pull from https://codecov.io/bash got updated,
breaking 'upload-codecov-report' make rule. The token we use is read from
`/usr/local/redhat-developer-service-binding-operator-codecov-token/token`
and that file is mounted from a read-only volume. The codecov script tries to write something on that volume and it fails.

In order to fix the issue, we read token uuid within Makefile and pass it to the codecov script