### PR TITLE
Trigger reconcile on updates to services' status

### DIFF
--- a/test/acceptance/features/steps/openshift.py
+++ b/test/acceptance/features/steps/openshift.py
@@ -334,3 +334,8 @@ spec:
             return lst
         print('Resource list is empty under namespace - {}'.format(namespace))
         return None
+
+    def oc_apply_yaml_file(self, yaml):
+        (output, exit_code) = self.cmd.run("oc apply -f " + yaml)
+        assert exit_code == 0, "Applying yaml file failed as the exit code is not 0"
+        return output

--- a/test/acceptance/resources/backend.operator.manifest.yaml
+++ b/test/acceptance/resources/backend.operator.manifest.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backends.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    plural: backends
+    singular: backend
+    kind: Backend
+    shortNames:
+      - bk
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Basic Install
+  name: backend-operator.v0.1.0
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Backend is the Schema for the backend API
+      kind: Backend
+      name: backends.stable.example.com
+      version: v1
+  displayName: Backend Operator
+  install:
+    spec:
+      deployments:
+      - name: backend-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: backend-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: backend-operator
+            spec:
+              containers:
+              - command:
+                - backend-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: backend-operator
+                image: REPLACE_IMAGE
+                imagePullPolicy: Always
+                name: backend-operator
+                resources: {}
+    strategy: deployment


### PR DESCRIPTION
Fix #508 

Follow steps mentioned here https://github.com/redhat-developer/service-binding-operator/issues/508#issuecomment-646777684
to test the functionality


Steps to reproduce:

Install the Strimzi Operator (v0.18.0).
Install the Service Binding Operator./ Run the SBO locally
Create ServiceBindingRequest, application, and the backing service (Kafka) resources:

```
apiVersion: apps.openshift.io/v1alpha1
kind: ServiceBindingRequest
metadata:
  name: kafka-producer-binding
spec:
  applicationSelector:
    resourceRef: nginx-deployment
    group: apps
    version: v1
    resource: deployments
  backingServiceSelectors:
    - group: kafka.strimzi.io
      kind: Kafka
      resourceRef: my-cluster
      version: v1beta1
      id: kaf
  customEnvVar:
    - name: BOOTSTRAP_SERVERS
      value: |-
        {{- range .kaf.status.listeners -}}
          {{- if and (eq .type "tls") (gt (len .addresses) 0) -}}
            {{- with (index .addresses 0) -}}
              {{ .host }}:{{ .port }}
            {{- end -}}
          {{- end -}}
        {{- end -}}
```

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
spec:
  selector:
    matchLabels:
      app: nginx
  replicas: 0 # tells deployment to deploy no pod
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
```

```
apiVersion: kafka.strimzi.io/v1alpha1
kind: Kafka
metadata:
  name: my-cluster
  labels:
    app: my-cluster
spec:
  kafka:
    replicas: 3
    resources:
      requests:
        memory: 2Gi
        cpu: 500m
      limits:
        memory: 2Gi
        cpu: "1"
    jvmOptions:
      -Xms: 1024m
      -Xmx: 1024m
    listeners:
      plain: {}
      tls:
        authentication:
          type: tls
    authorization:
      type: simple
      superUsers:
        - CN=my-connect
        - my-connect
        - ANONYMOUS
    config:
      offsets.topic.replication.factor: 3
      transaction.state.log.replication.factor: 3
      transaction.state.log.min.isr: 2
    storage:
      type: ephemeral
  zookeeper:
    replicas: 3
    resources:
      requests:
        memory: 1Gi
        cpu: "0.3"
      limits:
        memory: 1Gi
        cpu: "0.5"
    storage:
      type: ephemeral
```