### PR TITLE
Add .kube cache dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ tmp/
 # gocache
 out/
 
+# Acceptance test cache
+.kube/
+
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-


### PR DESCRIPTION
### Motivation
acceptance tests create some Kubernetes object-related cache inside `.kube`. So adding it `.gitignore`

For further more details refer the CONTRIBUTING.md