### PR TITLE
[WIP] [acceptance-tests] Add UI scenarios

### DIFF
--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -368,6 +368,7 @@ def check_secret_key_with_ip_value(context, secret_name, secret_key):
 # STEP
 @given(u'The openshift route is present')
 @given(u'Namespace is present')
+@given(u'Catalog source is present')
 @given(u'Backend service CSV is installed')
 @given(u'The Custom Resource Definition is present')
 @given(u'The Custom Resource is present')

--- a/test/acceptance/features/steps/steps_ui.py
+++ b/test/acceptance/features/steps/steps_ui.py
@@ -1,0 +1,113 @@
+# @mark.steps
+# ----------------------------------------------------------------------------
+# STEPS:
+# ----------------------------------------------------------------------------
+
+from behave import given, then, when, step
+
+
+# STEP
+@given(u'user [{username}] is logged into OpenShift Console with [{password}]')
+def user_is_logged_into_openshift_console(username, password):
+    raise NotImplementedError(f'STEP: Given user [{username}] is logged into OpenShift Console with [{password}]')
+
+
+# STEP
+@given(u'DB "{db_name}" is shown')
+def db_is_shown(db_name):
+    raise NotImplementedError(f'STEP: DB instance "{db_name}" is shown')
+
+
+# STEP
+@given(u'Application "{application_name}" is shown')
+def app_is_shown(application_name):
+    raise NotImplementedError(f'STEP: Application "{application_name}" is shown')
+
+
+# STEP
+arrow_is_dragged_from_application_to_db_step = u'Arrow is dragged and dropped from application icon to DB icon to "Create a binding connector"'
+
+
+@given(arrow_is_dragged_from_application_to_db_step)
+@when(arrow_is_dragged_from_application_to_db_step)
+def arrow_is_dragged_from_application_to_db():
+    raise NotImplementedError(u'STEP: Arrow is dragged and dropped from application icon to DB icon to "Create a binding connector"')
+
+
+# STEP
+arrow_is_rendered_from_application_to_db_step = u'Arrow is rendered from application icon to DB icon to indicate binding'
+
+
+@step(arrow_is_rendered_from_application_to_db_step)
+def arrow_is_rendered_from_application_to_db():
+    raise NotImplementedError(u'STEP: Arrow is rendered from application icon to DB icon to indicate binding')
+
+
+# STEP
+@given(u'"{text}" is shown on page')
+def text_is_shown_on_page(text):
+    raise NotImplementedError(f'"{text}" is shown on page')
+
+
+# STEP
+@then(u'Operator page for "{operator_name}" is opened')
+def operator_page_is_open(operator_name):
+    raise NotImplementedError(f'STEP: Operator page for "{operator_name}" is opened')
+
+
+# STEP
+view_is_opened_step = u'"{view}" view is opened'
+
+
+@given(view_is_opened_step)
+@when(view_is_opened_step)
+def view_is_opened(view):
+    raise NotImplementedError(f'STEP: "{view}" view is opened')
+
+
+# STEP
+page_is_opened_step = u'"{page}" page is opened'
+
+
+@given(page_is_opened_step)
+@when(page_is_opened_step)
+def page_is_opened(page):
+    raise NotImplementedError(f'STEP: "{page}" page is opened')
+
+
+# STEP
+@given(u'"{card}" card is clicked and Community operators confirmed')
+def card_is_clicked(card):
+    raise NotImplementedError(f'STEP: Given "{card}" card is clicked and Community operators confirmed')
+
+
+# STEP
+@given(u'"{selection}" checkbox for "{selection_category}" is selected')
+def step_impl(selection, selection_category):
+    raise NotImplementedError(f'STEP: Given "{selection}" checkbox for "{selection_category}" is selected')
+
+
+# STEP
+button_is_clicked_step = u'"{button}" button is clicked'
+
+
+@given(button_is_clicked_step)
+@when(button_is_clicked_step)
+def button_is_clicked(button):
+    raise NotImplementedError(f'STEP: "{button}" button is clicked')
+
+
+# STEP
+selection_is_selected_step = '"{selection}" is selected to be "{selected_value}"'
+
+
+@given(selection_is_selected_step)
+@when(selection_is_selected_step)
+def selection_is_selected(selection, selected_value):
+    raise NotImplementedError(f'STEP: "{selection}" is selected to be "{selected_value}"')
+
+
+# STEP
+@then(u'Operator status is "{status}"')
+def operator_status_is(status):
+    raise NotImplementedError(f'STEP: Operator status is "{status}"')

