### PR TITLE
[acceptance-tests] Unify python's venv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,4 @@ tags
 .idea
 ### Logs
 **/*.log
-venv
 **/*/__pycache__

--- a/hack/check-python/check-PEP8-style.sh
+++ b/hack/check-python/check-PEP8-style.sh
@@ -13,12 +13,12 @@ echo
 # checks for the whole directories
 for directory in $directories
 do
-    files=$(find "$directory" -path "$directory/venv" -prune -o -name '*.py' -print)
+    files=$(find "$directory" -path "$PYTHON_VENV_DIR" -prune -o -name '*.py' -print)
 
     for source in $files
     do
         echo "$source"
-        pycodestyle "$source"
+        $PYTHON_VENV_DIR/bin/pycodestyle "$source"
         if [ $? -eq 0 ]
         then
             echo "    Pass"

--- a/hack/check-python/check-python-docstyle.sh
+++ b/hack/check-python/check-python-docstyle.sh
@@ -7,7 +7,7 @@ function check_files() {
     for source in $1
     do
         echo "$source"
-        pydocstyle --count "$source"
+        $PYTHON_VENV_DIR/bin/pydocstyle --count "$source"
         if [ $? -eq 0 ]
         then
             echo "    Pass"
@@ -36,7 +36,7 @@ echo
 # checks for the whole directories
 for directory in $directories
 do
-    files=$(find "$directory" -path "$directory/venv" -prune -o -name '*.py' -print)
+    files=$(find "$directory" -path "$PYTHON_VENV_DIR" -prune -o -name '*.py' -print)
 
     check_files "$files"
 done

--- a/hack/check-python/detect-common-errors.sh
+++ b/hack/check-python/detect-common-errors.sh
@@ -7,7 +7,7 @@ function check_files() {
     for source in $1
     do
         echo "$source"
-        pyflakes "$source"
+        $PYTHON_VENV_DIR/bin/pyflakes "$source"
         if [ $? -eq 0 ]
         then
             echo "    Pass"
@@ -36,7 +36,8 @@ echo
 # checks for the whole directories
 for directory in $directories
 do
-    files=$(find "$directory" -path "$directory/venv" -prune -o -name '*.py' -print)
+    pwd
+    files=$(find "$directory" -path "$PYTHON_VENV_DIR" -prune -o -name '*.py' -print)
 
     check_files "$files"
 done

--- a/hack/check-python/detect-dead-code.sh
+++ b/hack/check-python/detect-dead-code.sh
@@ -7,7 +7,7 @@ function check_files() {
     for source in $1
     do
         echo "$source"
-        vulture --min-confidence 90 "$source"
+        $PYTHON_VENV_DIR/bin/vulture --min-confidence 90 "$source"
         if [ $? -eq 0 ]
         then
             echo "    Pass"
@@ -36,7 +36,7 @@ echo
 # checks for the whole directories
 for directory in $directories
 do
-    files=$(find "$directory" -path "$directory/venv" -prune -o -name '*.py' -print)
+    files=$(find "$directory" -prune -o -name '*.py' -print)
 
     check_files "$files"
 done

--- a/hack/check-python/measure-cyclomatic-complexity.sh
+++ b/hack/check-python/measure-cyclomatic-complexity.sh
@@ -7,5 +7,5 @@
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 pushd "${SCRIPT_DIR}/.."
-radon cc -s -a -i venv .
+$PYTHON_VENV_DIR/bin/radon cc -s -a -i "$PYTHON_VENV_DIR" .
 popd

--- a/hack/check-python/measure-maintainability-index.sh
+++ b/hack/check-python/measure-maintainability-index.sh
@@ -7,5 +7,5 @@
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 pushd "${SCRIPT_DIR}/.."
-radon mi -s -i venv .
+$PYTHON_VENV_DIR/bin/radon mi -s -i "$PYTHON_VENV_DIR" .
 popd

--- a/hack/check-python/prepare-env.sh
+++ b/hack/check-python/prepare-env.sh
@@ -1,10 +1,11 @@
-
-directories=${directories:-"./test/acceptance/features"}
+directories=${directories:-"test/acceptance/features"}
 pass=0
 fail=0
 
+export PYTHON_VENV_DIR=${PYTHON_VENV_DIR:-venv}
+
 function prepare_venv() {
-    python3 -m venv venv && source venv/bin/activate
+    python3 -m venv "$PYTHON_VENV_DIR" && source "$PYTHON_VENV_DIR/bin/activate"
     for req in $(find . -name 'requirements.txt'); do
         python3 "$(which pip3)" install -q -r $req;
     done


### PR DESCRIPTION
### Motivation

Currently, there are multiple python's virtual environment directories

* `./out/venv3`
* `./venv`

used throughout the repository:

* `make setup-venv`
* `make lint-yaml`
* `make lint-python-code`
* `make test-acceptnace`
* `make validate-release`
* `make prepare-bundle-to-quay`
* `make push-bundle-to-quay`

### Changes

This PR unifies them all under a single one under `out/venv3`:

### Testing

Any or all of the above make targets.