### PR TITLE
Use yamllint==1.23.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ YAML_FILES := $(shell find . -path ./vendor -prune -o -type f -regex ".*y[a]ml" 
 .PHONY: lint-yaml
 ## runs yamllint on all yaml files
 lint-yaml: ${YAML_FILES}
-	$(Q)$(OUTPUT_DIR)/venv3/bin/pip install yamllint
+	$(Q)$(OUTPUT_DIR)/venv3/bin/pip install yamllint==1.23.0
 	$(Q)$(OUTPUT_DIR)/venv3/bin/yamllint -c .yamllint $(YAML_FILES)
 
 .PHONY: lint-go-code


### PR DESCRIPTION
### Motivation

Latest yamllint==1.24.0 was released a few hours ago and it appears to be broken. 

An issue on yamllint: https://github.com/adrienverge/yamllint/issues/285

Our lint job in CI is failing with the same reason.