### PR TITLE
[acceptance-tests] Enable test artifacts gathering in CI

### DIFF
--- a/hack/deploy-sbo-local.sh
+++ b/hack/deploy-sbo-local.sh
@@ -3,7 +3,10 @@
 OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE:-}
 ZAP_FLAGS=${ZAP_FLAGS:-}
 
-SBO_LOCAL_LOG=out/sbo-local.log
+OUTPUT="${OUTPUT:-out/acceptance-tests}"
+mkdir -p "$OUTPUT"
+
+SBO_LOCAL_LOG="$OUTPUT/sbo-local.log"
 
 _killall(){
     which killall &> /dev/null


### PR DESCRIPTION
### Motivation

Currently the only archived data is the test console output archived in CI. To be able to investigate any acceptance tests failures it is useful and necessary to gather as much data as possible and archive it along the prow job that executed it.

### Changes

This PR:
* Moves the local SBO log under `out/acceptance-tests` directory
* Adds `test-acceptance-artifacts` target (so it can be called in the CI as soon as the tests are finished) to copy the whole `out/acceptnace-tests` directory to the `/tmp/artifacts` (which is the directory from CI ultimately gathers and archives the artifacts)

This is a dependency for https://github.com/openshift/release/pull/10489

### Testing

`make test-acceptance-artifacts`