### PR TITLE
[acceptance-tests] Check SBR status after the SBR step before checking the desired binding outcome

### DIFF
--- a/test/acceptance/features/bindAppToMultipleServices.feature
+++ b/test/acceptance/features/bindAppToMultipleServices.feature
@@ -48,8 +48,8 @@ Feature: Bind a single application to multiple services
                     kind: Database
                     resourceRef: db-demo-2
             """
-        Then "nodejs-app" deployment must contain SBR name "binding-request-1" and "binding-request-2"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-1" should be changed to "True"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-1" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-1" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-2" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-2" should be changed to "True"
+        And "nodejs-app" deployment must contain SBR name "binding-request-1" and "binding-request-2"

--- a/test/acceptance/features/bindAppToService.feature
+++ b/test/acceptance/features/bindAppToService.feature
@@ -29,10 +29,11 @@ Feature: Bind an application to a service
                     kind: Database
                     resourceRef: db-demo-a-d-s
             """
-        Then application should be re-deployed
-        And application should be connected to the DB "db-demo-a-d-s"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-a-d-s" should be changed to "True"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-a-d-s" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-a-d-s" should be changed to "True"
+        And application should be re-deployed
+        And application should be connected to the DB "db-demo-a-d-s"
+
 
     Scenario: Bind an imported Node.js application to PostgreSQL database in the following order: Application, Service Binding Request and DB
         Given Imported Nodejs application "nodejs-rest-http-crud-a-s-d" is running
@@ -55,10 +56,11 @@ Feature: Bind an application to a service
                     resourceRef: db-demo-a-s-d
             """
         When DB "db-demo-a-s-d" is running
-        Then application should be re-deployed
-        And application should be connected to the DB "db-demo-a-s-d"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-a-s-d" should be changed to "True"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-a-s-d" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-a-s-d" should be changed to "True"
+        And application should be re-deployed
+        And application should be connected to the DB "db-demo-a-s-d"
+
 
     Scenario: Bind an imported Node.js application to PostgreSQL database in the following order: DB, Application and Service Binding Request
         Given DB "db-demo-d-a-s" is running
@@ -81,10 +83,11 @@ Feature: Bind an application to a service
                     kind: Database
                     resourceRef: db-demo-d-a-s
             """
-        Then application should be re-deployed
-        And application should be connected to the DB "db-demo-d-a-s"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-d-a-s" should be changed to "True"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-d-a-s" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-d-a-s" should be changed to "True"
+        And application should be re-deployed
+        And application should be connected to the DB "db-demo-d-a-s"
+
 
     # Currently disabled as not supported by SBO
     @disabled
@@ -109,10 +112,11 @@ Feature: Bind an application to a service
                     resourceRef: db-demo-d-s-a
             """
         When Imported Nodejs application "nodejs-rest-http-crud-d-s-a" is running
-        Then application should be re-deployed
-        And application should be connected to the DB "db-demo-d-s-a"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-d-s-a" should be changed to "True"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-d-s-a" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-d-s-a" should be changed to "True"
+        And application should be re-deployed
+        And application should be connected to the DB "db-demo-d-s-a"
+
 
     # Currently disabled as not supported by SBO
     @disabled
@@ -137,10 +141,10 @@ Feature: Bind an application to a service
             """
         * Imported Nodejs application "nodejs-rest-http-crud-s-a-d" is running
         When DB "db-demo-s-a-d" is running
-        Then application should be re-deployed
-        And application should be connected to the DB "db-demo-s-a-d"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-s-a-d" should be changed to "True"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-s-a-d" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-s-a-d" should be changed to "True"
+        And application should be re-deployed
+        And application should be connected to the DB "db-demo-s-a-d"
 
     # Currently disabled as not supported by SBO
     @disabled
@@ -165,10 +169,11 @@ Feature: Bind an application to a service
             """
         * DB "db-demo-s-d-a" is running
         When Imported Nodejs application "nodejs-rest-http-crud-s-d-a" is running
-        Then application should be re-deployed
-        And application should be connected to the DB "db-demo-s-d-a"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-s-d-a" should be changed to "True"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-s-d-a" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-s-d-a" should be changed to "True"
+        And application should be re-deployed
+        And application should be connected to the DB "db-demo-s-d-a"
+
 
     @negative
     Scenario: Attempt to bind a non existing application to PostgreSQL database

--- a/test/acceptance/features/bindKnativeService.feature
+++ b/test/acceptance/features/bindKnativeService.feature
@@ -39,7 +39,7 @@ Feature: Bind knative service to a service
                 - name: DB_PASSWORD
                   value: "{{ .knav.status.dbCredentials.password }}"
       """
-    Then deployment must contain intermediate secret "binding-request-knative"
-    Then application should be connected to the DB "db-demo-knative"
-    And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-knative" should be changed to "True"
+    Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-knative" should be changed to "True"
     And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-knative" should be changed to "True"
+    And deployment must contain intermediate secret "binding-request-knative"
+    And application should be connected to the DB "db-demo-knative"

--- a/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
+++ b/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
@@ -72,9 +72,9 @@ Feature: Insert service binding to a custom location in application resource
                     id: zzz
                     envVarPrefix: qiye
             """
-        Then Secret "binding-request-csp" has been injected in to CR "demo-appconfig-csp" of kind "AppConfig" at path "{.spec.spec.containers[0].envFrom[0].secretRef.name}"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-csp" should be changed to "True"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-csp" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-csp" should be changed to "True"
+        And Secret "binding-request-csp" has been injected in to CR "demo-appconfig-csp" of kind "AppConfig" at path "{.spec.spec.containers[0].envFrom[0].secretRef.name}"
 
     Scenario: Specify secret's path in service binding request
         Given DB "db-demo-ssp" is running
@@ -111,6 +111,6 @@ Feature: Insert service binding to a custom location in application resource
                     id: zzz
                     envVarPrefix: qiye
             """
-        Then Secret "binding-request-ssp" has been injected in to CR "demo-appconfig-ssp" of kind "AppConfig" at path "{.spec.spec.secret}"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-ssp" should be changed to "True"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding Request "binding-request-ssp" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding Request "binding-request-ssp" should be changed to "True"
+        And Secret "binding-request-ssp" has been injected in to CR "demo-appconfig-ssp" of kind "AppConfig" at path "{.spec.spec.secret}"


### PR DESCRIPTION
### Motivation

The acceptance tests sometimes fail for a timing issue caused by checking the desired binding outcome (such as `envFrom` in the deployment) - that was supposed to be done by the binding. Such checks sometimes happen before the actual binding process is finished.

Anything about the outcome should be checked only after the binding is finished, which is ensured by verifying the `.status.condition[]` steps after the SBR is applied.

### Changes

This PR moves the steps to verify desired binding outcome after the SBR status conditions are verified. After those steps passed, there is ~100% certainty that the desired binding outcome is in place so the tests can validate it.


### Testing

`make test-acceptance`