### PR TITLE
Add podman package to OpenShift CI's base image.

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -19,6 +19,7 @@ RUN yum install epel-release -y \
     bc \
     jq \
     python36-virtualenv \
+    podman \
     && yum clean all
 
 ENV PATH=:$GOPATH/bin:/tmp/goroot/go/bin:$PATH


### PR DESCRIPTION
### Motivation

This is a dependency for the acceptance tests to be able to run in containerized environment.

The tool needs to be added and merged in a separated PR prior merging the actual PR that depends on it, because of how OpenShift CI and Prow works.

### Changes

This PR add `podman` package to the `root` base image for OpenShift CI jobs

### Testing
