### PR TITLE
Use CRD name instead of hard-coded "sbr" or "sbrs" in hack/remove-sbr-finalizers.sh

### DIFF
--- a/hack/remove-sbr-finalizers.sh
+++ b/hack/remove-sbr-finalizers.sh
@@ -7,11 +7,12 @@ else
 fi
 
 # Remove SBR finalizers if CRD exists
-[ -z "$(kubectl get -f deploy/crds/*crd.yaml -o jsonpath="{.metadata.name}" --ignore-not-found)" ] && exit 0
+CRD_NAME=$(kubectl get -f deploy/crds/*crd.yaml -o jsonpath="{.metadata.name}" --ignore-not-found)
+[ -z $CRD_NAME ] && exit 0
 
-SBRS=($(kubectl get sbrs $USE_NS -o jsonpath="{.items[*].metadata.name}"))
-SBR_NS=($(kubectl get sbrs $USE_NS -o jsonpath="{.items[*].metadata.namespace}"))
+SBRS=($(kubectl get $CRD_NAME $USE_NS -o jsonpath="{.items[*].metadata.name}"))
+SBR_NS=($(kubectl get $CRD_NAME $USE_NS -o jsonpath="{.items[*].metadata.namespace}"))
 
 for i in "${!SBRS[@]}"; do
-    kubectl patch sbr/${SBRS[$i]} -p '{"metadata":{"finalizers":[]}}' --type=merge --namespace=${SBR_NS[$i]};
+    kubectl patch $CRD_NAME/${SBRS[$i]} -p '{"metadata":{"finalizers":[]}}' --type=merge --namespace=${SBR_NS[$i]};
 done


### PR DESCRIPTION
### Motivation

Jira: [APPSVC-726](https://issues.redhat.com/browse/APPSVC-726)

Currently the `hack/remove-sbr-finalizers.sh` script uses hardcoded short names for Service Binding resources `sbr`/`sbrs` that is not reliable - it fails sometimes to find the resource by that short name. And also it can change in the future.
 
### Changes

This PR changes the script to use exact name of the CRD instead of the short name.

### Testing

`make test-cleanup`