### PR TITLE
remove OperatorSource reference from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,22 +80,7 @@ spec:
 ## Quick Start
 
 Clone the repository and run `make local` in an existing `kube:admin` OpenShift
-CLI session. Alternatively, install the operator using:
-
-``` bash
-cat <<EOS |kubectl apply -f -
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorSource
-metadata:
-  name: redhat-developer-operators
-  namespace: openshift-marketplace
-spec:
-  type: appregistry
-  endpoint: https://quay.io/cnr
-  registryNamespace: redhat-developer
-EOS
-```
+CLI session. 
 
 
 ## Key Features


### PR DESCRIPTION
`OperatorSource` API has been removed from OpenShift 4.6 nightly.