### PR TITLE
[acceptance-tests] Kill local sbo process before running acceptance tests.

### DIFF
--- a/hack/deploy-sbo-local.sh
+++ b/hack/deploy-sbo-local.sh
@@ -5,6 +5,18 @@ ZAP_FLAGS=${ZAP_FLAGS:-}
 
 SBO_LOCAL_LOG=out/sbo-local.log
 
+_killall(){
+    which killall &> /dev/null
+    if [ $? -eq 0 ]; then
+        killall $1
+    else
+        for i in "$(ps -l | grep $1)"; do if [ -n "$i" ]; then kill $(echo "$i" | sed -e 's,\s\+,#,g' | cut -d "#" -f4); fi; done
+    fi
+}
+
+_killall operator-sdk
+_killall service-binding-operator-local
+
 operator-sdk --verbose run --local --namespace="$OPERATOR_NAMESPACE" --operator-flags "$ZAP_FLAGS" > $SBO_LOCAL_LOG 2>&1 &
 
 SBO_PID=$!


### PR DESCRIPTION
### Motivation

Follow-op on #574 

There is indeed no need to kill the `operator-sdk` or `service-binding-operator-local` processes in the CI, since it all runs in a clean container. However, it is necessary for the development of the acceptance tests or for running those locally to kill those processes every time a local SBO instance is started for the acceptance tests to avoid conflicts and to make sure the acceptance tests are executed with the latest codebase.

### Changes

A kill all mechanism is introduced into the `./hack/deploy-sbo-local.sh` which covers both cases of `killall` tool being installed or not.

### Testing

`make test-acceptance-setup`