### PR TITLE
Deprecate relationship annotations

### DIFF
--- a/pkg/controller/servicebindingrequest/mapper.go
+++ b/pkg/controller/servicebindingrequest/mapper.go
@@ -1,9 +1,18 @@
 package servicebindingrequest
 
 import (
-	"github.com/redhat-developer/service-binding-operator/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/pkg/log"
 )
 
 var (
@@ -17,6 +26,93 @@ type sbrRequestMapper struct {
 	restMapper meta.RESTMapper
 }
 
+var serviceBindingRequestGVK = v1alpha1.SchemeGroupVersion.WithKind("ServiceBindingRequest")
+var secretGVK = corev1.SchemeGroupVersion.WithKind("Secret")
+
+// isServiceBindingRequest checks whether the given obj is a Service Binding Request through GVK
+// comparison.
+func isServiceBindingRequest(obj runtime.Object) bool {
+	return obj.GetObjectKind().GroupVersionKind() == serviceBindingRequestGVK
+}
+
+// isSecret checks whether the given obj is a Secret through GVK comparison.
+func isSecret(obj runtime.Object) bool {
+	return obj.GetObjectKind().GroupVersionKind() == secretGVK
+}
+
+// isSBRService checks whether the given obj is a service in given sbr.
+func isSBRService(sbr *v1alpha1.ServiceBindingRequest, obj runtime.Object) bool {
+	services := extractServiceSelectors(sbr)
+	for _, svc := range services {
+		svcGVK := schema.GroupVersionKind{Group: svc.Group, Version: svc.Version, Kind: svc.Kind}
+		if obj.GetObjectKind().GroupVersionKind() == svcGVK {
+			return true
+		}
+	}
+	return false
+}
+
+// isApplication checks whether the given obj is an application in given sbr.
+func isApplication(
+	restMapper meta.RESTMapper,
+	sbr *v1alpha1.ServiceBindingRequest,
+	obj runtime.Object,
+) (bool, error) {
+	appGVR := schema.GroupVersionResource{
+		Group:    sbr.Spec.ApplicationSelector.Group,
+		Version:  sbr.Spec.ApplicationSelector.Version,
+		Resource: sbr.Spec.ApplicationSelector.Resource,
+	}
+	appGVK, err := restMapper.KindFor(appGVR)
+	if err != nil {
+		return false, err
+	}
+
+	isEqual := obj.GetObjectKind().GroupVersionKind() == appGVK
+
+	return isEqual, nil
+}
+
+// isSecretOwnedBySBR checks whether the given obj is a secret owned by the given sbr.
+func isSecretOwnedBySBR(obj metav1.Object, sbr *v1alpha1.ServiceBindingRequest) bool {
+	return sbr.GetNamespace() == obj.GetNamespace() && sbr.Status.Secret == obj.GetName()
+}
+
+// convertToSBR attempts to convert the given obj into a Service Binding Request.
+func convertToSBR(obj map[string]interface{}) (*v1alpha1.ServiceBindingRequest, error) {
+	sbr := &v1alpha1.ServiceBindingRequest{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, sbr)
+	return sbr, err
+}
+
+// convertToNamespacedName returns a NamespacedName with information extracted from given obj.
+func convertToNamespacedName(obj metav1.Object) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}
+
+// namespacedNameSet is a set of NamespacedNames.
+type namespacedNameSet map[types.NamespacedName]bool
+
+// add adds the given namespaced name n into the set.
+func (t namespacedNameSet) add(n types.NamespacedName) {
+	t[n] = true
+}
+
+func convertToRequests(t namespacedNameSet) []reconcile.Request {
+	toReconcile := make([]reconcile.Request, 0)
+	for n := range t {
+		toReconcile = append(
+			toReconcile,
+			reconcile.Request{NamespacedName: n},
+		)
+	}
+	return toReconcile
+
+}
+
 // Map execute the mapping of a resource with the requests it would produce. Here we inspect the
 // given object trying to identify if this object is part of a SBR, or a actual SBR resource.
 func (m *sbrRequestMapper) Map(obj handler.MapObject) []reconcile.Request {
@@ -24,17 +120,60 @@ func (m *sbrRequestMapper) Map(obj handler.MapObject) []reconcile.Request {
 		"Object.Namespace", obj.Meta.GetNamespace(),
 		"Object.Name", obj.Meta.GetName(),
 	)
-	toReconcile := []reconcile.Request{}
 
-	sbrNamespacedName, err := getSBRNamespacedNameFromObject(obj.Object)
+	namespacedNamesToReconcile := make(namespacedNameSet)
+
+	if isServiceBindingRequest(obj.Object) {
+		requests := []reconcile.Request{
+			{NamespacedName: convertToNamespacedName(obj.Meta)},
+		}
+		log.Debug("current resource is a SBR", "Requests", requests)
+		return requests
+	}
+
+	sbrList, err := m.client.Resource(groupVersion).List(metav1.ListOptions{})
 	if err != nil {
-		log.Error(err, "on inspecting object for annotations for SBR object")
-		return toReconcile
-	}
-	if isNamespacedNameEmpty(sbrNamespacedName) {
-		log.Debug("not able to extract SBR namespaced-name")
-		return toReconcile
+		log.Error(err, "listing SBRs")
+		// NOTE: nothing to do anymore if obj isn't a SBR and there's an error listing SBRs; I'm not
+		// sure whether retrying in the same reconcile loop is the proper approach so we'll rely on
+		// the resync period to re-process all watched objects.
+		return []reconcile.Request{}
 	}
 
-	return append(toReconcile, reconcile.Request{NamespacedName: sbrNamespacedName})
+ITEMS:
+	for _, item := range sbrList.Items {
+		namespacedName := convertToNamespacedName(&item)
+
+		sbr, err := convertToSBR(item.Object)
+		if err != nil {
+			log.Error(err, "converting unstructured to SBR")
+			continue ITEMS
+		}
+
+		if isSecret(obj.Object) && isSecretOwnedBySBR(obj.Meta, sbr) {
+			log.Debug("current resource is a secret declared in SBR")
+			namespacedNamesToReconcile.add(namespacedName)
+		}
+
+		if isSBRService(sbr, obj.Object) {
+			log.Debug("resource is declared as service in SBR")
+			namespacedNamesToReconcile.add(namespacedName)
+		} else {
+			log.Debug("resource does not match any declared service")
+		}
+
+		if ok, err := isApplication(m.restMapper, sbr, obj.Object); err != nil {
+			log.Error(err, "verifying if resource is an application in SBR")
+			continue ITEMS
+		} else if !ok {
+			log.Debug("not an application")
+			continue ITEMS
+		} else {
+			namespacedNamesToReconcile.add(namespacedName)
+		}
+	}
+
+	requests := convertToRequests(namespacedNamesToReconcile)
+	log.Debug("did finish request mapper", "Requests", requests)
+	return requests
 }

