### PR TITLE
[acceptance-tests] Fix python linting dependencies.

### DIFF
--- a/hack/check-python/prepare-env.sh
+++ b/hack/check-python/prepare-env.sh
@@ -9,5 +9,5 @@ function prepare_venv() {
     for req in $(find . -name 'requirements.txt'); do
         python3 "$(which pip3)" install -q -r $req;
     done
-    python3 "$(which pip3)" install -q pydocstyle pyflakes vulture radon
+    python3 "$(which pip3)" install -q -r $(dirname $0)/requirements.txt
 }

--- a/hack/check-python/requirements.txt
+++ b/hack/check-python/requirements.txt
@@ -1,0 +1,5 @@
+pydocstyle==2.1.1
+pyflakes==2.2.0
+vulture==2.1
+radon==4.3.1
+flake8_polyfill==1.0.2

--- a/test/acceptance/features/requirements.txt
+++ b/test/acceptance/features/requirements.txt
@@ -1,3 +1,3 @@
-behave
-pyshould
-requests
+behave==1.2.6
+pyshould==0.7.1
+requests==2.24.0


### PR DESCRIPTION
### Motivation

Recently the python linter started to require `flake8_polyfill` module which is not installed. 

### Changes

This PR adds `flake8_polyfill` module into the installed dependencies.

### Testing

`make lint-python-code`