### PR TITLE
Upgrade go version from 1.14 to 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: xenial
 language: go
 
 go:
-  - 1.14.x
+  - 1.15.x
 
 git:
   depth: false

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,7 +1,7 @@
 # On CI, use
-# FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
+# FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.15 AS builder
 
-FROM openshift/origin-release:golang-1.14 AS builder
+FROM openshift/origin-release:golang-1.15 AS builder
 
 ENV LANG=en_US.utf8
 ENV GIT_COMMITTER_NAME devtools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-developer/service-binding-operator
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go v0.45.1 // indirect

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -28,7 +28,7 @@ WORKDIR /tmp
 RUN mkdir -p $GOPATH/bin
 RUN mkdir -p /tmp/goroot
 
-RUN curl -Lo go1.14.3.linux-amd64.tar.gz https://dl.google.com/go/go1.14.3.linux-amd64.tar.gz && tar -C /tmp/goroot -xzf go1.14.3.linux-amd64.tar.gz
+RUN curl -Lo go1.15.linux-amd64.tar.gz https://dl.google.com/go/go1.15.linux-amd64.tar.gz && tar -C /tmp/goroot -xzf go1.15.linux-amd64.tar.gz
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl $GOPATH/bin/
 
 RUN curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.16.0/operator-sdk-v0.16.0-x86_64-linux-gnu && chmod +x operator-sdk && mv operator-sdk $GOPATH/bin/


### PR DESCRIPTION
Upgrade go version from 1.14 to 1.15 .
New golang version now also available in https://github.com/openshift/release/tree/master/projects/origin-release/golang-1.15


fixes #657 