### PR TITLE
Temporarily disable e2e scenarios not supported by SBO.

### DIFF
--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -93,18 +93,22 @@ func TestAddSchemesToFramework(t *testing.T) {
 		t.Run("scenario-app-db-sbr", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{AppStep, DBStep, SBRStep})
 		})
+		/* Currently disabled as not supported by SBO
 		t.Run("scenario-db-sbr-app", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{DBStep, SBRStep, AppStep})
 		})
+		*/
 		t.Run("scenario-app-sbr-db", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{AppStep, SBRStep, DBStep})
 		})
+		/* Currently disabled as not supported by SBO
 		t.Run("scenario-sbr-db-app", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{SBRStep, DBStep, AppStep})
 		})
 		t.Run("scenario-sbr-app-db", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{SBRStep, AppStep, DBStep})
 		})
+		*/
 		t.Run("scenario-csv-db-app-sbr", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{CSVStep, DBStep, AppStep, SBRStep})
 		})

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -94,15 +94,19 @@ func TestAddSchemesToFramework(t *testing.T) {
 			ServiceBindingRequest(t, []Step{AppStep, DBStep, SBRStep})
 		})
 		t.Run("scenario-db-sbr-app", func(t *testing.T) {
+			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{DBStep, SBRStep, AppStep})
 		})
 		t.Run("scenario-app-sbr-db", func(t *testing.T) {
+			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{AppStep, SBRStep, DBStep})
 		})
 		t.Run("scenario-sbr-db-app", func(t *testing.T) {
+			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{SBRStep, DBStep, AppStep})
 		})
 		t.Run("scenario-sbr-app-db", func(t *testing.T) {
+			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{SBRStep, AppStep, DBStep})
 		})
 		t.Run("scenario-csv-db-app-sbr", func(t *testing.T) {

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -93,22 +93,18 @@ func TestAddSchemesToFramework(t *testing.T) {
 		t.Run("scenario-app-db-sbr", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{AppStep, DBStep, SBRStep})
 		})
-		/* Currently disabled as not supported by SBO
 		t.Run("scenario-db-sbr-app", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{DBStep, SBRStep, AppStep})
 		})
-		*/
 		t.Run("scenario-app-sbr-db", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{AppStep, SBRStep, DBStep})
 		})
-		/* Currently disabled as not supported by SBO
 		t.Run("scenario-sbr-db-app", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{SBRStep, DBStep, AppStep})
 		})
 		t.Run("scenario-sbr-app-db", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{SBRStep, AppStep, DBStep})
 		})
-		*/
 		t.Run("scenario-csv-db-app-sbr", func(t *testing.T) {
 			ServiceBindingRequest(t, []Step{CSVStep, DBStep, AppStep, SBRStep})
 		})


### PR DESCRIPTION
### Motivation

As described in https://github.com/redhat-developer/service-binding-operator/issues/549#issuecomment-657500353 by @isutton:
>Currently when the application is created after the SBR, even if the GVK of the application is being observed (corev1.Deployment for example), there is no way to correlate the application resource and the SBR to be reconciled since there are no annotations in the application resource yet (the annotation is created after the first reconciliation).
In other words the scenarios where the Application is created after the SBR are currently not supported by the SBO and the tests that implement those passes or fails randomly by cheer chance.

### Changes

e2e scenarios where the application is created after SBR are disabled to un-block all the other PR that are blocked by those e2e scenarios failing. Those will be enabled again as soon as the issue is fixed.

### Testing

`make test-e2e`