### PR TITLE
e2e-cleanup make rule should not fail if testname does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,6 @@ e2e-setup: e2e-cleanup e2e-create-namespace e2e-deploy-3rd-party-crds
 .PHONY: e2e-cleanup
 e2e-cleanup: get-test-namespace
 	$(Q)-TEST_NAMESPACE=$(TEST_NAMESPACE) $(HACK_DIR)/e2e-cleanup.sh
-	$(Q)-kubectl delete namespace $(TEST_NAMESPACE) --timeout=45s --wait
 
 OBSOLETE_E2E_MESSAGE=WARNING: e2e tests are obsolete and will be removed soon in favour of acceptance tests, \
 so they are disabled by default. If you need to run it anyway, set ENABLE_OBSOLETE_E2E=true in the environment.

--- a/hack/e2e-cleanup.sh
+++ b/hack/e2e-cleanup.sh
@@ -4,3 +4,6 @@ HACK_DIR=${HACK_DIR:-$(dirname $0)}
 
 # Remove SBR finalizers
 NAMESPACE=$TEST_NAMESPACE $HACK_DIR/remove-sbr-finalizers.sh
+
+
+[ ! -z "$(kubectl get namespace ${TEST_NAMESPACE} --ignore-not-found -o yaml)" ] && kubectl delete namespace ${TEST_NAMESPACE} --timeout=45s --wait || true


### PR DESCRIPTION
* removal of namespace moved to hack/e2e-cleanup.sh
* if namespace does not exit, do not try to remove it