### PR TITLE
[acceptance-tests] Do not install any resource if SBO is remote.

### DIFF
--- a/test/acceptance/features/environment.py
+++ b/test/acceptance/features/environment.py
@@ -13,13 +13,24 @@ before_all(context), after_all(context)
 """
 
 import subprocess
-from pyshould import should
+import os
+
+
+def before_all(_context):
+    start_sbo = os.getenv("TEST_ACCEPTANCE_START_SBO")
+    assert start_sbo is not None, "TEST_ACCEPTANCE_START_SBO is not set. It should be one of local, remote or operator-hub"
+    assert start_sbo in {"local", "remote", "operator-hub"}, "TEST_ACCEPTANCE_START_SBO should be one of local, remote or operator-hub"
+
+    if start_sbo == "local":
+        assert not os.getenv("TEST_ACCEPTANCE_SBO_STARTED").startswith("FAILED"), "TEST_ACCEPTANCE_SBO_STARTED shoud not be FAILED."
+    elif start_sbo == "remote":
+        sbo_namespace = os.getenv("SBO_NAMESPACE")
+        assert sbo_namespace is not None, "SBO_NAMESPACE is required but not set."
+        _context.sbo_namespace = sbo_namespace
+    else:
+        assert False, f"TEST_ACCEPTANCE_START_SBO={start_sbo} is currently unsupported."
 
 
 def before_scenario(_context, _scenario):
-    print("Getting OC status before {} scenario".format(_scenario))
-    code, output = subprocess.getstatusoutput('oc get project default')
-    print("[CODE] {}".format(code))
-    print("[CMD] {}".format(output))
-    code | should.be_equal_to(0)
-    print("***Connected to cluster***")
+    code, output = subprocess.getstatusoutput('kubectl get project default -o jsonpath="{.metadata.name}"')
+    assert code == 0, f"Checking connection to OS cluster by getting the 'default' project failed: {output}"

--- a/test/acceptance/features/steps/servicebindingoperator.py
+++ b/test/acceptance/features/steps/servicebindingoperator.py
@@ -9,15 +9,17 @@ class Servicebindingoperator():
     name = ""
     namespace = ""
 
+    name_pattern = f"{name}.*"
+
     def __init__(self,  name="service-binding-operator", namespace="openshift-operators"):
         self.namespace = namespace
         self.name = name
 
     def check_resources(self):
         self.openshift.is_resource_in("servicebinding") | should.be_truthy.desc("CRD is in")
-        self.openshift.search_resource_in_namespace("rolebindings", self.name, self.namespace) | should_not.be_none.desc("Role binding is in")
-        self.openshift.search_resource_in_namespace("roles", self.name, self.namespace) | should_not.be_none.desc("Role is in")
-        self.openshift.search_resource_in_namespace("serviceaccounts", self.name, self.namespace) | should_not.be_none.desc("Service Account")
+        self.openshift.search_resource_in_namespace("rolebindings", self.get_name_pattern(), self.namespace) | should_not.be_none.desc("Role binding is in")
+        self.openshift.search_resource_in_namespace("roles", self.get_name_pattern(), self.namespace) | should_not.be_none.desc("Role is in")
+        self.openshift.search_resource_in_namespace("serviceaccounts", self.get_name_pattern(), self.namespace) | should_not.be_none.desc("Service Account")
         return True
 
     def is_running(self):
@@ -31,3 +33,6 @@ class Servicebindingoperator():
             return False
 
         return self.check_resources()
+
+    def get_name_pattern(self):
+        return self.name_pattern.format(name=self.name)

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -83,8 +83,11 @@ sbo_is_running_step = u'Service Binding Operator is running'
 @given(sbo_is_running_step)
 @when(sbo_is_running_step)
 def sbo_is_running(context):
-    context.namespace | should_not.be_none.desc("Namespace set in context")
-    sbo_is_running_in_namespace(context, context.namespace.name)
+    if "sbo_namespace" in context:
+        sbo_is_running_in_namespace(context, context.sbo_namespace)
+    else:
+        context.namespace | should_not.be_none.desc("Namespace set in context")
+        sbo_is_running_in_namespace(context, context.namespace.name)
 
 
 # STEP
@@ -344,7 +347,7 @@ def check_secret_key_with_ip_value(context, secret_name, secret_key):
     json_path = f'{{.data.{secret_key}}}'
     polling2.poll(lambda: ipaddress.ip_address(
         openshift.get_resource_info_by_jsonpath("secrets", secret_name, context.namespace.name, json_path)),
-                  step=5, timeout=120, ignore_exceptions=(ValueError,))
+        step=5, timeout=120, ignore_exceptions=(ValueError,))
 
 
 # STEP


### PR DESCRIPTION
### Motivation

Currently there are some resources (such as CRD, role, role-binding,...) that are installed for acceptance tests before the actual tests are execued. This should only by the case when SBO is running `local`. In case SBO is running `remote`ly (i.e. installed in OpenShift beforehand) all of the resources should be already there by the installation.

### Changes

This PR:
* Skips steps in Makefile that install resources
* Introduces `SBO_NAMESPACE` variable to specify in which namespace the remote SBO is running. 

### Testing

1. Install SBO via OperatorHub (`beta` channel)
2. Run  `TEST_ACCEPTANCE_START_SBO=remote SBO_NAMESPACE=openshift-operators make test-acceptance-smoke
`
