### PR TITLE
[acceptance-tests] Fix negative corner cases handling env variables

### DIFF
--- a/test/acceptance/features/steps/command.py
+++ b/test/acceptance/features/steps/command.py
@@ -12,10 +12,17 @@ class Command(object):
             self.path = os.getcwd()
         else:
             self.path = path
-        self.setenv("KUBECONFIG", os.getenv("KUBECONFIG"))
-        self.setenv("PATH", os.getenv("PATH"))
+
+        kubeconfig = os.getenv("KUBECONFIG")
+        assert kubeconfig is not None, "KUBECONFIG needs to be set in the environment"
+        self.setenv("KUBECONFIG", kubeconfig)
+
+        path = os.getenv("PATH")
+        assert path is not None, "PATH needs to be set in the environment"
+        self.setenv("PATH", path)
 
     def setenv(self, key, value):
+        assert key is not None and value is not None, f"Name or value of the environment variable cannot be None: [{key} = {value}]"
         self.env[key] = value
 
     def run(self, cmd, stdin=None):

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -36,8 +36,8 @@ def given_namespace_is_used(context, namespace_name):
 # STEP
 @given(u'Namespace [{namespace_env}] is used')
 def given_namespace_from_env_is_used(context, namespace_env):
-    env = os.getenv(namespace_env, "")
-    env | should_not.be_none.desc(f"{namespace_env} env variable is set")
+    env = os.getenv(namespace_env)
+    assert env is not None, f"{namespace_env} environment variable needs to be set"
     print(f"{namespace_env} = {env}")
     given_namespace_is_used(context, env)
 
@@ -64,8 +64,8 @@ sbo_is_running_in_namespace_from_env_step = u'Service Binding Operator is runnin
 @given(sbo_is_running_in_namespace_from_env_step)
 @when(sbo_is_running_in_namespace_from_env_step)
 def sbo_is_running_in_namespace_from_env(context, operator_namespace_env):
-    env = os.getenv(operator_namespace_env, "")
-    env | should_not.be_none.desc(f"{operator_namespace_env} env variable is set")
+    env = os.getenv(operator_namespace_env)
+    assert env is not None, f"{operator_namespace_env} environment variable needs to be set"
     print(f"{operator_namespace_env} = {env}")
     sbo_is_running_in_namespace(context, env)
 


### PR DESCRIPTION
### Motivation

Currently the acceptance tests assume `KUBECONFIG` and `PATH` variables are set. If any of them is not set, the tests fails with the failure similar to the following:
```
Given Namespace [TEST_NAMESPACE] is used                                                                                                                                      # test/acceptance/features/steps/steps.py:33 0.001s
      Traceback (most recent call last):
        File "/home/user/go/src/github.com/redhat-developer/service-binding-operator/out/venv3/lib64/python3.7/site-packages/behave/model.py", line 1329, in run
          match.run(runner.context)
        File "/home/user/go/src/github.com/redhat-developer/service-binding-operator/out/venv3/lib64/python3.7/site-packages/behave/matchers.py", line 98, in run
          self.func(context, *args, **kwargs)
        File "test/acceptance/features/steps/steps.py", line 38, in given_namespace_from_env_is_used
          given_namespace_is_used(context, env)
        File "test/acceptance/features/steps/steps.py", line 25, in given_namespace_is_used
          if not namespace.is_present():
        File "/home/user/go/src/github.com/redhat-developer/service-binding-operator/test/acceptance/features/steps/namespace.py", line 23, in is_present
          output, exit_code = self.cmd.run('oc get ns {}'.format(self.name))
        File "/home/user/go/src/github.com/redhat-developer/service-binding-operator/test/acceptance/features/steps/command.py", line 27, in run
          output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, cwd=self.path, env=self.env)
        File "/usr/lib64/python3.7/subprocess.py", line 411, in check_output
          **kwargs).stdout
        File "/usr/lib64/python3.7/subprocess.py", line 488, in run
          with Popen(*popenargs, **kwargs) as process:
        File "/usr/lib64/python3.7/subprocess.py", line 800, in __init__
          restore_signals, start_new_session)
        File "/usr/lib64/python3.7/subprocess.py", line 1462, in _execute_child
          env_list.append(k + b'=' + os.fsencode(v))
        File "/usr/lib64/python3.7/os.py", line 810, in fsencode
          filename = fspath(filename)  # Does type-checking of `filename`.
      TypeError: expected str, bytes or os.PathLike object, not NoneType
      
      Captured stdout:
      TEST_NAMESPACE = test-namespace-1
```

### Changes

This PR add checks in the `Command`  class  and to the environment sensitive steps to make sure, no invalid or missing variables or values are used.

### Testing

`make test-acceptance`