### PR TITLE
Add validation to use 'services' and not 'service'.

### DIFF
--- a/deploy/crds/operators.coreos.com_servicebindings_crd.yaml
+++ b/deploy/crds/operators.coreos.com_servicebindings_crd.yaml
@@ -13,6 +13,7 @@ spec:
     - sbrs
     singular: servicebinding
   scope: Namespaced
+  preserveUnknownFields: false
   subresources:
     status: {}
   validation:
@@ -259,6 +260,8 @@ spec:
                 type: object
               type: array
           type: object
+          required:
+              - "services"
         status:
           description: ServiceBindingStatus defines the observed state of ServiceBinding
           properties:


### PR DESCRIPTION
### Motivation

We are deprecating service and supporting services so updating CRD to enforce the use of CSV.

In the current situation, CR gets applied if it has service instead of services and on reconciling the operator crashes. So this PR will add validation to use services and if not used then CR will not be applied and will throw an error.