### PR TITLE
[acceptance-tests] Add checks for feature files among linters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ endif
 
 .PHONY: lint
 ## Runs linters on Go code files and YAML files - DISABLED TEMPORARILY
-lint: setup-venv lint-go-code lint-yaml lint-python-code
+lint: setup-venv lint-go-code lint-yaml lint-python-code lint-feature-files
 
 YAML_FILES := $(shell find . -path ./vendor -prune -o -type f -regex ".*y[a]ml" -print)
 .PHONY: lint-yaml
@@ -197,6 +197,11 @@ $(GOLANGCI_LINT_BIN):
 .PHONY: lint-python-code
 lint-python-code: setup-venv
 	$(Q)PYTHON_VENV_DIR=$(PYTHON_VENV_DIR) ./hack/check-python/lint-python-code.sh
+
+## -- Check the acceptance tests feature files
+.PHONY: lint-feature-files
+lint-feature-files:
+	$(Q)./hack/check-feature-files.sh
 
 .PHONY: setup-venv
 ## Setup virtual environment

--- a/hack/check-feature-files.sh
+++ b/hack/check-feature-files.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+TEST_ACCEPTANCE_FEATURES_DIR=${TEST_ACCEPTANCE_FEATURES_DIR:-$(dirname $0)/../test/acceptance/features}
+
+FORBIDDEN_TAGS="@wip @dev"
+
+failed=""
+
+for t in $FORBIDDEN_TAGS; do
+    echo "----------------------------------------------------------"
+    echo "Checking for forbidden tag '$t' in feature files:"
+    echo "----------------------------------------------------------"
+    for i in $(find $TEST_ACCEPTANCE_FEATURES_DIR -name '*.feature'); do
+        echo -e "\nChecking $i"
+        match=$(grep -PirnH "$t" $i) || true
+        if [[ -z $match ]]; then
+            echo -n "    PASS"
+        else
+            echo -en "    FAIL\n$match\n"
+            failed="$failed\n$match"
+        fi
+    done
+    echo
+    echo
+done
+
+if [ ! -z "$failed" ]; then
+    echo -e "\nERROR: Following feature file checks FAILED:$failed\n"
+    exit 1
+else
+    echo -e "\nAll feature file checks PASSED\n"
+fi


### PR DESCRIPTION
### Motivation

Currently it is very easy to accidently commit and merge acceptance test tags placed in the `*.feature` files which shouldn't be allowed.

### Changes

This PR makes it harder to merge `*.feature` files that contains so-called "forbiden" tags (currently they are`@wip` and `@dev`) by:
* Introducing `lint-feature-files` Makefile targed that goes through all the `*.feature` files under  `test/acceptance/features` directory and looking for forbidden tags and failing when and of the forbidden tag is found.
* Including the `lint-feature-files` targed among the main `lint` used by the per-PR checks.
 

### Testing
`make lint` or
`make lint-feature-files`