### PR TITLE
[acceptance-tests] Fix python linting - dead code detection

### DIFF
--- a/hack/check-python/detect-dead-code.sh
+++ b/hack/check-python/detect-dead-code.sh
@@ -36,7 +36,7 @@ echo
 # checks for the whole directories
 for directory in $directories
 do
-    files=$(find "$directory" -prune -o -name '*.py' -print)
+    files=$(find "$directory" -path "$PYTHON_VENV_DIR" -prune -o -name '*.py' -print)
 
     check_files "$files"
 done


### PR DESCRIPTION
### Motivation

Currently the dead code detection part of python linters `make lint-python-code` do not find the `*.py` files and is useless.

### Changes

This PR fixes the dead code detection script (`hack/check-python/detect-dead-code.sh`) to include all the `*.py` files

### Testing

`make lint-python-code`