### PR TITLE
[acceptance-tests] Replace deprecated OperatorSource by CatalogSource.

### DIFF
--- a/test/acceptance/features/steps/dboperator.py
+++ b/test/acceptance/features/steps/dboperator.py
@@ -14,8 +14,8 @@ class DbOperator():
 
     name = ""
     namespace = ""
-    operator_source_name = "db-operators"
-    operator_registry_namespace = "pmacik"
+    operator_source_name = "pmacik-olm-registry"
+    operator_registry_image = "quay.io/pmacik/olm:v1"
     operator_registry_channel = "stable"
     package_name = "db-operators"
 
@@ -35,16 +35,19 @@ class DbOperator():
         else:
             return False
 
-    def install_operator_source(self):
-        install_src_output = self.openshift.create_operator_source(self.operator_source_name, self.operator_registry_namespace)
-        if not re.search(r'.*operatorsource.operators.coreos.com/%s\s(unchanged|created)' % self.operator_source_name, install_src_output):
-            print("Failed to create {} operator source".format(self.operator_source_name))
+    def install_catalog_source(self):
+        install_src_output = self.openshift.create_catalog_source(self.operator_source_name, self.operator_registry_image)
+        if re.search(r'.*catalogsource.operators.coreos.com/%s\s(unchanged|created)' % self.operator_source_name, install_src_output) is None:
+            print("Failed to create {} catalog source".format(self.operator_source_name))
             return False
         return self.openshift.wait_for_package_manifest(self.package_name, self.operator_source_name, self.operator_registry_channel)
 
     def install_operator_subscription(self):
         install_sub_output = self.openshift.create_operator_subscription(self.package_name, self.operator_source_name, self.operator_registry_channel)
-        return re.search(r'.*subscription.operators.coreos.com/%s\s(unchanged|created)' % self.operator_source_name, install_sub_output)
+        if re.search(r'.*subscription.operators.coreos.com/%s\s(unchanged|created)' % self.package_name, install_sub_output) is None:
+            print("Failed to create {} operator subscription".format(self.package_name))
+            return False
+        return True
 
     def get_package_manifest(self):
         cmd = 'oc get packagemanifest %s -o "jsonpath={.metadata.name}"' % self.pkgManifest

--- a/test/acceptance/features/steps/dboperator.py
+++ b/test/acceptance/features/steps/dboperator.py
@@ -14,8 +14,8 @@ class DbOperator():
 
     name = ""
     namespace = ""
-    operator_catalog_source_name = "pmacik-olm-registry"
-    operator_catalog_image = "quay.io/pmacik/olm:v1"
+    operator_catalog_source_name = "sample-db-operators"
+    operator_catalog_image = "quay.io/redhat-developer/sample-db-operators-olm:v1"
     operator_catalog_channel = "stable"
     package_name = "db-operators"
 

--- a/test/acceptance/features/steps/dboperator.py
+++ b/test/acceptance/features/steps/dboperator.py
@@ -14,9 +14,9 @@ class DbOperator():
 
     name = ""
     namespace = ""
-    operator_source_name = "pmacik-olm-registry"
-    operator_registry_image = "quay.io/pmacik/olm:v1"
-    operator_registry_channel = "stable"
+    operator_catalog_source_name = "pmacik-olm-registry"
+    operator_catalog_image = "quay.io/pmacik/olm:v1"
+    operator_catalog_channel = "stable"
     package_name = "db-operators"
 
     def __init__(self, name="postgresql-operator", namespace="openshift-operators"):
@@ -36,14 +36,14 @@ class DbOperator():
             return False
 
     def install_catalog_source(self):
-        install_src_output = self.openshift.create_catalog_source(self.operator_source_name, self.operator_registry_image)
-        if re.search(r'.*catalogsource.operators.coreos.com/%s\s(unchanged|created)' % self.operator_source_name, install_src_output) is None:
-            print("Failed to create {} catalog source".format(self.operator_source_name))
+        install_src_output = self.openshift.create_catalog_source(self.operator_catalog_source_name, self.operator_catalog_image)
+        if re.search(r'.*catalogsource.operators.coreos.com/%s\s(unchanged|created)' % self.operator_catalog_source_name, install_src_output) is None:
+            print("Failed to create {} catalog source".format(self.operator_catalog_source_name))
             return False
