### PR TITLE
[acceptance-tests] Introduce way to smoke test with acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,11 @@ ifeq ($(TEST_ACCEPTANCE_START_SBO), local)
 	$(Q)kill $(TEST_ACCEPTANCE_SBO_STARTED)
 endif
 
+.PHONY: test-acceptance-smoke
+## Runs a sub-set of acceptance tests tagged with @smoke tag
+test-acceptance-smoke:
+	$(Q)TEST_ACCEPTANCE_TAGS=@smoke $(MAKE) test-acceptance
+
 .PHONY: test-acceptance-artifacts
 ## Collect artifacts from acceptance tests to be archived in CI
 test-acceptance-artifacts:

--- a/test/acceptance/features/bindAppToService.feature
+++ b/test/acceptance/features/bindAppToService.feature
@@ -8,6 +8,7 @@ Feature: Bind an application to a service
         * Service Binding Operator is running
         * PostgreSQL DB operator is installed
 
+    @smoke
     Scenario: Bind an imported Node.js application to PostgreSQL database in the following order: Application, DB and Service Binding
         Given Imported Nodejs application "nodejs-rest-http-crud-a-d-s" is running
         * DB "db-demo-a-d-s" is running


### PR DESCRIPTION
### Motivation

Resolves: [APPSVC-710](https://issues.redhat.com/browse/APPSVC-710)

Currently there is no out-of-the-box way to run just a few tests to just check fundamental pieces of acceptance scenarios.
The only way now is to manually mark a chosen scenario with a tag and than run the acceptance tests with `TEST_ACCEPTANCE_TAGS=@<tag>` variable set, which is repetitive and annoying and has a potential for including those forgotten tags into a codebase.

### Changes

This PR:
* Introduces `test-acceptance-smoke` Makefile target that executes a sub-set of acceptance scenarios marked with `@smoke` tag.
* Tags `Bind an imported Node.js application to PostgreSQL database in the following order: Application, DB and Service Binding` scenarios with `@smoke` tag to be part of the smoke testing sub-set.

### Testing

`make test-acceptance-smoke`