### PR TITLE
[acceptance-tests] Generate test results in JUnit XML/xUnit format.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ test-acceptance: e2e-setup set-test-namespace deploy-clean deploy-rbac deploy-cr
 	$(Q)TEST_ACCEPTANCE_START_SBO=$(TEST_ACCEPTANCE_START_SBO) \
 		TEST_ACCEPTANCE_SBO_STARTED=$(TEST_ACCEPTANCE_SBO_STARTED) \
 		TEST_NAMESPACE=$(TEST_NAMESPACE) \
-		$(PYTHON_VENV_DIR)/bin/behave -v --no-capture --no-capture-stderr --tags="~@disabled" test/acceptance/features
+		$(PYTHON_VENV_DIR)/bin/behave --junit --junit-directory $(OUTPUT_DIR)/acceptance-tests $(V_FLAG) --no-capture --no-capture-stderr --tags="~@disabled" test/acceptance/features
 	$(Q)kill $(TEST_ACCEPTANCE_SBO_STARTED)
 
 .PHONY: test


### PR DESCRIPTION
### Motivation

Currently the only output is the console which is useful for humans but not for processing my a machine. xUnit format is a standardized format and the acceptance tests should generate this form in order to be able to report those results in an automated way later on.

### Changes

This PR enables the generation of the results in [xUnit](https://en.wikipedia.org/wiki/XUnit) format. The result files are stored under the `out/acceptance-tests` directory.

### Testing

* `make test-acceptance`
* look under `out/acceptance-tests` for `*.xml` files