--- a/pkg/controller/servicebindingrequest/mapper.go
+++ b/pkg/controller/servicebindingrequest/mapper.go
@@ -52,8 +52,8 @@ func isSBRService(sbr *v1alpha1.ServiceBindingRequest, obj runtime.Object) bool 
 	return false
 }
 
-// isApplication checks whether the given obj is an application in given sbr.
-func isApplication(
+// isSBRApplication checks whether the given obj is an application in given sbr.
+func isSBRApplication(
 	restMapper meta.RESTMapper,
 	sbr *v1alpha1.ServiceBindingRequest,
 	obj runtime.Object,
@@ -168,7 +168,7 @@ ITEMS:
 			log.Debug("resource is not a service declared by the SBR")
 		}
 
-		if ok, err := isApplication(m.restMapper, sbr, obj.Object); err != nil {
+		if ok, err := isSBRApplication(m.restMapper, sbr, obj.Object); err != nil {
 			log.Error(err, "identifying resource resource as SBR application")
 			continue ITEMS
 		} else if !ok {

--- a/pkg/controller/servicebindingrequest/mapper.go
+++ b/pkg/controller/servicebindingrequest/mapper.go
@@ -169,7 +169,7 @@ ITEMS:
 		}
 
 		if ok, err := isSBRApplication(m.restMapper, sbr, obj.Object); err != nil {
-			log.Error(err, "identifying resource resource as SBR application")
+			log.Error(err, "identifying resource as SBR application")
 			continue ITEMS
 		} else if !ok {
 			log.Debug("resource is not an application declared by the SBR")

--- a/pkg/controller/servicebindingrequest/mapper.go
+++ b/pkg/controller/servicebindingrequest/mapper.go
@@ -12,7 +12,10 @@ var (
 
 // sbrRequestMapper is the handler.Mapper interface implementation. It should influence the
 // enqueue process considering the resources informed.
-type sbrRequestMapper struct{}
+type sbrRequestMapper struct {
+	client     dynamic.Interface
+	restMapper meta.RESTMapper
+}
 
 // Map execute the mapping of a resource with the requests it would produce. Here we inspect the
 // given object trying to identify if this object is part of a SBR, or a actual SBR resource.

--- a/pkg/controller/servicebindingrequest/mapper.go
+++ b/pkg/controller/servicebindingrequest/mapper.go
@@ -131,12 +131,13 @@ func (m *sbrRequestMapper) Map(obj handler.MapObject) []reconcile.Request {
 		return requests
 	}
 
+	// note(isutton): The client handles retries on the operator behalf, so only unrecoverable errors
+	// are left.
+	//
+	// please see https://github.com/isutton/service-binding-operator/blob/e17445570bd3889bcf7499142350a3b81463c6be/vendor/k8s.io/client-go/rest/request.go#L723-L812
 	sbrList, err := m.client.Resource(groupVersion).List(metav1.ListOptions{})
 	if err != nil {
 		log.Error(err, "listing SBRs")
-		// NOTE: nothing to do anymore if obj isn't a SBR and there's an error listing SBRs; I'm not
-		// sure whether retrying in the same reconcile loop is the proper approach so we'll rely on
-		// the resync period to re-process all watched objects.
 		return []reconcile.Request{}
 	}
 

--- a/pkg/controller/servicebindingrequest/mapper_test.go
+++ b/pkg/controller/servicebindingrequest/mapper_test.go
@@ -35,13 +35,15 @@ func TestSBRRequestMapperMap(t *testing.T) {
 				},
 				ResourceRef: "mapper-unit-deployment",
 			},
-			BackingServiceSelector: &v1alpha1.BackingServiceSelector{
-				GroupVersionKind: metav1.GroupVersionKind{
-					Group:   "",
-					Version: "v1",
-					Kind:    "Secret",
+			BackingServiceSelectors: &[]v1alpha1.BackingServiceSelector{
+				{
+					GroupVersionKind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Secret",
+					},
+					ResourceRef: "mapper-unit-secret",
 				},
-				ResourceRef: "mapper-unit-secret",
 			},
 		},
 	}

--- a/pkg/controller/servicebindingrequest/mapper_test.go
+++ b/pkg/controller/servicebindingrequest/mapper_test.go
@@ -4,44 +4,142 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/pkg/testutils"
+	"github.com/redhat-developer/service-binding-operator/test/mocks"
 )
 
 func TestSBRRequestMapperMap(t *testing.T) {
-	mapper := &sbrRequestMapper{}
+	sbr := &v1alpha1.ServiceBindingRequest{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceBindingRequest",
+			APIVersion: "apps.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "mapper-unit",
+			Name:      "mapper-unit-sbr",
+		},
+		Spec: v1alpha1.ServiceBindingRequestSpec{
+			ApplicationSelector: v1alpha1.ApplicationSelector{
+				GroupVersionResource: metav1.GroupVersionResource{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "deployments",
+				},
+				ResourceRef: "mapper-unit-deployment",
+			},
+			BackingServiceSelector: &v1alpha1.BackingServiceSelector{
+				GroupVersionKind: metav1.GroupVersionKind{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+				ResourceRef: "mapper-unit-secret",
+			},
+		},
+	}
 
-	u := &unstructured.Unstructured{}
-	u.SetNamespace("mapper-unit")
-	u.SetName("mapper-unit")
-	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
+	type testCase struct {
+		description         string
+		expectedRequestsLen int
+		buildMapObjectFn    func(*mocks.Fake) handler.MapObject
+		buildFakeFn         func() *mocks.Fake
+	}
 
-	// not containing annotations, should return empty
-	mapObj := handler.MapObject{Meta: u, Object: u.DeepCopyObject()}
-	mappedRequests := mapper.Map(mapObj)
-	require.Equal(t, 0, len(mappedRequests))
+	testCases := []testCase{
+		{
+			description: "no service bindings declared in namespace",
+			buildFakeFn: func() *mocks.Fake {
+				f := mocks.NewFake(t, reconcilerNs)
+				return f
+			},
+			buildMapObjectFn: func(f *mocks.Fake) handler.MapObject {
+				return handler.MapObject{
+					Meta: &metav1.ObjectMeta{
+						Namespace: "mapper-unit",
+						Name:      "mapper-unit-secret",
+					},
+					Object: &corev1.Secret{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind:       "Secret",
+						},
+					},
+				}
+			},
+			expectedRequestsLen: 0,
+		},
+		{
+			description: "resource declared as application of a service binding",
+			buildFakeFn: func() *mocks.Fake {
+				f := mocks.NewFake(t, reconcilerNs)
+				uSbr, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sbr)
+				require.NoError(t, err)
+				f.AddMockResource(&unstructured.Unstructured{Object: uSbr})
+				return f
+			},
+			buildMapObjectFn: func(f *mocks.Fake) handler.MapObject {
+				return handler.MapObject{
+					Meta: &metav1.ObjectMeta{
+						Namespace: "mapper-unit",
+						Name:      "mapper-unit-deployment",
+					},
+					Object: &appsv1.Deployment{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+						},
+					},
+				}
+			},
+			expectedRequestsLen: 1,
+		},
+		{
+			description: "resource declared as service of a service binding",
+			buildFakeFn: func() *mocks.Fake {
+				f := mocks.NewFake(t, reconcilerNs)
+				uSbr, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sbr)
+				require.NoError(t, err)
+				f.AddMockResource(&unstructured.Unstructured{Object: uSbr})
+				return f
+			},
+			buildMapObjectFn: func(f *mocks.Fake) handler.MapObject {
+				return handler.MapObject{
+					Meta: &metav1.ObjectMeta{
+						Namespace: "mapper-unit",
+						Name:      "mapper-unit-secret",
+					},
+					Object: &corev1.Secret{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind:       "Secret",
+						},
+					},
+				}
+			},
+			expectedRequestsLen: 1,
+		},
+	}
 
