### PR TITLE
Updates  java-postgresql example to demonstrate use of annotations to fetch data from scalar, sequence, map data structures

### DIFF
--- a/examples/java_postgresql_customvar/service-binding-request.yaml
+++ b/examples/java_postgresql_customvar/service-binding-request.yaml
@@ -23,3 +23,9 @@ spec:
       value: '{{ .postgresDB.status.dbCredentials.user }}'
     - name: DB_PASSWORD
       value: '{{ .postgresDB.status.dbCredentials.password }}'
+    - name: TAGS
+      value: '{{ .postgresDB.spec.tags }}'
+    - name: ARCHIVE_USERLABEL
+      value: '{{ .postgresDB.spec.userLabels.archive }}'
+    - name: SECONDARY_SECRETNAME
+      value: '{{ .postgresDB.spec.secretName }}'


### PR DESCRIPTION
### JIRA task

https://issues.redhat.com/browse/APPSVC-482

### Motivation

This PR updates the existing [java_postgresql_customenvvar example](https://github.com/redhat-developer/service-binding-operator/tree/master/examples/java_postgresql_customvar) with additional information  to demonstrate use of annotations to fetch data from different data structures.

The example demonstrates that it is not required for the developer to create distinct annotations for sibling properties.

If the postgresql database CR has `tag` field:

```
  tags:
          - "centos7-12.3"
          - 123
``` 
with sibling properties of different data structure type:

-  `string` _centos7-12.3_
-  `int` _123_ 


Then

this Custom Environment Variable in the Service Binding Request

```
- name: TAGS 
  value: '{{ .postgresDB.spec.tags }}' 
```

will result in creation of following environment variables in the application pod

```
DATABASE_TAGS_0=centos7-12.3
DATABASE_TAGS_1=123
```

Notice, distinct environment variables are produced for sibling properties with index number `0` and `1` in the variable name.


### Changes

[1] Updates the README of java_postgresql_customenvvar example.
[2] Updates the service binding request with additional custom environment variables.
