### PR TITLE
fix(#561): Pin version of yamllint to v1.23.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ YAML_FILES := $(shell find . -path ./vendor -prune -o -type f -regex ".*y[a]ml" 
 .PHONY: lint-yaml
 ## runs yamllint on all yaml files
 lint-yaml: ${YAML_FILES}
-	$(Q)$(OUTPUT_DIR)/venv3/bin/pip install yamllint
+	$(Q)$(OUTPUT_DIR)/venv3/bin/pip install yamllint==1.23.0
 	$(Q)$(OUTPUT_DIR)/venv3/bin/yamllint -c .yamllint $(YAML_FILES)
 
 .PHONY: lint-go-code


### PR DESCRIPTION
### Motivation
Fixes https://github.com/redhat-developer/service-binding-operator/issues/561

### Changes

Pins version of yamllint to v1.23.0

### Testing

`make lint-yaml`
