### PR TITLE
Remove global & service prefixes from customEnvVar

### DIFF
--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -140,12 +140,6 @@ func (r *retriever) ProcessServiceContexts(
 	}
 
 	for k, v := range customEnvVars {
-		prefix := []string{}
-		if len(globalEnvVarPrefix) > 0 {
-			prefix = append(prefix, globalEnvVarPrefix)
-		}
-		prefix = append(prefix, k)
-		k = strings.Join(prefix, "_")
 		envVars[k] = []byte(v.(string))
 	}
 

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -63,7 +63,7 @@ func TestRetrieverProcessServiceContexts(t *testing.T) {
 				{Name: "SAME_NAMESPACE", Value: toIndexTemplate(cr, "metadata.name")},
 			},
 			expected: map[string][]byte{
-				"SERVICE_BINDING_SAME_NAMESPACE": []byte(cr.GetName()),
+				"SAME_NAMESPACE": []byte(cr.GetName()),
 			},
 		},
 		{
@@ -79,7 +79,7 @@ func TestRetrieverProcessServiceContexts(t *testing.T) {
 				},
 			},
 			expected: map[string][]byte{
-				"SERVICE_BINDING_DIRECT_ACCESS": []byte(cr.GetName()),
+				"DIRECT_ACCESS": []byte(cr.GetName()),
 			},
 		},
 		{
@@ -98,7 +98,7 @@ func TestRetrieverProcessServiceContexts(t *testing.T) {
 				},
 			},
 			expected: map[string][]byte{
-				"SERVICE_BINDING_ID_ACCESS": []byte(cr.GetName()),
+				"ID_ACCESS": []byte(cr.GetName()),
 			},
 		},
 		{
@@ -116,7 +116,7 @@ func TestRetrieverProcessServiceContexts(t *testing.T) {
 				},
 			},
 			expected: map[string][]byte{
-				"SERVICE_BINDING_ID_ACCESS": []byte("<no value>"),
+				"ID_ACCESS": []byte("<no value>"),
 			},
 		},
 	}


### PR DESCRIPTION
Fix #486 

Steps to confirm
- Create a postgres db
```
apiVersion: postgresql.baiju.dev/v1alpha1
kind: Database
metadata:
  name: db-demo
spec:
  image: docker.io/postgres
  imageName: postgres
  dbName: db-demo
```

- Create a SBR
```
apiVersion: apps.openshift.io/v1alpha1
kind: ServiceBindingRequest
metadata:
  name: binding-request
spec:
  backingServiceSelector:
    group: postgresql.baiju.dev
    version: v1alpha1
    kind: Database
    resourceRef: db-demo
    id: postgresDB
  envVarPrefix: HELLO
  customEnvVar:
    - name: JDBC_URL
      value: 'jdbc:postgresql://{{ .postgresDB.status.dbConnectionIP }}:{{ .postgresDB.status.dbConnectionPort }}/{{ .postgresDB.status.dbName }}'
    - name: DB_USER
      value: '{{ .postgresDB.status.dbCredentials.user }}'
    - name: DB_PASSWORD
      value: '{{ .postgresDB.status.dbCredentials.password }}'
    - name: TAGS
      value: '{{ .postgresDB.spec.tags }}'
    - name: ARCHIVE_USERLABEL
      value: '{{ .postgresDB.spec.userLabels.archive }}'
    - name: SECONDARY_SECRETNAME
      value: '{{ .postgresDB.spec.secretName }}'
```

- check the secret `binding-request`
```
data:
  ARCHIVE_USERLABEL: PG5vIHZhbHVlPg==
  DB_PASSWORD: cGFzc3dvcmQ=
  DB_USER: cG9zdGdyZXM=
  HELLO_DATABASE_CONFIGMAP_DB_HOST: MTcyLjMwLjE2OS4xOA==
  HELLO_DATABASE_CONFIGMAP_DB_NAME: ZGItZGVtbw==
  HELLO_DATABASE_CONFIGMAP_DB_PASSWORD: cGFzc3dvcmQ=
  HELLO_DATABASE_CONFIGMAP_DB_PORT: NTQzMg==
  HELLO_DATABASE_DBCONNECTIONIP: MTcyLjMwLjE2OS4xOA==
  HELLO_DATABASE_DBCONNECTIONPORT: NTQzMg==
  HELLO_DATABASE_DBNAME: ZGItZGVtbw==
  HELLO_DATABASE_SECRET_PASSWORD: cGFzc3dvcmQ=
  HELLO_DATABASE_SECRET_USER: cG9zdGdyZXM=
  JDBC_URL: amRiYzpwb3N0Z3Jlc3FsOi8vMTcyLjMwLjE2OS4xODo1NDMyL2RiLWRlbW8=
  SECONDARY_SECRETNAME: PG5vIHZhbHVlPg==
  TAGS: PG5vIHZhbHVlPg==
```

Prefixes should not be included for customEnvVar. The names for customEnVar is mentioned in customEnvVar.Name