### PR TITLE
Add link to mailing list info page

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,6 @@ The Service Binding community meets weekly on Thursdays at 11:15 AM UTC via [Goo
 
 Meeting Agenda is maintained [here](https://github.com/redhat-developer/service-binding-operator/issues?q=is%3Aissue+is%3Aopen+label%3Ameeting)
 
-Please file bug reports on [Github](https://github.com/redhat-developer/service-binding-operator/issues/new). For any other questions, reach out on `service-binding-support@redhat.com`.
+Please file bug reports on [Github](https://github.com/redhat-developer/service-binding-operator/issues/new). For any other questions, reach out on [service-binding-support@redhat.com](https://www.redhat.com/mailman/listinfo/service-binding-support).
 
 


### PR DESCRIPTION
### Motivation

Link to mailing list info page will users to join and see old archives.

### Changes

Add link

### Testing

Preview the README using https://pypi.org/project/grip/ and see if the link is available.
