### PR TITLE
Remove an unused target and Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,15 +450,9 @@ else
 		-Z > codecov-upload.log
 endif
 
-## -- Target for maintaining consistent crd copies --
 
-.PHONY: consistent-crds-manifests-upstream
-## Copy crd from deploy/crds to manifests-upstream/
-consistent-crds-manifests-upstream:
-	$(Q)cd ./manifests-upstream/${OPERATOR_VERSION}/ && ln -srf ../../deploy/crds/apps_v1alpha1_servicebindingrequest_crd.yaml \
-	servicebindingrequests.apps.openshift.io.crd.yaml
+## -- Bundle validation, push and release targets
 
-## -- Target for merge to master dev release --
 .PHONY: merge-to-master-release
 ## Make a dev release on every merge to master
 merge-to-master-release:
@@ -468,7 +462,6 @@ merge-to-master-release:
 	docker push "$(OPERATOR_IMAGE_REF)"
 
 
-## -- Target for pushing manifest bundle to service-binding-operator-manifest repo --
 .PHONY: push-to-manifest-repo
 ## Push manifest bundle to service-binding-operator-manifest repo
 push-to-manifest-repo:
@@ -486,7 +479,6 @@ push-to-manifest-repo:
 	sed -i -e 's,ICON_BASE64_DATA,$(shell base64 --wrap=0 ./assets/icon/red-hat-logo.svg),g' $(MANIFESTS_TMP)/${BUNDLE_VERSION}/*.clusterserviceversion.yaml
 	sed -i -e 's,ICON_MEDIA_TYPE,image/svg+xml,g' $(MANIFESTS_TMP)/${BUNDLE_VERSION}/*.clusterserviceversion.yaml
 
-## -- Target for preparing manifest bundle to quay application --
 .PHONY: prepare-bundle-to-quay
 ## Prepare manifest bundle to quay application
 prepare-bundle-to-quay:
@@ -498,23 +490,21 @@ prepare-bundle-to-quay:
 	$(Q)$(PYTHON_VENV_DIR)/bin/operator-courier verify $(MANIFESTS_TMP)
 	rm -rf deploy/olm-catalog/$(GO_PACKAGE_REPO_NAME)/$(BUNDLE_VERSION)
 
-## -- Target to push bundle to quay
+
 .PHONY: push-bundle-to-quay
 ## Push manifest bundle to quay application
 push-bundle-to-quay:
 	$(Q)$(PYTHON_VENV_DIR)/bin/operator-courier verify $(SBR_MANIFESTS)
 	$(Q)$(PYTHON_VENV_DIR)/bin/operator-courier push $(SBR_MANIFESTS) redhat-developer service-binding-operator $(BUNDLE_VERSION) "$(QUAY_BUNDLE_TOKEN)"
 
-## -- Target for validating the operator --
+
 .PHONY: dev-release
 ## validating the operator by installing new quay releases
 dev-release:
 	BUNDLE_VERSION=$(BUNDLE_VERSION) ./hack/dev-release.sh
 
-## -- Target to validate release --
 .PHONY: validate-release
 ## validate the operator by installing the releases
 validate-release: setup-venv
 	$(Q)$(PYTHON_VENV_DIR)/bin/pip install yq==2.10.0
 	BUNDLE_VERSION=$(BASE_BUNDLE_VERSION) CHANNEL="alpha" ./hack/validate-release.sh
-


### PR DESCRIPTION
Remove consistent-crds-manifests-upstream as it is no longer required since manifests-upstream has been removed.
```
consistent-crds-manifests-upstream:  Copy crd from deploy/crds to manifests-upstream/
merge-to-master-release  -- Target for merge to master dev release --
merge-to-master-release:  Make a dev release on every merge to master
push-to-manifest-repo  -- Target for pushing manifest bundle to service-binding-operator-manifest repo --
push-to-manifest-repo:  Push manifest bundle to service-binding-operator-manifest repo
prepare-bundle-to-quay  -- Target for preparing manifest bundle to quay application --
prepare-bundle-to-quay:  Prepare manifest bundle to quay application
push-bundle-to-quay   -- Target to push bundle to quay
push-bundle-to-quay:  Push manifest bundle to quay application
dev-release           -- Target for validating the operator --
dev-release:          validating the operator by installing new quay releases
validate-release      -- Target to validate release --
validate-release:     validate the operator by installing the releases
```
Makeup target headings cleanup, . Run `make` to find the following now
```
                      -- Bundle validation, push and release targets
merge-to-master-release:  Make a dev release on every merge to master
push-to-manifest-repo:  Push manifest bundle to service-binding-operator-manifest repo
prepare-bundle-to-quay:  Prepare manifest bundle to quay application
push-bundle-to-quay:  Push manifest bundle to quay application
dev-release:          validating the operator by installing new quay releases
validate-release:     validate the operator by installing the releases
````