-        return self.openshift.wait_for_package_manifest(self.package_name, self.operator_source_name, self.operator_registry_channel)
+        return self.openshift.wait_for_package_manifest(self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel)
 
     def install_operator_subscription(self):
-        install_sub_output = self.openshift.create_operator_subscription(self.package_name, self.operator_source_name, self.operator_registry_channel)
+        install_sub_output = self.openshift.create_operator_subscription(self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel)
         if re.search(r'.*subscription.operators.coreos.com/%s\s(unchanged|created)' % self.package_name, install_sub_output) is None:
             print("Failed to create {} operator subscription".format(self.package_name))
             return False

--- a/test/acceptance/features/steps/openshift.py
+++ b/test/acceptance/features/steps/openshift.py
@@ -17,7 +17,7 @@ metadata:
     namespace: openshift-marketplace
 spec:
     sourceType: grpc
-    image: {registry_image}
+    image: {catalog_image}
     displayName: {name} OLM registry
     updateStrategy:
         registryPoll:
@@ -104,8 +104,8 @@ spec:
         (output, exit_code) = self.cmd.run("oc apply -f -", yaml)
         return output
 
-    def create_catalog_source(self, name, registry_image):
-        catalog_source = self.catalog_source_yaml_template.format(name=name, registry_image=registry_image)
+    def create_catalog_source(self, name, catalog_image):
+        catalog_source = self.catalog_source_yaml_template.format(name=name, catalog_image=catalog_image)
         return self.oc_apply(catalog_source)
 
     def get_current_csv(self, package_name, catalog, channel):

--- a/test/acceptance/features/steps/openshift.py
+++ b/test/acceptance/features/steps/openshift.py
@@ -9,17 +9,19 @@ nodejs_app = "https://github.com/pmacik/nodejs-rest-http-crud"
 class Openshift(object):
     def __init__(self):
         self.cmd = Command()
-        self.operator_source_yaml_template = '''
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorSource
+        self.catalog_source_yaml_template = '''
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
 metadata:
     name: {name}
     namespace: openshift-marketplace
 spec:
-    type: appregistry
-    endpoint: https://quay.io/cnr
-    registryNamespace: {registry_namespace}
+    sourceType: grpc
+    image: {registry_image}
+    displayName: {name} OLM registry
+    updateStrategy:
+        registryPoll:
+            interval: 30m
 '''
         self.operator_subscription_yaml_template = '''
 ---
@@ -102,9 +104,9 @@ spec:
         (output, exit_code) = self.cmd.run("oc apply -f -", yaml)
         return output
 
-    def create_operator_source(self, name, registry_namespace):
-        operator_source = self.operator_source_yaml_template.format(name=name, registry_namespace=registry_namespace)
-        return self.oc_apply(operator_source)
+    def create_catalog_source(self, name, registry_image):
+        catalog_source = self.catalog_source_yaml_template.format(name=name, registry_image=registry_image)
+        return self.oc_apply(catalog_source)
 
     def get_current_csv(self, package_name, catalog, channel):
         cmd = f'oc get packagemanifests -o json | jq -r \'.items[] \

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -82,7 +82,7 @@ def given_db_operator_is_installed(context):
     db_operator = DbOperator()
     if not db_operator.is_running():
         print("DB operator is not installed, installing...")
-        db_operator.install_operator_source() | should.be_truthy.desc("DB operator source installed")
+        db_operator.install_catalog_source() | should.be_truthy.desc("DB catalog source installed")
         db_operator.install_operator_subscription() | should.be_truthy.desc("DB operator subscription installed")
         db_operator.is_running(wait=True) | should.be_truthy.desc("DB operator installed")
     print("PostgresSQL DB operator is running!!!")


### PR DESCRIPTION
### Motivation

`OperatorSource` is [deprecated](https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-marketplace-apis-deprecated) for OpenShift 4.4+

Fixes [APPSVC-592](https://issues.redhat.com/browse/APPSVC-592) for the acceptance tests.

### Changes

Use of `OperatorSource` to install PostgreSQL DB operator is replaced by the use of plain `CatalogSource`.

### Testing

`make test-acceptance`
