### PR TITLE
[acceptance-tests] Use out/operator binary for local SBO instance instead of operator-sdk

### DIFF
--- a/hack/deploy-sbo-local.sh
+++ b/hack/deploy-sbo-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE:-}
 ZAP_FLAGS=${ZAP_FLAGS:-}
@@ -8,32 +8,30 @@ mkdir -p "$OUTPUT"
 
 SBO_LOCAL_LOG="$OUTPUT/sbo-local.log"
 
-_killall(){
-    which killall &> /dev/null
-    if [ $? -eq 0 ]; then
-        killall $1
-    else
-        for i in "$(ps -l | grep $1)"; do if [ -n "$i" ]; then kill $(echo "$i" | sed -e 's,\s\+,#,g' | cut -d "#" -f4); fi; done
-    fi
+RUN_IN_BACKGROUND="${RUN_IN_BACKGROUND:-false}"
+
+_run_operator(){
+    SERVICE_BINDING_OPERATOR_DISABLE_ELECTION=false WATCH_NAMESPACE="" ./out/operator $ZAP_FLAGS
 }
 
-_killall operator-sdk
-_killall service-binding-operator-local
+if [ "$RUN_IN_BACKGROUND" == "true" ]; then
+    _run_operator > $SBO_LOCAL_LOG 2>&1 &
 
-operator-sdk --verbose run --local --namespace="$OPERATOR_NAMESPACE" --operator-flags "$ZAP_FLAGS" > $SBO_LOCAL_LOG 2>&1 &
+    SBO_PID=$!
 
-SBO_PID=$!
+    attempts=24
+    while [ -z "$(grep 'Starting workers' $SBO_LOCAL_LOG)" ]; do
+        if [[ $attempts -ge 0 ]]; then
+            sleep 5
+            attempts=$((attempts-1))
+        else
+            echo "FAILED"
+            kill $SBO_PID
+            exit 1
+        fi
+    done
 
-attempts=24
-while [ -z "$(grep 'Starting workers' $SBO_LOCAL_LOG)" ]; do
-    if [[ $attempts -ge 0 ]]; then
-        sleep 5
-        attempts=$((attempts-1))
-    else
-        echo "FAILED"
-        kill $SBO_PID
-        exit 1
-    fi
-done
-
-echo $SBO_PID
+    echo $SBO_PID
+else
+    _run_operator
+fi

--- a/hack/stop-sbo-local.sh
+++ b/hack/stop-sbo-local.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+_killall(){
+    which killall &> /dev/null
+    if [ $? -eq 0 ]; then
+        killall $1
+    else
+        for i in "$(ps -l | grep $1)"; do if [ -n "$i" ]; then kill $(echo "$i" | sed -e 's,\s\+,#,g' | cut -d "#" -f4); fi; done
+    fi
+}
+
+# Kill SBO running locally (no matter how it was started);
+_killall out/operator
+_killall operator
+_killall operator-sdk
+_killall service-binding-operator
+_killall service-binding-operator-local
+
+exit 0


### PR DESCRIPTION
### Motivation

Currently the `deploy-sbo-local.sh` and `make local` use `operator-sdk run --local` to start the local instance of SBO (SDK builds and run the `build/_output/bin/service-binding-operator-local`, however the "production" binary that is part of the shipped image is build by the `make build` target and is actually `out/operator`:

This means that the acceptance tests actually test a different binary, than the one that is a part of releases.

### Changes

This PR:
* Modifies the `local` Makefile target to build and use `out/operator` binary
* Modifies the `test-acceptance-setup` Makefile target to build and use `out/operator` binary
* Updates the `hack/deploy-sbo-local.sh` script to be able to start local instance of SBO either in background or foreground.
* Unifies the above targets to all use `hack/deploy-sbo-local.sh` script approprietaly

### Testing

`make local`
`make test-acceptance-smoke`