### PR TITLE
fix: there's no need to requeue if app is not found

### DIFF
--- a/pkg/controller/servicebinding/reconciler_test.go
+++ b/pkg/controller/servicebinding/reconciler_test.go
@@ -277,8 +277,8 @@ func TestApplicationNotFound(t *testing.T) {
 
 	// Reconcile without deployment
 	res, err := r.Reconcile(reconcileRequest())
-	require.EqualError(t, err, errApplicationNotFound.Error())
-	require.True(t, res.Requeue)
+	require.NoError(t, err)
+	require.False(t, res.Requeue)
 
 	namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
 	sbrOutput, err := r.getServiceBinding(namespacedName)

--- a/pkg/controller/servicebinding/servicebinder.go
+++ b/pkg/controller/servicebinding/servicebinder.go
@@ -287,12 +287,6 @@ func (b *serviceBinder) handleApplicationError(reason string, applicationError e
 		return requeueError(err)
 	}
 
-	// appending finalizer, should be later removed upon resource deletion
-	addFinalizer(b.sbr)
-	if _, err = b.updateServiceBinding(sbr); err != nil {
-		return requeueError(err)
-	}
-
 	b.logger.Info(applicationError.Error())
 
 	if errors.Is(applicationError, errApplicationNotFound) {
@@ -300,8 +294,6 @@ func (b *serviceBinder) handleApplicationError(reason string, applicationError e
 		if _, err = b.updateServiceBinding(sbr); err != nil {
 			return requeueError(err)
 		}
-		return requeue(applicationError, requeueAfter)
-
 	}
 
 	return done()
@@ -393,7 +385,7 @@ func ensureDefaults(applicationSelector *v1alpha1.Application) {
 				ContainersPath: defaultPathToContainers,
 			}
 		}
-	}else {
+	} else {
 		applicationSelector = &v1alpha1.Application{}
 		applicationSelector.LabelSelector = &metav1.LabelSelector{}
 		applicationSelector.BindingPath = &v1alpha1.BindingPath{


### PR DESCRIPTION
Since there's nothing to recover from and there's a watch already
configured for further reverse lookups, the operator should not
requeue the work item.

Also, there's no need to update the service binding twice in the same
process because the finalizer has been already added during `bind`.