### PR TITLE
[acceptance-tests] Increase various timeouts to make acceptance tests less flaky

### DIFF
--- a/hack/deploy-sbo-local.sh
+++ b/hack/deploy-sbo-local.sh
@@ -24,7 +24,7 @@ operator-sdk --verbose run --local --namespace="$OPERATOR_NAMESPACE" --operator-
 
 SBO_PID=$!
 
-attempts=12
+attempts=24
 while [ -z "$(grep 'Starting workers' $SBO_LOCAL_LOG)" ]; do
     if [[ $attempts -ge 0 ]]; then
         sleep 5

--- a/test/acceptance/features/steps/openshift.py
+++ b/test/acceptance/features/steps/openshift.py
@@ -170,26 +170,26 @@ spec:
         exit_code | should.be_equal_to(0)
         return env_from
 
-    def get_resource_info_by_jsonpath(self, resource_type, name, namespace, json_path, wait=False):
+    def get_resource_info_by_jsonpath(self, resource_type, name, namespace, json_path, wait=False, interval=5, timeout=120):
         output, exit_code = self.cmd.run(f'oc get {resource_type} {name} -n {namespace} -o "jsonpath={json_path}"')
         if exit_code != 0:
             if wait:
-                attempts = 5
+                attempts = timeout/interval
                 while exit_code != 0 and attempts > 0:
                     output, exit_code = self.cmd.run(f'oc get {resource_type} {name} -n {namespace} -o "jsonpath={json_path}"')
                     attempts -= 1
-                    time.sleep(5)
+                    time.sleep(interval)
         exit_code | should.be_equal_to(0).desc(f'Exit code should be 0:\n OUTPUT:\n{output}')
         return output
 
-    def get_resource_info_by_jq(self, resource_type, name, namespace, jq_expression, wait=False):
+    def get_resource_info_by_jq(self, resource_type, name, namespace, jq_expression, wait=False, interval=5, timeout=120):
         output, exit_code = self.cmd.run(f'oc get {resource_type} {name} -n {namespace} -o json | jq -rc \'{jq_expression}\'')
         if exit_code != 0:
             if wait:
-                attempts = 5
+                attempts = timeout/interval
                 while exit_code != 0 and attempts > 0:
                     output, exit_code = self.cmd.run(f'oc get {resource_type} {name} -n {namespace} -o json | jq -rc \'{jq_expression}\'')
                     attempts -= 1
-                    time.sleep(5)
+                    time.sleep(interval)
         exit_code | should.be_equal_to(0).desc(f'Exit code should be 0:\n OUTPUT:\n{output}')
         return output.rstrip("\n")

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -157,7 +157,7 @@ def sbr_is_applied(context):
 @then(u'application should be re-deployed')
 def then_application_redeployed(context):
     application = context.nodejs_app
-    application.get_redeployed_pod_name(context.nodejs_app_original_pod_name) | should_not.be_none.desc(
+    application.get_redeployed_pod_name(context.nodejs_app_original_pod_name, timeout=120) | should_not.be_none.desc(
         "There is a running pod of the application different from the original one before redeployment.")
 
 
@@ -174,7 +174,7 @@ def then_app_is_connected_to_db(context, db_name):
 def then_sbo_jsonpath_is(context, json_path, sbr_name, json_value_regex):
     openshift = Openshift()
     openshift.search_resource_in_namespace("servicebindingrequests", sbr_name, context.namespace.name) | should_not.be_none.desc("SBR {sbr_name} exists")
-    result = openshift.get_resource_info_by_jsonpath("sbr", sbr_name, context.namespace.name, json_path, wait=True)
+    result = openshift.get_resource_info_by_jsonpath("sbr", sbr_name, context.namespace.name, json_path, wait=True, timeout=600)
     result | should_not.be_none.desc("jsonpath result")
     re.fullmatch(json_value_regex, result) | should_not.be_none.desc("SBO jsonpath result \"{result}\" should match \"{json_value_regex}\"")
 
@@ -184,7 +184,7 @@ def then_sbo_jsonpath_is(context, json_path, sbr_name, json_value_regex):
 def then_sbo_jq_is(context, jq_expression, sbr_name, json_value_regex):
     openshift = Openshift()
     openshift.search_resource_in_namespace("servicebindingrequests", sbr_name, context.namespace.name) | should_not.be_none.desc("SBR {sbr_name} exists")
-    result = openshift.get_resource_info_by_jq("sbr", sbr_name, context.namespace.name, jq_expression, wait=True)
+    result = openshift.get_resource_info_by_jq("sbr", sbr_name, context.namespace.name, jq_expression, wait=True, timeout=600)
     result | should_not.be_none.desc("jq result")
     re.fullmatch(json_value_regex, result) | should_not.be_none.desc("SBO jq result \"{result}\" should match \"{json_value_regex}\"")
 


### PR DESCRIPTION
### Motivation

Currently, the time to reach the required condition in cases below is exceeded sometimes. In that case the test fails even if the condition is met eventually.  Those relatively small timeouts make the acceptnace tests flaky.

### Changes

This PR increases the timeout for:
* "Get SBR info by jsonpath" to 10 minutes (was 25s)
* "Get SBR info by jq" to 10 minutes (was 25s)
* "Start local SBO instance" to 120s (was 60s)
* "Wait for the Node.js app to re-deploy" to 2 minutes (was 60s)

### Testing

`make test-acceptnace`
