### PR TITLE
[acceptance-tests] Make it possible to run SBO instance independendly on acceptnace testing setup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,10 @@ ifeq ($(TEST_ACCEPTANCE_START_SBO), local)
 test-acceptance-setup:
 	$(Q)echo "Starting local SBO instance"
 	$(eval TEST_ACCEPTANCE_SBO_STARTED := $(shell OPERATOR_NAMESPACE="$(TEST_NAMESPACE)" ZAP_FLAGS="$(ZAP_FLAGS)" OUTPUT="$(TEST_ACCEPTANCE_OUTPUT_DIR)" ./hack/deploy-sbo-local.sh))
+else ifeq ($(TEST_ACCEPTANCE_START_SBO), remote)
+test-acceptance-setup:
+	$(Q)echo "Using remote SBO instance running in '$(TEST_NAMESPACE)' namespace"
+	$(eval TEST_ACCEPTANCE_SBO_STARTED := $(TEST_NAMESPACE))
 else ifeq ($(TEST_ACCEPTANCE_START_SBO), operator-hub)
 test-acceptance-setup:
 	$(eval TEST_ACCEPTANCE_SBO_STARTED := $(shell ./hack/deploy-sbo-operator-hub.sh))
@@ -329,7 +333,9 @@ test-acceptance: test-acceptance-setup
 		TEST_ACCEPTANCE_SBO_STARTED=$(TEST_ACCEPTANCE_SBO_STARTED) \
 		TEST_NAMESPACE=$(TEST_NAMESPACE) \
 		$(PYTHON_VENV_DIR)/bin/behave --junit --junit-directory $(TEST_ACCEPTANCE_OUTPUT_DIR) $(V_FLAG) --no-capture --no-capture-stderr $(TEST_ACCEPTANCE_TAGS_ARG) test/acceptance/features
+ifeq ($(TEST_ACCEPTANCE_START_SBO), local)
 	$(Q)kill $(TEST_ACCEPTANCE_SBO_STARTED)
+endif
 
 .PHONY: test-acceptance-artifacts
 ## Collect artifacts from acceptance tests to be archived in CI

--- a/test/acceptance/features/steps/servicebindingoperator.py
+++ b/test/acceptance/features/steps/servicebindingoperator.py
@@ -23,7 +23,7 @@ class Servicebindingoperator():
     def is_running(self):
         start_sbo = os.getenv("TEST_ACCEPTANCE_START_SBO")
         start_sbo | should_not.be_none.desc("TEST_ACCEPTANCE_START_SBO is set")
-        start_sbo | should.be_in({"local", "operator-hub"})
+        start_sbo | should.be_in({"local", "remote", "operator-hub"})
 
         if start_sbo == "local":
             os.getenv("TEST_ACCEPTANCE_SBO_STARTED") | should_not.start_with("FAILED").desc("TEST_ACCEPTANCE_SBO_STARTED is not FAILED")


### PR DESCRIPTION
### Motivation
Fixes: [APPSVC-692](https://issues.redhat.com/browse/APPSVC-692)

Currently the only way how the acceptance tests can test the SBO is by using the local instance of the operator (that is built and started as a local binary as part of the test setup). It would be useful if we could start the SBO instance independently (by installing it into OpenShift cluster via OperatorHub, by running the local instance independently of the acceptance testing process, by running SBO in a local or remote container...).

### Changes

* `TEST_ACCEPTANCE_START_SBO` variable has an additional option for `remote` which means that the SBO instance is already running outside the scope of the acceptnace testing process and no local instance is started.
* The step for checking if the SBO is running is updated to take this option into account
* The means of the other options (such as `local` or `operator-hub`) are not affected
* All the acceptnace tests run no matter which option was set

### Testing

1) Install SBO via OperatorHub:
```bash
kubectl apply -f - << EOD
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
    name: redhat-developer-olm
    namespace: openshift-marketplace
spec:
    sourceType: grpc
    image: quay.io/pmacik/rhd-olm:v1
    displayName: Red Hat Developer OLM registry
    updateStrategy:
        registryPoll:
            interval: 30m
---
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: service-binding-operator
  namespace: openshift-operators
spec:
  channel: beta
  installPlanApproval: Automatic
  name: service-binding-operator
  source: redhat-developer-olm
  sourceNamespace: openshift-marketplace
  startingCSV: service-binding-operator.v0.2.0-387
EOD
```
2) Run the acceptance tests
 ```bash
TEST_ACCEPTANCE_START_SBO=remote make test-acceptance
```