--- a/test/acceptance/features/ui/bindAppToService.feature
+++ b/test/acceptance/features/ui/bindAppToService.feature
@@ -1,0 +1,23 @@
+@ui @disabled
+Feature: Bind an application to a service
+
+    As a user of Service Binding Operator
+    I want to bind applications to services it depends on
+
+    Background:
+        Given Namespace [TEST_NAMESPACE] is used
+        * Service Binding Operator is running
+        * PostgreSQL DB operator is installed
+
+    Scenario: Bind Node.js application to DB in Topology view of OpenShift Console
+        Given user [ADMIN_USER] is logged into OpenShift Console with [ADMIN_PASSWORD]
+        * "Developer" view is opened
+        * "Topology" page is opened
+        * DB "db-demo-ui" is running
+        * Imported Nodejs application "nodejs-app-ui" is not running
+        * DB "db-demo-ui" is shown
+        * Application "nodejs-app-ui" is shown
+        * Arrow is dragged and dropped from application icon to DB icon to "Create a binding connector"
+        Then Arrow is rendered from application icon to DB icon to indicate binding
+        And application should be re-deployed
+        And application should be connected to the DB "db-demo-ui"

--- a/test/acceptance/features/ui/installServiceBindingOperator.feature
+++ b/test/acceptance/features/ui/installServiceBindingOperator.feature
@@ -1,0 +1,60 @@
+@ui @disabled
+Feature: Install Service Binding Operator
+
+    Background: Logged into OpenShift Console
+        Given user [ADMIN_USER] is logged into OpenShift Console with [ADMIN_PASSWORD]
+        * "Administrator" view is opened
+
+    Scenario: Install Community version of Service Binding Operator via OperaHub in OpenShift DevConsole
+        Given "OperatorHub" page is opened
+        * "Community" checkbox for "Provider Type" is selected
+        * "Service Binding Operator" card is clicked and Community operators confirmed
+        * "Install" button is clicked
+        * "Installation Mode" is selected to be "All namespaces on the cluster (default)"
+        * "Update Channel" is selected to be "beta"
+        * "Approval Strategy" is selected to be "Automatic"
+        * "Install" button is clicked
+        * "Installing operator" is shown on page
+        When "View Operator" button is clicked
+        Then Operator page for "Service Binding Operator" is opened
+        And Operator status is "Succeeded"
+
+    Scenario: Install upstream version of Service Binding Operator from OperatorHub.io
+        Given Catalog source is present
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+                name: operatorhub-io
+                namespace: openshift-marketplace
+            spec:
+                sourceType: grpc
+                image: quay.io/operatorhubio/catalog:latest
+                displayName: OperatorHub.io
+            """
+        * "OperatorHub" page is opened
+        * "OperatorHub.io" checkbox for "Provider Type" is selected
+        * "Service Binding Operator" card is clicked and Community operators confirmed
+        * "Install" button is clicked
+        * "Installation Mode" is selected to be "All namespaces on the cluster (default)"
+        * "Update Channel" is selected to be "beta"
+        * "Approval Strategy" is selected to be "Automatic"
+        * "Install" button is clicked
+        * "Installing operator" is shown on page
+        When "View Operator" button is clicked
+        Then Operator page for "Service Binding Operator" is opened
+        And Operator status is "Succeeded"
+
+    Scenario: Install productized version of Service Binding Operator released by Red Hat via OperaHub in OpenShift DevConsole
+        * "OperatorHub" page is opened
+        * "OperatorHub.io" checkbox for "Provider Type" is selected
+        * "Service Binding Operator" card is clicked and Community operators confirmed
+        * "Install" button is clicked
+        * "Installation Mode" is selected to be "All namespaces on the cluster (default)"
+        * "Update Channel" is selected to be "beta"
+        * "Approval Strategy" is selected to be "Automatic"
+        * "Install" button is clicked
+        * "Installing operator" is shown on page
+        When "View Operator" button is clicked
+        Then Operator page for "Service Binding Operator" is opened
+        And Operator status is "Succeeded"


### PR DESCRIPTION
### Motivation

SBO is used by the Developer Console UI and can be installed via OperatorHub in OpenShift.

### Changes

This PR introduces most basic UI scenarios  such as:
* Install community version of SBO via OperatorHub in the OpenShift Console
* Bind application to DB in Topology View by draggin an arrow (binding connection) from application icon to DB icon

The scenarios are:
* marked by `@ui` tag
* not implemented and disabled by `@disabled` tag

### Testing

Manually follow the steps described in the scenarios.