### PR TITLE
Update README.md to reflect our goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Connecting Applications with Operator-backed Services
+# Connecting Applications with Services
 
 <p align="center">
     <a alt="GoReport" href="https://goreportcard.com/report/github.com/redhat-developer/service-binding-operator">


### PR DESCRIPTION
Since our goal has evolved to support binding to non-operator-backed services too, I'm updating the README

Example of binding to non-operator-backed service:
https://github.com/redhat-developer/service-binding-operator/blob/master/examples/route_k8s_resource/README.md