### PR TITLE
Add acceptance test to validate cross-namespace service support

### DIFF
--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -363,6 +363,7 @@ def check_secret_key_with_ip_value(context, secret_name, secret_key):
 
 
 # STEP
+@given(u'Namespace is present')
 @given(u'Backend service CSV is installed')
 @given(u'The Custom Resource Definition is present')
 @given(u'The Custom Resource is present')


### PR DESCRIPTION
### Motivation

We support binding service to application present in a different namespace. This PR adds an acceptance test to validate it.
https://issues.redhat.com/browse/APPSVC-418

### Testing

`make test-acceptance VERBOSE=3`


For further more details refer the CONTRIBUTING.md