### PR TITLE
Update generated group name from apps.openshift.io to operators.coreos.com

### DIFF
--- a/pkg/apis/operators/v1alpha1/doc.go
+++ b/pkg/apis/operators/v1alpha1/doc.go
@@ -1,4 +1,4 @@
 // Package v1alpha1 contains API Schema definitions for the apps v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=apps.openshift.io
+// +groupName=operators.coreos.com
 package v1alpha1


### PR DESCRIPTION
Fix https://github.com/redhat-developer/service-binding-operator/pull/735#discussion_r515024936