### PR TITLE
[acceptance-tests] Remove killall line before starting local SBO

### DIFF
--- a/hack/deploy-sbo-local.sh
+++ b/hack/deploy-sbo-local.sh
@@ -5,8 +5,6 @@ ZAP_FLAGS=${ZAP_FLAGS:-}
 
 SBO_LOCAL_LOG=out/sbo-local.log
 
-killall operator-sdk service-binding-operator-local
-
 operator-sdk --verbose run --local --namespace="$OPERATOR_NAMESPACE" --operator-flags "$ZAP_FLAGS" > $SBO_LOCAL_LOG 2>&1 &
 
 SBO_PID=$!


### PR DESCRIPTION
### Motivation

`killall`is not installed in the `test` container by default. So, calling it as part of the acceptance tests setup breaks it (along with per-PR checks). However, there is no need for running `killall` before local SBO is started in CI, since there are no `operator-sdk` or `service-binding-operator-local` processes running in the `test` container, anyway.

### Changes

Removed `killall` line in the `deploy-sbo-local.sh` script.

### Testing

`make test-acceptnace-setup`