### PR TITLE
Support air gap scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_install:
 script:
   # Run merge-to-master-release
   - if [ "$TRAVIS_BRANCH" = "master" ]; then
-    make merge-to-master-release &&
     make push-to-manifest-repo &&
     make prepare-bundle-to-quay || exit 1;
     fi

--- a/Makefile
+++ b/Makefile
@@ -493,15 +493,18 @@ merge-to-master-release:
 	$(eval COMMIT_COUNT := $(shell git rev-list --count HEAD))
 	$(Q)docker build -f Dockerfile.rhel -t $(OPERATOR_IMAGE_REF) .
 	docker push "$(OPERATOR_IMAGE_REF)"
+
+.PHONY: verify-image-using-sha256-digest
+## The image pushed to registry should be verified
+verify-image-using-sha256-digest:
 	$(eval AIR_GAP_OPERATOR_IMAGE_REF := $(shell docker inspect --format="{{index .RepoDigests 0}}" $(OPERATOR_IMAGE_REF)))
 	docker rmi "$(AIR_GAP_OPERATOR_IMAGE_REF)"
 	docker rmi "$(OPERATOR_IMAGE_REF)"
 	docker pull "$(AIR_GAP_OPERATOR_IMAGE_REF)"
 
-
 .PHONY: push-to-manifest-repo
 ## Push manifest bundle to service-binding-operator-manifest repo
-push-to-manifest-repo:
+push-to-manifest-repo: verify-image-using-sha256-digest
 	@rm -rf $(MANIFESTS_TMP) || true
 	@mkdir -p ${MANIFESTS_TMP}/${BUNDLE_VERSION}
 	operator-sdk generate csv --csv-version $(BUNDLE_VERSION) --from-version=0.0.23


### PR DESCRIPTION
### Motivation

Fixes #557

### Changes

After pushing the image to the registry, get the sha256 digest.
Pull it again using the digest to verify.

### Testing

1. Copy Quay token from here: https://quay.io/organization/redhat-developer?tab=robots
2. Set `QUAY_TOKEN` environment variable
3. Set `export OPERATOR_GROUP=redhat-developer`
4. Run `make merge-to-master-release`
5. Run `make push-to-manifest-repo`
6. Check the CSV file under `tmp/manifests` and verify the image location
7. Remove tag from here: https://quay.io/repository/redhat-developer/app-binding-operator?tab=tags