-	request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "name"}}
-
-	// with annotations in place it should return the actual values
-	u.SetAnnotations(map[string]string{sbrNamespaceAnnotation: "ns", sbrNameAnnotation: "name"})
-	mapObj = handler.MapObject{Meta: u, Object: u.DeepCopyObject()}
-	mappedRequests = mapper.Map(mapObj)
-	require.Equal(t, 1, len(mappedRequests))
-	require.Equal(t, request, mappedRequests[0])
-
-	// it should also understand a actual SBR as well, so return not empty
-	sbr := &unstructured.Unstructured{}
-	sbr.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind(serviceBindingRequestKind))
-	sbr.SetNamespace("ns")
-	sbr.SetName("name")
-	mapObj = handler.MapObject{Meta: u, Object: sbr.DeepCopyObject()}
-	mappedRequests = mapper.Map(mapObj)
-	require.Equal(t, 1, len(mappedRequests))
-	require.Equal(t, request, mappedRequests[0])
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			f := tc.buildFakeFn()
+			mapObject := tc.buildMapObjectFn(f)
+			client := f.FakeDynClient()
+			restMapper := testutils.BuildTestRESTMapper()
+			mapper := &sbrRequestMapper{
+				client:     client,
+				restMapper: restMapper,
+			}
+			mappedRequests := mapper.Map(mapObject)
+			require.Len(t, mappedRequests, tc.expectedRequestsLen)
+		})
+	}
 }

