### PR TITLE
[WIP] Adding bundle with manifests for operator packaging

### DIFF
--- a/bundle/bundle.Dockerfile
+++ b/bundle/bundle.Dockerfile
@@ -7,5 +7,5 @@ LABEL operators.operatorframework.io.bundle.package.v1=service-binding-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=4.6
 LABEL operators.operatorframework.io.bundle.channel.default.v1=
 
-COPY deploy/olm-catalog/service-binding-operator/manifests /manifests/
-COPY deploy/olm-catalog/service-binding-operator/metadata /metadata/
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/bundle/bundle.Dockerfile
+++ b/bundle/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=service-binding-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=4.6
+LABEL operators.operatorframework.io.bundle.channel.default.v1=
+
+COPY deploy/olm-catalog/service-binding-operator/manifests /manifests/
+COPY deploy/olm-catalog/service-binding-operator/metadata /metadata/

--- a/bundle/manifests/apps.openshift.io_servicebindingrequests_crd.yaml
+++ b/bundle/manifests/apps.openshift.io_servicebindingrequests_crd.yaml
@@ -1,0 +1,331 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicebindingrequests.apps.openshift.io
+spec:
+  group: apps.openshift.io
+  names:
+    kind: ServiceBindingRequest
+    listKind: ServiceBindingRequestList
+    plural: servicebindingrequests
+    shortNames:
+    - sbr
+    - sbrs
+    singular: servicebindingrequest
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ServiceBindingRequest expresses intent to bind an operator-backed
+        service with an application workload.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ServiceBindingRequestSpec defines the desired state of ServiceBindingRequest
+          properties:
+            applicationSelector:
+              description: ApplicationSelector is used to identify the application
+                connecting to the backing service operator.
+              properties:
+                group:
+                  type: string
+                labelSelector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resource:
+                  type: string
+                resourceRef:
+                  type: string
+                version:
+                  type: string
+              required:
+              - group
+              - resource
+              - version
+              type: object
+            backingServiceSelector:
+              description: 'BackingServiceSelector is used to identify the backing
+                service operator. Deprecation Notice: In the upcoming release, this
+                field would be depcreated. It would be mandatory to set "backingServiceSelectors".'
+              properties:
+                envVarPrefix:
+                  type: string
+                group:
+                  type: string
+                id:
+                  type: string
+                kind:
+                  type: string
+                namespace:
+                  type: string
+                resourceRef:
+                  type: string
+                version:
+                  type: string
+              required:
+              - group
+              - kind
+              - resourceRef
+              - version
+              type: object
+            backingServiceSelectors:
+              description: BackingServiceSelectors is used to identify multiple backing
+                services. This would be made a required field after 'BackingServiceSelector'
+                is removed.
+              items:
+                description: BackingServiceSelector defines the selector based on
+                  resource name, version, and resource kind
+                properties:
+                  envVarPrefix:
+                    type: string
+                  group:
+                    type: string
+                  id:
+                    type: string
+                  kind:
+                    type: string
+                  namespace:
+                    type: string
+                  resourceRef:
+                    type: string
+                  version:
+                    type: string
+                required:
+                - group
+                - kind
+                - resourceRef
+                - version
+                type: object
+              type: array
+            customEnvVar:
+              description: Custom env variables
+              items:
+                description: EnvVar represents an environment variable present in
+                  a Container.
+                properties:
+                  name:
+                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                    type: string
+                  value:
+                    description: 'Variable references $(VAR_NAME) are expanded using
+                      the previous defined environment variables in the container
+                      and any service environment variables. If a variable cannot
+                      be resolved, the reference in the input string will be unchanged.
+                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                      $$(VAR_NAME). Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Defaults to "".'
+                    type: string
+                  valueFrom:
+                    description: Source for the environment variable's value. Cannot
+                      be used if value is not empty.
+                    properties:
+                      configMapKeyRef:
+                        description: Selects a key of a ConfigMap.
+                        properties:
+                          key:
+                            description: The key to select.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap or its key
+                              must be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      fieldRef:
+                        description: 'Selects a field of the pod: supports metadata.name,
+                          metadata.namespace, metadata.labels, metadata.annotations,
+                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.'
+                        properties:
+                          apiVersion:
+                            description: Version of the schema the FieldPath is written
+                              in terms of, defaults to "v1".
+                            type: string
+                          fieldPath:
+                            description: Path of the field to select in the specified
+                              API version.
+                            type: string
+                        required:
+                        - fieldPath
+                        type: object
+                      resourceFieldRef:
+                        description: 'Selects a resource of the container: only resources
+                          limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage,
+                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                          are currently supported.'
+                        properties:
+                          containerName:
+                            description: 'Container name: required for volumes, optional
+                              for env vars'
+                            type: string
+                          divisor:
+                            description: Specifies the output format of the exposed
+                              resources, defaults to "1"
+                            type: string
+                          resource:
+                            description: 'Required: resource to select'
+                            type: string
+                        required:
+                        - resource
+                        type: object
+                      secretKeyRef:
+                        description: Selects a key of a secret in the pod's namespace
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                required:
+                - name
+                type: object
+              type: array
+            detectBindingResources:
+              description: DetectBindingResources is flag used to bind all non-bindable
+                variables from different subresources owned by backing operator CR.
+              type: boolean
+            envVarPrefix:
+              description: EnvVarPrefix is the prefix for environment variables
+              type: string
+            mountPathPrefix:
+              description: MountPathPrefix is the prefix for volume mount
+              type: string
+          type: object
+        status:
+          description: ServiceBindingRequestStatus defines the observed state of ServiceBindingRequest
+          properties:
+            applications:
+              description: ApplicationObjects contains all the application objects
+                filtered by label
+              items:
+                description: BoundApplication defines the application workloads to
+                  which the binding secret has injected.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                  version:
+                    type: string
+                required:
+                - group
+                - kind
+                - version
+                type: object
+              type: array
+            conditions:
+              description: Conditions describes the state of the operator's reconciliation
+                functionality.
+              items:
+                description: Condition represents the state of the operator's reconciliation
+                  functionality.
+                properties:
+                  lastHeartbeatTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: ConditionType is the state of the operator's reconciliation
+                      functionality.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            secret:
+              description: Secret is the name of the intermediate secret
+              type: string
+          required:
+          - conditions
+          - secret
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/bundle/manifests/service-binding-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/service-binding-operator.clusterserviceversion.yaml
@@ -1,0 +1,176 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "apps.openshift.io/v1alpha1",
+          "kind": "ServiceBindingRequest",
+          "metadata": {
+            "name": "example-servicebindingrequest"
+          },
+          "spec": {
+            "applicationSelector": {
+              "group": "apps",
+              "resource": "deployments",
+              "resourceRef": "nodejs-rest-http-crud",
+              "version": "v1"
+            },
+            "backingServiceSelector": {
+              "group": "postgresql.example.dev",
+              "kind": "Database",
+              "resourceRef": "pg-instance",
+              "version": "v1alpha1"
+            },
+            "mountPathPrefix": "/var/credentials"
+          }
+        }
+      ]
+    capabilities: Basic Install
+  name: service-binding-operator.v0.3.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ServiceBindingRequest expresses intent to bind an operator-backed
+        service with an application workload.
+      displayName: Service Binding Request
+      kind: ServiceBindingRequest
+      name: servicebindingrequests.apps.openshift.io
+      version: v1alpha1
+  displayName: Service Binding Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments:
+      - name: service-binding-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: service-binding-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: service-binding-operator
+            spec:
+              containers:
+              - command:
+                - service-binding-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: service-binding-operator
+                image: REPLACE_IMAGE
+                imagePullPolicy: Always
+                name: service-binding-operator
+                resources: {}
+              serviceAccountName: service-binding-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - pods/log
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          - deployments/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          - customresourcedefinitions/status
+          verbs:
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - service-binding-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+        serviceAccountName: service-binding-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - ""
+  maintainers:
+  - {}
+  maturity: alpha
+  provider: {}
+  version: 0.0.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: ""
+  operators.operatorframework.io.bundle.channels.v1: "4.6"
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: service-binding-operator


### PR DESCRIPTION
### Motivation

<< Why this change is relevant, what's the "story" behind it? >>
This PR adds
1. Bundle configuration and dockerfile for metadata image
2. metadata and manifests csv are added to bundle directory for metadata image

These are required for packaging the operator with ocp 4.6 version compatible

### Changes

<< What has been changed in order to achieve "story's" objective? >>

### Testing

<< How to test those changes, reference implementation of unit/e2e tests. >>


For further more details refer the CONTRIBUTING.md