### PR TITLE
The framework's olm-catalog doc now resides at a new place

### DIFF
--- a/deploy/olm-catalog/README.md
+++ b/deploy/olm-catalog/README.md
@@ -1,2 +1,2 @@
 Users can configure CSV composition by populating several fields in the file `deploy/olm-catalog/csv-config.yaml`.
-Please refer the [Operator-SDK CSV generation Design Doc](https://github.com/operator-framework/operator-sdk/blob/master/doc/design/milestone-0.2.0/csv-generation.md#configuration)
+Please refer the [Operator-SDK CSV generation Design Doc](https://github.com/operator-framework/operator-sdk/blob/master/design/milestone-0.2.0/csv-generation.md)


### PR DESCRIPTION
The link to the operator-framework olm-catalog doc is broken.