--- a/pkg/controller/servicebindingrequest/sbrcontroller.go
+++ b/pkg/controller/servicebindingrequest/sbrcontroller.go
@@ -64,7 +64,10 @@ func compareObjectFields(objOld, objNew runtime.Object, fields ...string) (bool,
 // newEnqueueRequestsForSBR returns a handler.EventHandler configured to map any incoming object to a
 // ServiceBindingRequest if it contains the required configuration.
 func (s *sbrController) newEnqueueRequestsForSBR() handler.EventHandler {
-	return &handler.EnqueueRequestsFromMapFunc{ToRequests: &sbrRequestMapper{}}
+	return &handler.EnqueueRequestsFromMapFunc{ToRequests: &sbrRequestMapper{
+		client:     s.Client,
+		restMapper: s.RestMapper,
+	}}
 }
 
 // createSourceForGVK creates a *source.Kind for the given gvk.

--- a/pkg/controller/servicebindingrequest/servicebinder.go
+++ b/pkg/controller/servicebindingrequest/servicebinder.go
@@ -12,7 +12,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -327,13 +326,6 @@ func (b *serviceBinder) bind() (reconcile.Result, error) {
 		return b.onError(err, b.sbr, sbrStatus, nil)
 	}
 	b.setApplicationObjects(sbrStatus, updatedObjects)
-
-	// annotating objects related to binding
-	namespacedName := types.NamespacedName{Namespace: b.sbr.GetNamespace(), Name: b.sbr.GetName()}
-	if err = setAndUpdateSBRAnnotations(b.dynClient, namespacedName, append(b.objects, secretObj)); err != nil {
-		b.logger.Error(err, "On setting annotations in related objects.")
-		return b.onError(err, b.sbr, sbrStatus, updatedObjects)
-	}
 
 	conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
 		Type:   InjectionReady,

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -95,19 +95,15 @@ func TestAddSchemesToFramework(t *testing.T) {
 			ServiceBindingRequest(t, []Step{AppStep, DBStep, SBRStep})
 		})
 		t.Run("scenario-db-sbr-app", func(t *testing.T) {
-			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{DBStep, SBRStep, AppStep})
 		})
 		t.Run("scenario-app-sbr-db", func(t *testing.T) {
-			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{AppStep, SBRStep, DBStep})
 		})
 		t.Run("scenario-sbr-db-app", func(t *testing.T) {
-			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{SBRStep, DBStep, AppStep})
 		})
 		t.Run("scenario-sbr-app-db", func(t *testing.T) {
-			t.Skip("Currently disabled as not supported by SBO")
 			ServiceBindingRequest(t, []Step{SBRStep, AppStep, DBStep})
 		})
 		t.Run("scenario-csv-db-app-sbr", func(t *testing.T) {

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -519,14 +519,6 @@ func serviceBindingRequestTest(
 		t.Logf("Inspecting SBR secret: '%s'", intermediarySecretNamespacedName)
 		_, ok := assertSBRSecret(t, todoCtx, f, intermediarySecretNamespacedName, assertKeys)
 		return ok
-		// if err != nil {
-		// 	// it can be that assertSBRSecret returns nil until service configuration values can be
-		// 	// collected.
-		// 	t.Logf("Binding secret contents are invalid: '%#v', error: '%#v'", sbrSecret, err)
-		// 	return false
-		// }
-		// t.Logf("SBR-Secret: Result after attempts, error: '%#v'", err)
-		// return true
 	}, 120*time.Second, 2*time.Second)
 
 	// editing intermediary secret in order to trigger update event
@@ -549,12 +541,6 @@ func serviceBindingRequestTest(
 		t.Logf("Inspecting secret: '%s'", intermediarySecretNamespacedName)
 		_, ok := assertSBRSecret(t, todoCtx, f, intermediarySecretNamespacedName, assertKeys)
 		return ok
-		// if err != nil {
-		// 	t.Logf("Secret inspection error: '%#v'", err)
-		// 	return false
-		// }
-		// t.Logf("Secret: Result after attempts, error: '%#v'", err)
-		// return true
 	}, 120*time.Second, 2*time.Second)
 
 	// executing deletion of the request, triggering unbinding actions

