### PR TITLE
Fix annotations with sliceOfStrings

### DIFF
--- a/examples/java_postgresql_customvar/README.md
+++ b/examples/java_postgresql_customvar/README.md
@@ -100,7 +100,7 @@ kubectl edit crd databases.postgresql.baiju.dev
 Add these annotations under `metadata.annotations` along with other annotations.
 
 ```yaml
-service.binding/tags: path={.spec.tags}
+service.binding/tags: path={.spec.tags},elementType=sliceOfStrings
 service.binding/userLabels: path={.spec.userLabels},elementType=map
 service.binding/secretName: path={.spec.secretName},elementType=sliceOfMaps,sourceKey=type,sourceValue=secret
 ```
@@ -324,7 +324,8 @@ DATABASE_PASSWORD=password
 DATABASE_SECRETNAME_PRIMARYSECRETNAME=example-primaryuser
 DATABASE_SECRETNAME_ROOTSECRETNAME=example-rootuser
 DATABASE_SECRETNAME_SECONDARYSECRETNAME=example-secondaryuser
-DATABASE_TAGS=[centos7-12.3 centos7-12.4]
+DATABASE_TAGS_0=centos7-12.3
+DATABASE_TAGS_1=centos7-12.4
 DATABASE_USER=postgres
 DATABASE_USERLABELS_ARCHIVE=false
 DATABASE_USERLABELS_ENVIRONMENT=demo

--- a/pkg/controller/servicebinding/binding/definition.go
+++ b/pkg/controller/servicebinding/binding/definition.go
@@ -286,12 +286,19 @@ func (d *sliceOfStringsFromPathDefinition) Apply(u *unstructured.Unstructured) (
 		return nil, errors.New("not found")
 	}
 
-	v := make([]string, 0, len(val))
+	v := make([]interface{}, 0, len(val))
 	for _, e := range val {
-		if mm, ok := e.(map[string]interface{}); ok {
-			sourceValue := mm[d.sourceValue].(string)
-			v = append(v, sourceValue)
+		if d.sourceValue != "" {
+			if mm, ok := e.(map[string]interface{}); ok {
+				sourceValue := mm[d.sourceValue].(string)
+				v = append(v, sourceValue)
+			}
+		} else {
+			if x, ok := e.(string); ok {
+				v = append(v, x)
+			}
 		}
+
 	}
 
 	return &value{v: map[string]interface{}{d.outputName: v}}, nil

--- a/pkg/controller/servicebinding/binding/definition_test.go
+++ b/pkg/controller/servicebinding/binding/definition_test.go
@@ -149,7 +149,7 @@ func TestSliceOfStringsFromPath(t *testing.T) {
 	})
 	require.NoError(t, err)
 	v := map[string]interface{}{
-		"bootstrap": []string{"www.example.com", "secure.example.com"},
+		"bootstrap": []interface{}{"www.example.com", "secure.example.com"},
 	}
 	require.Equal(t, v, val.Get())
 }

--- a/pkg/controller/servicebinding/binding/model.go
+++ b/pkg/controller/servicebinding/binding/model.go
@@ -13,7 +13,7 @@ type model struct {
 	objectType  objectType
 	sourceKey   string
 	sourceValue string
-	bindAs		BindingType
+	bindAs      BindingType
 }
 
 func (m *model) isStringElementType() bool {

--- a/pkg/controller/servicebinding/binding/spec_test.go
+++ b/pkg/controller/servicebinding/binding/spec_test.go
@@ -353,11 +353,11 @@ func TestSpecHandler(t *testing.T) {
 			},
 		},
 		expectedData: map[string]interface{}{
-			"bootstrap": []string{"secure.example.com", "www.example.com"},
+			"bootstrap": []interface{}{"secure.example.com", "www.example.com"},
 		},
 		expectedRawData: map[string]interface{}{
 			"status": map[string]interface{}{
-				"bootstrap": []string{"secure.example.com", "www.example.com"},
+				"bootstrap": []interface{}{"secure.example.com", "www.example.com"},
 			},
 		},
 	}))
@@ -377,11 +377,11 @@ func TestSpecHandler(t *testing.T) {
 			},
 		},
 		expectedData: map[string]interface{}{
-			"urls": []string{"secure.example.com", "www.example.com"},
+			"urls": []interface{}{"secure.example.com", "www.example.com"},
 		},
 		expectedRawData: map[string]interface{}{
 			"status": map[string]interface{}{
-				"urls": []string{"secure.example.com", "www.example.com"},
+				"urls": []interface{}{"secure.example.com", "www.example.com"},
 			},
 		},
 	}))

--- a/pkg/controller/servicebinding/envvars/envvars_test.go
+++ b/pkg/controller/servicebinding/envvars/envvars_test.go
@@ -136,6 +136,21 @@ func TestBuild(t *testing.T) {
 			},
 			src: "",
 		},
+		{
+			name: "should create envvars for each string in slice",
+			expected: map[string]string{
+				"TAGS_0": "knowledge",
+				"TAGS_1": "is",
+				"TAGS_2": "power",
+			},
+			src: map[string]interface{}{
+				"tags": []string{
+					"knowledge",
+					"is",
+					"power",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/controller/servicebinding/nested/nested.go
+++ b/pkg/controller/servicebinding/nested/nested.go
@@ -68,7 +68,7 @@ func convertToSlice(src interface{}) ([]interface{}, error) {
 			obj[i] = e
 		}
 	default:
-		return nil, unsupportedTypeErr
+		return nil, fmt.Errorf("%v: %v", unsupportedTypeErr, t)
 	}
 	return obj, nil
 }


### PR DESCRIPTION
### Motivation

Implements:
* https://github.com/k8s-service-bindings/spec/issues/131
* [APPSVC-739](https://issues.redhat.com/browse/APPSVC-739)

Fixes:
* https://github.com/redhat-developer/service-binding-operator/issues/728
* [APPSVC-729](https://issues.redhat.com/browse/APPSVC-729)

The `unsupported type` error is thrown because when using a list of strings (a.k.a. slice of strings) the env variable building piece of SBO does not recognize it because it ends up as `[]string` which is not the case of `[]interface{}` or any other considered case.

### Changes

This PR:
* Adds a case for `[]string` in a similar way as `[]interface{}` is in the env variable build part of SBO.
* Improves a bit of error logs related to the issue.
* Implements case for `sliceOfStrings` without `sourceValue`
* Adds acceptance tests

### Testing

`make test-unit`
`TEST_ACCEPTANCE_TAGS=@annotations make test-acceptance`
