### PR TITLE
Remove SBR finalizers in the test namespace before deleting the namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ e2e-setup: e2e-cleanup e2e-create-namespace e2e-deploy-3rd-party-crds
 
 .PHONY: e2e-cleanup
 e2e-cleanup: get-test-namespace
+	$(Q)-TEST_NAMESPACE=$(TEST_NAMESPACE) $(HACK_DIR)/e2e-cleanup.sh
 	$(Q)-kubectl delete namespace $(TEST_NAMESPACE) --timeout=45s --wait
 
 OBSOLETE_E2E_MESSAGE=WARNING: e2e tests are obsolete and will be removed soon in favour of acceptance tests, \
@@ -437,12 +438,7 @@ deploy-crds:
 .PHONY: deploy-clean
 ## Deploy-Clean: Removing CRDs and CRs
 deploy-clean:
-	$(Q)-kubectl delete -f deploy/crds/apps_v1alpha1_servicebindingrequest_cr.yaml
-	$(Q)-kubectl delete -f deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
-	$(Q)-kubectl delete -f deploy/operator.yaml
-	$(Q)-kubectl delete -f deploy/role_binding.yaml
-	$(Q)-kubectl delete -f deploy/role.yaml
-	$(Q)-kubectl delete -f deploy/service_account.yaml
+	$(Q)-$(HACK_DIR)/deploy-clean.sh
 
 .PHONY: deploy
 ## Deploy:

--- a/hack/deploy-clean.sh
+++ b/hack/deploy-clean.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+HACK_DIR=${HACK_DIR:-$(dirname $0)}
+
+# Remove SBR finalizers
+$HACK_DIR/remove-sbr-finalizers.sh
+
+# Delete deployed resources
+kubectl delete -f deploy/crds/apps_v1alpha1_servicebindingrequest_cr.yaml
+kubectl delete -f deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
+kubectl delete -f deploy/operator.yaml
+kubectl delete -f deploy/role_binding.yaml
+kubectl delete -f deploy/role.yaml
+kubectl delete -f deploy/service_account.yaml

--- a/hack/e2e-cleanup.sh
+++ b/hack/e2e-cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -xe
+
+HACK_DIR=${HACK_DIR:-$(dirname $0)}
+
+# Remove SBR finalizers
+NAMESPACE=$TEST_NAMESPACE $HACK_DIR/remove-sbr-finalizers.sh

--- a/hack/remove-sbr-finalizers.sh
+++ b/hack/remove-sbr-finalizers.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -xe
+
+if [[ -z $NAMESPACE ]]; then
+    USE_NS="--all-namespaces"
+else
+    USE_NS="-n $NAMESPACE"
+fi
+
+# Remove SBR finalizers
+SBRS=($(kubectl get sbrs $USE_NS -o jsonpath="{.items[*].metadata.name}"))
+SBR_NS=($(kubectl get sbrs $USE_NS -o jsonpath="{.items[*].metadata.namespace}"))
+
+for i in "${!SBRS[@]}"; do
+    kubectl patch sbr/${SBRS[$i]} -p '{"metadata":{"finalizers":[]}}' --type=merge --namespace=${SBR_NS[$i]};
+done


### PR DESCRIPTION
### Motivation

Currently the acceptance tests setup deletes the test namespace and creates a new one. But if there are finalizers set on SBRs in that test namespace (for whatever reason) the deletion of the namespace is stuck in Terminating state.

Like in https://github.com/redhat-developer/service-binding-operator/issues/476

### Changes

This PR removes all the finalizers from all the SBRs in the test namespace just before it attempts the namespace deletion.

### Testing

`make e2e-cleanup`