### PR TITLE
Use file path as target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,11 +339,11 @@ build-image:
 generate-k8s:
 	$(Q)GOCACHE=$(GOCACHE) operator-sdk generate k8s
 
-build-openapi-gen-cli: $(OUTPUT_DIR)/openapi-gen
+$(OUTPUT_DIR)/openapi-gen:
 	$(Q)GOCACHE=$(GOCACHE) go build -o $(OUTPUT_DIR)/openapi-gen k8s.io/kube-openapi/cmd/openapi-gen
 
 ## Generate-OpenAPI: after modifying _types, generate OpenAPI scaffolding.
-generate-openapi: build-openapi-gen-cli
+generate-openapi: $(OUTPUT_DIR)/openapi-gen
 	# Build the latest openapi-gen from source
 	$(Q)GOCACHE=$(GOCACHE) $(OUTPUT_DIR)/openapi-gen --logtostderr=true -o "" -i $(GO_PACKAGE_PATH)/pkg/apis/apps/v1alpha1 -O zz_generated.openapi -p ./pkg/apis/apps/v1alpha1 -h ./hack/boilerplate.go.txt -r "-"
 


### PR DESCRIPTION
### Motivation

Makefile target better fits as a non-PHONY target.

### Changes

Use file path as target

### Testing

Run `make generate-openapi` and check for the existence of binary.