### PR TITLE
[acceptance-tests] Fix timeout waiting for serverless/knative to be imported

### DIFF
--- a/test/acceptance/features/requirements.txt
+++ b/test/acceptance/features/requirements.txt
@@ -1,3 +1,4 @@
 behave==1.2.6
 pyshould==0.7.1
 requests==2.24.0
+polling2==0.4.6

--- a/test/acceptance/features/steps/knative_serving.py
+++ b/test/acceptance/features/steps/knative_serving.py
@@ -23,7 +23,7 @@ metadata:
 '''
 
     def is_present(self):
-        cmd = f'oc get ks {self.name} -n {self.namespace}'
+        cmd = f'oc get knativeserving.operator.knative.dev {self.name} -n {self.namespace}'
         output, exit_code = self.cmd.run(cmd)
         if exit_code != 0:
             print(f"cmd-{cmd} result for getting available knative serving is {output} with the exit code {exit_code}")

--- a/test/acceptance/features/steps/openshift.py
+++ b/test/acceptance/features/steps/openshift.py
@@ -190,13 +190,13 @@ spec:
         assert exit_code == 0, f"Getting route host failed as the exit code is not 0 with output - {output}"
         return output
 
-    def get_deployment_status(self, deployment_name, namespace, wait_for_status=None):
+    def get_deployment_status(self, deployment_name, namespace, wait_for_status=None, interval=5, timeout=400):
         deployment_status_cmd = f'oc get deployment {deployment_name} -n {namespace} -o json' \
             + ' | jq -rc \'.status.conditions[] | select(.type=="Available").status\''
         output = None
         exit_code = -1
         if wait_for_status is not None:
-            status_found, output, exit_code = self.cmd.run_wait_for_status(deployment_status_cmd, wait_for_status, 5, 400)
+            status_found, output, exit_code = self.cmd.run_wait_for_status(deployment_status_cmd, wait_for_status, interval, timeout)
             if exit_code == 0:
                 assert status_found is True, f"Deployment {deployment_name} result after waiting for status is {status_found}"
         else:


### PR DESCRIPTION
### Motivation

Currently the knative-related acceptance tests scenarios fails for timeout sometimes.

### Changes
This PR:
* Increases various timeouts around quarkus app steps
* Changes the way to detect knative app is imported - uses number of replicas on deployment instead of checking `Available` status condition
* Changes the way to detect that serverless operator is running but checking for CSV and then for all the expected pods from it's deployments given by the CSV.

### Testing

`make test-acceptance`