### PR TITLE
Reconcile should log error if a resource is not found in detect Bindable resource

### DIFF
--- a/pkg/controller/servicebindingrequest/service.go
+++ b/pkg/controller/servicebindingrequest/service.go
@@ -173,13 +173,12 @@ func getOwnedResources(
 	error,
 ) {
 	var resources []*unstructured.Unstructured
-BINDING_RESOURCES:
 	for _, br := range bindableResources {
 		lst, err := client.Resource(br.gvr).Namespace(ns).List(metav1.ListOptions{})
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				logger.Debug("Resource not found in Bindable Resources", "Error", err)
-				continue BINDING_RESOURCES
+				continue
 			}
 			return resources, err
 		}

--- a/pkg/controller/servicebindingrequest/service.go
+++ b/pkg/controller/servicebindingrequest/service.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -176,11 +177,11 @@ BINDING_RESOURCES:
 	for _, br := range bindableResources {
 		lst, err := client.Resource(br.gvr).Namespace(ns).List(metav1.ListOptions{})
 		if err != nil {
-			// if err == k8serrors.NewNotFound() {
-			logger.Debug("Resource not found in Bindable Resources", "Error", err)
-			continue BINDING_RESOURCES
-			// }
-			// return resources, err
+			if k8serrors.IsNotFound(err) {
+				logger.Debug("Resource not found in Bindable Resources", "Error", err)
+				continue BINDING_RESOURCES
+			}
+			return resources, err
 		}
 		for idx, item := range lst.Items {
 			owners := item.GetOwnerReferences()

--- a/pkg/controller/servicebindingrequest/servicecontext.go
+++ b/pkg/controller/servicebindingrequest/servicecontext.go
@@ -85,6 +85,7 @@ SELECTORS:
 				svcEnvVarPrefix = &s.Kind
 			}
 			ownedResourcesCtxs, err := findOwnedResourcesCtxs(
+				logger,
 				client,
 				ns,
 				svcCtx.service.GetName(),
@@ -104,6 +105,7 @@ SELECTORS:
 }
 
 func findOwnedResourcesCtxs(
+	logger *log.Log,
 	client dynamic.Interface,
 	ns string,
 	name string,
@@ -113,6 +115,7 @@ func findOwnedResourcesCtxs(
 	restMapper meta.RESTMapper,
 ) (serviceContextList, error) {
 	ownedResources, err := getOwnedResources(
+		logger,
 		client,
 		ns,
 		gvk,

--- a/pkg/controller/servicebindingrequest/servicecontext_test.go
+++ b/pkg/controller/servicebindingrequest/servicecontext_test.go
@@ -189,11 +189,13 @@ func TestFindOwnedResourcesCtxs_ConfigMap(t *testing.T) {
 	f.AddMockResource(cr)
 	f.AddMockResource(us)
 	f.AddMockResource(&unstructured.Unstructured{Object: route})
+	logger := log.NewLog("testFindOwnedResourcesCtxs_cm")
 
 	restMapper := testutils.BuildTestRESTMapper()
 
 	t.Run("existing selectors", func(t *testing.T) {
 		got, err := findOwnedResourcesCtxs(
+			logger,
 			f.FakeDynClient(),
 			cr.GetNamespace(),
 			cr.GetName(),
@@ -251,6 +253,7 @@ func TestFindOwnedResourcesCtxs_Secrets(t *testing.T) {
 			f.S.AddKnownTypes(routev1.SchemeGroupVersion, &routev1.Route{})
 			f.AddMockResource(cr)
 			f.AddMockResource(&unstructured.Unstructured{Object: route})
+			logger := log.NewLog("testFindOwnedResourcesCtxs_secret")
 
 			restMapper := testutils.BuildTestRESTMapper()
 
@@ -265,6 +268,7 @@ func TestFindOwnedResourcesCtxs_Secrets(t *testing.T) {
 			}
 
 			ownedResourcesCtxs, err := findOwnedResourcesCtxs(
+				logger,
 				f.FakeDynClient(),
 				cr.GetNamespace(),
 				cr.GetName(),


### PR DESCRIPTION
Fix for #584 
Do not error out when resource not found in the binding resources, Instead log it as stated below
```
2020-07-23T21:04:33.309+0530	DEBUG	reconciler.buildServiceContexts	Resource not found in Bindable Resources	{"Request.Namespace": "try", "Request.Name": "binding-request-etcd", "ServiceBindingRequest.Name": "binding-request-etcd", "Error": "the server could not find the requested resource"}
```
