### PR TITLE
[acceptance-tests] move get_deployment_with_secret to openshift class

### DIFF
--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -275,4 +275,4 @@ def then_envFrom_contains(context, app_name, sbr_name1, sbr_name2):
 @then(u'deployment must contain intermediate secret "{intermediate_secret_name}"')
 def then_envFrom_contains_intermediate_secret_name(context, intermediate_secret_name):
     assert context.application.get_deployment_with_intermediate_secret(
-        intermediate_secret_name, wait=True, timeout=120) is not None, f"There is no deployment with intermediate secret {intermediate_secret_name}"
+        intermediate_secret_name) is not None, f"There is no deployment with intermediate secret {intermediate_secret_name}"


### PR DESCRIPTION
### Motivation

For now, getting deployment name with intermediate secret is implemented in quarkus application class which would make it to use at quarkus application context level. any other similar usage from different application will have to have these methods inspired in those context. also, this function `get_deployment_with_intermediate_secret_of_given_pattern` is more relevant to openshift class

### Changes

Renamed `get_deployment_with_intermediate_secret` to `get_deployment_with_intermediate_secret_of_given_pattern` giving the application deployment pattern with respective namespace

### Testing

make test-acceptance


For further more details refer the CONTRIBUTING.md