--- a/test/mocks/etcd_operator_mocks.go
+++ b/test/mocks/etcd_operator_mocks.go
@@ -36,7 +36,6 @@ func etcdClusterServiceMock(ns, name string) *corev1.Service {
 			Namespace: ns,
 		},
 		Spec: corev1.ServiceSpec{
-			ClusterIP: "172.30.0.129",
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "tcp-1",

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -465,6 +465,10 @@ func ServiceBindingRequestMock(
 			Namespace: ns,
 			Name:      name,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceBindingRequest",
+			APIVersion: "apps.openshift.io/v1alpha1",
+		},
 		Spec: v1alpha1.ServiceBindingRequestSpec{
 			MountPathPrefix: "/var/redhat",
 			CustomEnvVar:    []corev1.EnvVar{},


### PR DESCRIPTION
This PR deprecates the usage of annotations to relate Service Binding Requests and its services and applications in favor of a programmatic lookup.

Closes #458 

### Motivation

The main reason for this change is to reduce the amount of writes in the API server during the SBR reconciliation: those writes can trigger other reconciliation processes leading to unexpected race conditions; additionally, those annotations also seem to not be necessary to find a direct relationship between a Service Binding Request and a related resource, being it a service, application or the intermediate secret as changes in this PR can show.

### Changes

This PR does not stamp the SBR information to related resources using annotations during the reconciliation process, and performs a lookup up to identify the SBR associated with an incoming change, if any.

### Testing

Unit tests have been modified to a test table, and no e2e tests have been changed.