### PR TITLE
Make test namespace shorter to avoid having invalid - too long - URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ setup-venv:
 
 # Generate namespace name for test
 out/test-namespace:
-	@echo -n "test-namespace-$(shell uuidgen | tr '[:upper:]' '[:lower:]')" > $(OUTPUT_DIR)/test-namespace
+	@echo -n "test-namespace-$(shell uuidgen | tr '[:upper:]' '[:lower:]' | head -c 8)" > $(OUTPUT_DIR)/test-namespace
 
 .PHONY: get-test-namespace
 get-test-namespace: out/test-namespace


### PR DESCRIPTION
### Motivation

The current test namespace name is generated  - e.g. `test-namespace-72500cf4-96a3-4670-89a9-028eb8728307` - which is 52 characters long.
That long namespace names currently cause problems when exposing routes to applications' services (such as `nodejs-rest-http-crud`) (https://github.com/openshift/oc/issues/486).

### Changes

This PR shorten's the generated part to the first 8 characters of the UUID (e.g. `test-namespace-72500cf4`) to make the namespaces' name reasonable long (24 characters).

### Testing

`make test-e2e`
