### PR TITLE
update etcd example README

### DIFF
--- a/examples/nodejs_etcd_operator/README.md
+++ b/examples/nodejs_etcd_operator/README.md
@@ -2,14 +2,20 @@
 
 1. Install Etcd operator using operator hub,
    follow https://operatorhub.io/operator/etcd
+   you can specify the following while installing etcd operator:
+   catalog source = "community-operators"
+   channel = "clusterwide-alpha"
 
 2. Create an Etcd cluster.
  ```yaml
  apiVersion: "etcd.database.coreos.com/v1beta2"
  kind: "EtcdCluster"
  metadata:
+  annotations:
+   etcd.database.coreos.com/scope: clusterwide
   name: "etcd-cluster-example"
  spec:
+  repository: quay.io/coreos/etcd
   size: 3
   version: "3.2.13"
  ```


### PR DESCRIPTION
### Motivation
etcd cluster instance unable to run with this in openshift-operators namespace:
`apiVersion: "etcd.database.coreos.com/v1beta2"
kind: "EtcdCluster"
metadata:
 name: "etcd-cluster-example"
spec:
 size: 3
 version: "3.2.13"`

### Changes

Use this to make it run on openshift-operators namespace
`apiVersion: etcd.database.coreos.com/v1beta2
kind: EtcdCluster
metadata:
  annotations:
    etcd.database.coreos.com/scope: clusterwide
  name: etcd-cluster-example
  namespace: test-namespace-881f5a0b
spec:
  repository: quay.io/coreos/etcd
  size: 3
  version: 3.2.13
`

For further more details refer the CONTRIBUTING.md