### PR TITLE
[acceptance-tests] Fix remote SBO namespace checking.

### DIFF
--- a/test/acceptance/features/environment.py
+++ b/test/acceptance/features/environment.py
@@ -25,7 +25,7 @@ def before_all(_context):
         assert not os.getenv("TEST_ACCEPTANCE_SBO_STARTED").startswith("FAILED"), "TEST_ACCEPTANCE_SBO_STARTED shoud not be FAILED."
     elif start_sbo == "remote":
         sbo_namespace = os.getenv("SBO_NAMESPACE")
-        assert sbo_namespace is not None, "SBO_NAMESPACE is required but not set."
+        assert (sbo_namespace is not None) and (sbo_namespace != ""), f"SBO_NAMESPACE is required but it is not set or it is empty: {sbo_namespace}"
         _context.sbo_namespace = sbo_namespace
     else:
         assert False, f"TEST_ACCEPTANCE_START_SBO={start_sbo} is currently unsupported."


### PR DESCRIPTION
### Motivation

When using `TEST_ACCEPTANCE_START_SBO=remote` option, `SBO_NAMESPACE` is required to be set to a non-empty value, as well. Currently the check for that is missing so when the acceptance tests are executed without `SBO_NAMESPACE` the tests attempt to run with empty name for SBO namespace which is invalid.

### Changes

This PR:
* Enhances the check for `SBO_NAMESPACE` env variable value in `before_all` hook.
* Fixes: https://issues.redhat.com/browse/APPSVC-744

### Testing

Running `TEST_ACCEPTANCE_TESTS=remote make test-acceptance` should correctly fail with:
```
HOOK-ERROR in before_all: AssertionError: SBO_NAMESPACE is required but it is not set or it is empty: 
```