### PR TITLE
[acceptance-tests] Fix multiservice step to work with both oc v4.5 and v4.6

### DIFF
--- a/test/acceptance/features/steps/quarkus_application.py
+++ b/test/acceptance/features/steps/quarkus_application.py
@@ -108,8 +108,12 @@ class QuarkusApplication(object):
         return self.openshift.search_resource_lst_in_namespace("deployment", self.format_pattern(self.deployment_name_pattern), self.namespace)
 
     def get_deployment_with_intermediate_secret(self, intermediate_secret_name, wait=False, interval=5, timeout=300):
-        expected_secretRef_1 = f'[{{"secretRef":{{"name":"{intermediate_secret_name}"}}}}]'
-        expected_secretRef_2 = f'[map[secretRef:map[name:{intermediate_secret_name}]]]'
+
+        # Expected result from 'oc' (openshift client) v4.6
+        expected_secretRef_oc_46 = f'[{{"secretRef":{{"name":"{intermediate_secret_name}"}}}}]'
+        # Expected result from 'oc' (openshift client) v4.5
+        expected_secretRef_oc_45 = f'[map[secretRef:map[name:{intermediate_secret_name}]]]'
+
         deployment_name_pattern = self.format_pattern(self.deployment_name_pattern)
         if wait:
             start = 0
@@ -118,10 +122,11 @@ class QuarkusApplication(object):
                 if deployment_list is not None:
                     for deployment in deployment_list:
                         result = self.openshift.get_deployment_envFrom_info(deployment, self.namespace)
-                        if result == expected_secretRef_1 or result == expected_secretRef_2:
+                        if result == expected_secretRef_oc_45 or result == expected_secretRef_oc_46:
                             return deployment
                         else:
-                            print(f"\nUnexpected deployment's envFrom info: \nExpected: {expected_secretRef_1} or {expected_secretRef_2} \nbut was: {result}\n")
+                            print("\nUnexpected deployment's envFrom info: \n" +
+                                  f"Expected: {expected_secretRef_oc_45} or {expected_secretRef_oc_46} \nbut was: {result}\n")
                 else:
                     print(f"No deployment that matches {deployment_name_pattern} found.\n")
                 time.sleep(interval)
@@ -131,10 +136,11 @@ class QuarkusApplication(object):
             if deployment_list is not None:
                 for deployment in deployment_list:
                     result = self.openshift.get_deployment_envFrom_info(deployment, self.namespace)
-                    if result == expected_secretRef_1 or result == expected_secretRef_2:
+                    if result == expected_secretRef_oc_45 or result == expected_secretRef_oc_46:
                         return deployment
                     else:
-                        print(f"\nUnexpected deployment's envFrom info: \nExpected: {expected_secretRef_1} or {expected_secretRef_2} \nbut was: {result}\n")
+                        print("\nUnexpected deployment's envFrom info: \n" +
+                              f"Expected: {expected_secretRef_oc_45} or {expected_secretRef_oc_46} \nbut was: {result}\n")
             else:
                 print(f"No deployment that matches {deployment_name_pattern} found.\n")
         return None

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -267,9 +267,13 @@ def then_envFrom_contains(context, app_name, sbr_name1, sbr_name2):
     time.sleep(60)
     openshift = Openshift()
     result = openshift.get_deployment_envFrom_info(app_name, context.namespace.name)
-    expected_result_1 = f'[map[secretRef:map[name:{sbr_name1}]] map[secretRef:map[name:{sbr_name2}]]]'
-    expected_result_2 = f'[{{"secretRef":{{"name":"{sbr_name1}"}}}},{{"secretRef":{{"name":"{sbr_name2}"}}}}]'
-    assert result == expected_result_1 or result == expected_result_2, \
+
+    # Expected result from 'oc' (openshift client) v4.5
+    expected_result_oc_45 = f'[map[secretRef:map[name:{sbr_name1}]] map[secretRef:map[name:{sbr_name2}]]]'
+    # Expected result from 'oc' (openshift client) v4.6+
+    expected_result_oc_46 = f'[{{"secretRef":{{"name":"{sbr_name1}"}}}},{{"secretRef":{{"name":"{sbr_name2}"}}}}]'
+
+    assert result == expected_result_oc_45 or result == expected_result_oc_46, \
         f'\n{app_name} deployment should contain secretRef: {sbr_name1} and {sbr_name2}\nActual secretRef: {result}'
 
 

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -267,8 +267,10 @@ def then_envFrom_contains(context, app_name, sbr_name1, sbr_name2):
     time.sleep(60)
     openshift = Openshift()
     result = openshift.get_deployment_envFrom_info(app_name, context.namespace.name)
-    result | should.be_equal_to("[map[secretRef:map[name:binding-request-1]] map[secretRef:map[name:binding-request-2]]]")\
-        .desc(f'{app_name} deployment should contain secretRef: {sbr_name1} and {sbr_name2}')
+    expected_result_1 = f'[map[secretRef:map[name:{sbr_name1}]] map[secretRef:map[name:{sbr_name2}]]]'
+    expected_result_2 = f'[{{"secretRef":{{"name":"{sbr_name1}"}}}},{{"secretRef":{{"name":"{sbr_name2}"}}}}]'
+    assert result == expected_result_1 or result == expected_result_2, \
+        f'\n{app_name} deployment should contain secretRef: {sbr_name1} and {sbr_name2}\nActual secretRef: {result}'
 
 
 # STEP


### PR DESCRIPTION
### Motivation

Currently the `"{app_name}" deployment must contain SBR name "{sbr_name1}" and "{sbr_name2}" step assumes that the output from the `oc get ... -o jsonpath=...` would be in the form of a go structure:

`[map[secretRef:map[name:{binding-request-1}]] map[secretRef:map[name:{binding-request-2}]]]`

which is what the `oc` v4.5 produces. However when `oc` v4.6 is used, the output changes into a valid JSON su:

`[{{"secretRef":{{"name":"{binding-request-1}"}}}},{{"secretRef":{{"name":"{binding-request-2}"}}}}]`

So if one runs the acceptance tests with `oc` v4.6, the scenarios fails on that step, because the expected and actual values of the result do not match even if the operator's behavior is correct.

### Changes

This PR:
* Adds a support for both variants of the result in the `"{app_name}" deployment must contain SBR name "{sbr_name1}" and "{sbr_name2}"` step
* Replaces hard-coded SBR names with the respective step input parameters

### Testing

`make test-acceptance`