### PR TITLE
[acceptance-tests] Replace pyshould by asserts and refine error messages

### DIFF
--- a/test/acceptance/features/requirements.txt
+++ b/test/acceptance/features/requirements.txt
@@ -1,4 +1,3 @@
 behave==1.2.6
-pyshould==0.7.1
 requests==2.24.0
 polling2==0.4.6

--- a/test/acceptance/features/steps/dboperator.py
+++ b/test/acceptance/features/steps/dboperator.py
@@ -1,5 +1,4 @@
 import re
-from pyshould import should, should_not
 
 from command import Command
 from openshift import Openshift
@@ -50,9 +49,9 @@ class DbOperator():
         return True
 
     def get_package_manifest(self):
-        cmd = 'oc get packagemanifest %s -o "jsonpath={.metadata.name}"' % self.pkgManifest
+        cmd = f'oc get packagemanifest {self.pkgManifest} -o "jsonpath={{.metadata.name}}"'
         manifest = self.cmd.run_check_for_status(
             cmd, status=self.pkgManifest)
-        manifest | should_not.be_equal_to(None)
-        manifest | should.equal(self.pkgManifest)
+        assert manifest is not None, f"Unable to find packagemanifest '{self.pkgManifest}': {manifest}"
+        assert manifest == self.pkgManifest, f"Unexpected packagemanifest found: '{manifest}'. Expected: '{self.pkgManifest}'"
         return manifest


### PR DESCRIPTION
### Motivation

Jira: [APPSVC-724](https://issues.redhat.com/browse/APPSVC-724)

Currently the assertion in acceptance tests is done by a combination of `pyshould` library and Python's `assert` statements. which is confusing.

### Changes
This PR:
* Replaces use of `pyshould` library in acceptance tests is replaced by assert statements with concrete error messages to explain what went wrong or unexpected
* Removes `pyshould` from requirements

### Testing

`make test-acceptance`