### PR TITLE
[acceptance-tests] Merge steps for 'all-is-ready' into a single simplified step

### DIFF
--- a/test/acceptance/features/bindAppToMultipleServices.feature
+++ b/test/acceptance/features/bindAppToMultipleServices.feature
@@ -48,41 +48,36 @@ Feature: Bind a single application to multiple services
                     kind: Database
                     name: db-demo-2
             """
-
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-1" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-1" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-1" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-2" should be changed to "True"
+        Then Service Binding "binding-request-1" is ready
+        And Service Binding "binding-request-2" is ready
         And "nodejs-app" deployment must contain SBR name "binding-request-1"
         And "nodejs-app" deployment must contain SBR name "binding-request-2"
 
-        Scenario: Bind two backend services by creating 1 SBR to a single application
+    Scenario: Bind two backend services by creating 1 SBR to a single application
         Given Generic test application "myapp-1sbr" is running
         * OLM Operator "backend" is running
         * The Custom Resource is present
-        """
-        apiVersion: stable.example.com/v1
-        kind: Backend
-        metadata:
-            name: internal-db-1sbr
-            annotations:
-                service.binding/host_internal_db: path={.spec.host_internal_db}
-        spec:
-            host_internal_db: internal.db.stable.example.com
-        """
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: internal-db-1sbr
+                annotations:
+                    service.binding/host_internal_db: path={.spec.host_internal_db}
+            spec:
+                host_internal_db: internal.db.stable.example.com
+            """
         * The Custom Resource is present
-        """
-        apiVersion: stable.example.com/v1
-        kind: Backend
-        metadata:
-            name: external-db-1sbr
-            annotations:
-                service.binding/host_external_db: path={.spec.host_external_db}
-        spec:
-            host_external_db: external.db.stable.example.com
-        """
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: external-db-1sbr
+                annotations:
+                    service.binding/host_external_db: path={.spec.host_external_db}
+            spec:
+                host_external_db: external.db.stable.example.com
+            """
         When Service Binding is applied
             """
             apiVersion: operators.coreos.com/v1alpha1
@@ -105,9 +100,6 @@ Feature: Bind a single application to multiple services
                     kind: Backend
                     name: external-db-1sbr
             """
-
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-1sbr" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-1sbr" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-1sbr" should be changed to "True"
+        Then Service Binding "binding-request-1sbr" is ready
         And The application env var "BACKEND_HOST_INTERNAL_DB" has value "internal.db.stable.example.com"
         And The application env var "BACKEND_HOST_EXTERNAL_DB" has value "external.db.stable.example.com"

--- a/test/acceptance/features/bindAppToService.feature
+++ b/test/acceptance/features/bindAppToService.feature
@@ -30,10 +30,7 @@ Feature: Bind an application to a service
                     kind: Database
                     name: db-demo-a-d-s
             """
-
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-a-d-s" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-a-d-s" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-a-d-s" should be changed to "True"
+        Then Service Binding "binding-request-a-d-s" is ready
         And application should be re-deployed
         And application should be connected to the DB "db-demo-a-d-s"
         And Secret "binding-request-a-d-s" contains "DATABASE_DBNAME" key with value "db-demo-a-d-s"
@@ -68,9 +65,7 @@ Feature: Bind an application to a service
                     name: db-demo-a-s-d
             """
         When DB "db-demo-a-s-d" is running
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-a-s-d" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-a-s-d" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-a-s-d" should be changed to "True"
+        Then Service Binding "binding-request-a-s-d" is ready
         And application should be re-deployed
         And application should be connected to the DB "db-demo-a-s-d"
 
@@ -97,9 +92,7 @@ Feature: Bind an application to a service
                     name: db-demo-d-s-a
             """
         When Imported Nodejs application "nodejs-rest-http-crud-d-s-a" is running
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-d-s-a" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-d-s-a" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-d-s-a" should be changed to "True"
+        Then Service Binding "binding-request-d-s-a" is ready
         And application should be re-deployed
         And application should be connected to the DB "db-demo-d-s-a"
 
@@ -127,9 +120,7 @@ Feature: Bind an application to a service
             """
         * Imported Nodejs application "nodejs-rest-http-crud-s-a-d" is running
         When DB "db-demo-s-a-d" is running
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-s-a-d" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-s-a-d" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-s-a-d" should be changed to "True"
+        Then Service Binding "binding-request-s-a-d" is ready
         And application should be re-deployed
         And application should be connected to the DB "db-demo-s-a-d"
 
@@ -156,9 +147,7 @@ Feature: Bind an application to a service
             """
         * DB "db-demo-s-d-a" is running
         When Imported Nodejs application "nodejs-rest-http-crud-s-d-a" is running
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-s-d-a" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-s-d-a" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-s-d-a" should be changed to "True"
+        Then Service Binding "binding-request-s-d-a" is ready
         And application should be re-deployed
         And application should be connected to the DB "db-demo-s-d-a"
 
@@ -346,9 +335,7 @@ Feature: Bind an application to a service
                     - name: SOME_KEY
                       value: 'SOME_VALUE:{{ .postgresDB.status.dbConnectionPort }}:{{ .postgresDB.status.dbName }}'
             """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-a-d-c" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-a-d-c" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-a-d-c" should be changed to "True"
+        Then Service Binding "binding-request-a-d-c" is ready
         And Secret "binding-request-a-d-c" contains "SOME_KEY" key with value "SOME_VALUE:5432:db-demo-a-d-c"
 
     Scenario: Creating binding secret from the definitions managed in OLM operator descriptors
@@ -552,9 +539,7 @@ Feature: Bind an application to a service
                   name: etcd-cluster-example
               detectBindingResources: true
             """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-etcd" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-etcd" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-etcd" should be changed to "True"
+        Then Service Binding "binding-request-etcd" is ready
         And Application endpoint "/api/todos" is available
 
     @negative
@@ -732,8 +717,5 @@ Feature: Bind an application to a service
                     name: backend-cross-ns-service
                     namespace: backend-services
             """
-
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-cross-ns-service" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-cross-ns-service" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-cross-ns-service" should be changed to "True"
+        Then Service Binding "binding-request-cross-ns-service" is ready
         And The application env var "BACKEND_HOST_CROSS_NS_SERVICE" has value "cross.ns.service.stable.example.com"

--- a/test/acceptance/features/bindAppToServiceAnnotations.feature
+++ b/test/acceptance/features/bindAppToServiceAnnotations.feature
@@ -130,12 +130,11 @@ Feature: Bind an application to a service using annotations
                     version: v1
                     resource: deployments
             """
-        Then The application env var "BACKEND_SPEC_IMAGE" has value "docker.io/postgres"
+        Then Service Binding "rsa-2" is ready
+        And The application env var "BACKEND_SPEC_IMAGE" has value "docker.io/postgres"
         And The application env var "BACKEND_SPEC_IMAGENAME" has value "postgres"
         And The application env var "BACKEND_SPEC_DBNAME" has value "db-demo"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "rsa-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "rsa-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "rsa-2" should be changed to "True"
+
 
     Scenario: Each value in referred slice of strings from service resource gets injected into app as separate env variable
         Given Generic test application "slos-app" is running
@@ -193,8 +192,7 @@ Feature: Bind an application to a service using annotations
                     version: v1
                     resource: deployments
             """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "slos-binding" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "slos-binding" should be changed to "True"
+        Then Service Binding "slos-binding" is ready
         And The application env var "BACKEND_TAGS_0" has value "knowledge"
         And The application env var "BACKEND_TAGS_1" has value "is"
         And The application env var "BACKEND_TAGS_2" has value "power"
@@ -258,8 +256,7 @@ Feature: Bind an application to a service using annotations
                     version: v1
                     resource: deployments
             """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "slom-to-slos-binding" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "slom-to-slos-binding" should be changed to "True"
+        Then Service Binding "slom-to-slos-binding" is ready
         And The application env var "BACKEND_URL_0" has value "primary.example.com"
         And The application env var "BACKEND_URL_1" has value "secondary.example.com"
         And The application env var "BACKEND_URL_2" has value "black-hole.example.com"
@@ -323,9 +320,7 @@ Feature: Bind an application to a service using annotations
                     version: v1
                     resource: deployments
             """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "slom-binding" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "slom-binding" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "slom-binding" should be changed to "True"
+        Then Service Binding "slom-binding" is ready
         And The application env var "BACKEND_WEBARROWS_PRIMARY" has value "primary.example.com"
         And The application env var "BACKEND_WEBARROWS_SECONDARY" has value "secondary.example.com"
         And The application env var "BACKEND_WEBARROWS_404" has value "black-hole.example.com"

--- a/test/acceptance/features/bindAppToServiceUsingConfigMap.feature
+++ b/test/acceptance/features/bindAppToServiceUsingConfigMap.feature
@@ -8,152 +8,145 @@ Feature: Bind values from a config map referred in backing service resource
         * Service Binding Operator is running
 
     Scenario: Inject into app a key from a config map referred within service resource
-                Binding definition is declared on service CRD.
+        Binding definition is declared on service CRD.
 
         Given OLM Operator "backend" is running
         And Generic test application "cmsa-1" is running
         And The Custom Resource Definition is present
-        """
-        apiVersion: apiextensions.k8s.io/v1beta1
-        kind: CustomResourceDefinition
-        metadata:
-            name: backends.stable.example.com
-            annotations:
-                service.binding/username: path={.status.data.dbConfiguration},objectType=ConfigMap,valueKey=username
-        spec:
-            group: stable.example.com
-            versions:
-              - name: v1
-                served: true
-                storage: true
-            scope: Namespaced
-            names:
-                plural: backends
-                singular: backend
-                kind: Backend
-                shortNames:
-                  - bk
-        """
+            """
+            apiVersion: apiextensions.k8s.io/v1beta1
+            kind: CustomResourceDefinition
+            metadata:
+                name: backends.stable.example.com
+                annotations:
+                    service.binding/username: path={.status.data.dbConfiguration},objectType=ConfigMap,valueKey=username
+            spec:
+                group: stable.example.com
+                versions:
+                  - name: v1
+                    served: true
+                    storage: true
+                scope: Namespaced
+                names:
+                    plural: backends
+                    singular: backend
+                    kind: Backend
+                    shortNames:
+                      - bk
+            """
         And The ConfigMap is present
-        """
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-            name: cmsa-1-configmap
-        data:
-            certificate: "certificate value"
-        """
-        And The Custom Resource is present
-        """
-        apiVersion: stable.example.com/v1
-        kind: Backend
-        metadata:
-            name: cmsa-1-service
-        spec:
-            image: docker.io/postgres
-            imageName: postgres
-            dbName: db-demo
-        status:
+            """
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+                name: cmsa-1-configmap
             data:
-                dbConfiguration: cmsa-1-configmap    # ConfigMap
-        """
-        When Service Binding is applied
-        """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ServiceBinding
-        metadata:
-            name: cmsa-1
-        spec:
-            services:
-              - group: stable.example.com
-                version: v1
-                kind: Backend
+                certificate: "certificate value"
+            """
+        And The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
                 name: cmsa-1-service
-            application:
+            spec:
+                image: docker.io/postgres
+                imageName: postgres
+                dbName: db-demo
+            status:
+                data:
+                    dbConfiguration: cmsa-1-configmap    # ConfigMap
+            """
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
                 name: cmsa-1
-                group: apps
-                version: v1
-                resource: deployments
-
-        """
-        Then The application env var "BACKEND_CERTIFICATE" has value "certificate value"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "cmsa-1" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "cmsa-1" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "cmsa-1" should be changed to "True"
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: cmsa-1-service
+                application:
+                    name: cmsa-1
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding "cmsa-1" is ready
+        And The application env var "BACKEND_CERTIFICATE" has value "certificate value"
 
     Scenario: Inject into app all keys from a config map referred within service resource
-                Binding definition is declared on service CRD.
+        Binding definition is declared on service CRD.
 
         Given OLM Operator "backend" is running
         And Generic test application "cmsa-2" is running
         And The Custom Resource Definition is present
-        """
-        apiVersion: apiextensions.k8s.io/v1beta1
-        kind: CustomResourceDefinition
-        metadata:
-            name: backends.stable.example.com
-            annotations:
-                service.binding: path={.status.data.dbConfiguration},objectType=ConfigMap,elementType=map
-        spec:
-            group: stable.example.com
-            versions:
-              - name: v1
-                served: true
-                storage: true
-            scope: Namespaced
-            names:
-                plural: backends
-                singular: backend
-                kind: Backend
-                shortNames:
-                  - bk
-        """
+            """
+            apiVersion: apiextensions.k8s.io/v1beta1
+            kind: CustomResourceDefinition
+            metadata:
+                name: backends.stable.example.com
+                annotations:
+                    service.binding: path={.status.data.dbConfiguration},objectType=ConfigMap,elementType=map
+            spec:
+                group: stable.example.com
+                versions:
+                  - name: v1
+                    served: true
+                    storage: true
+                scope: Namespaced
+                names:
+                    plural: backends
+                    singular: backend
+                    kind: Backend
+                    shortNames:
+                      - bk
+            """
         And The ConfigMap is present
-        """
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-            name: cmsa-2-configmap
-        data:
-            timeout: "30"
-            certificate: certificate value
-        """
-        And The Custom Resource is present
-        """
-        apiVersion: stable.example.com/v1
-        kind: Backend
-        metadata:
-            name: cmsa-2-service
-        spec:
-            image: docker.io/postgres
-            imageName: postgres
-            dbName: db-demo
-        status:
+            """
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+                name: cmsa-2-configmap
             data:
-                dbConfiguration: cmsa-2-configmap    # ConfigMap
-        """
-        When Service Binding is applied
-        """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ServiceBinding
-        metadata:
-            name: cmsa-2
-        spec:
-            services:
-              - group: stable.example.com
-                version: v1
-                kind: Backend
+                timeout: "30"
+                certificate: certificate value
+            """
+        And The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
                 name: cmsa-2-service
-            application:
+            spec:
+                image: docker.io/postgres
+                imageName: postgres
+                dbName: db-demo
+            status:
+                data:
+                    dbConfiguration: cmsa-2-configmap    # ConfigMap
+            """
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
                 name: cmsa-2
-                group: apps
-                version: v1
-                resource: deployments
-
-        """
-        Then The application env var "BACKEND_CERTIFICATE" has value "certificate value"
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: cmsa-2-service
+                application:
+                    name: cmsa-2
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding "cmsa-2" is ready
         And The application env var "BACKEND_CERTIFICATE" has value "certificate value"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "cmsa-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "cmsa-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "cmsa-2" should be changed to "True"
-
+        And The application env var "BACKEND_CERTIFICATE" has value "certificate value"

--- a/test/acceptance/features/bindAppToServiceUsingSecret.feature
+++ b/test/acceptance/features/bindAppToServiceUsingSecret.feature
@@ -8,419 +8,389 @@ Feature: Bind values from a config map referred in backing service resource
         * Service Binding Operator is running
 
     Scenario: Inject into app a key from a secret referred within service resource
-                Binding definition is declared on service CRD.
+        Binding definition is declared on service CRD.
         Given OLM Operator "backend" is running
         And Generic test application "ssa-1" is running
         And The Custom Resource Definition is present
-        """
-        apiVersion: apiextensions.k8s.io/v1beta1
-        kind: CustomResourceDefinition
-        metadata:
-            name: backends.stable.example.com
-            annotations:
-                service.binding/username: path={.status.data.dbCredentials},objectType=Secret,valueKey=username
-        spec:
-            group: stable.example.com
-            versions:
-              - name: v1
-                served: true
-                storage: true
-            scope: Namespaced
-            names:
-                plural: backends
-                singular: backend
-                kind: Backend
-                shortNames:
-                  - bk
-        """
+            """
+            apiVersion: apiextensions.k8s.io/v1beta1
+            kind: CustomResourceDefinition
+            metadata:
+                name: backends.stable.example.com
+                annotations:
+                    service.binding/username: path={.status.data.dbCredentials},objectType=Secret,valueKey=username
+            spec:
+                group: stable.example.com
+                versions:
+                  - name: v1
+                    served: true
+                    storage: true
+                scope: Namespaced
+                names:
+                    plural: backends
+                    singular: backend
+                    kind: Backend
+                    shortNames:
+                      - bk
+            """
         And The Secret is present
-        """
-        apiVersion: v1
-        kind: Secret
-        metadata:
-            name: ssa-1-secret
-        stringData:
-            username: AzureDiamond
-        """
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: ssa-1-secret
+            stringData:
+                username: AzureDiamond
+            """
         And The Custom Resource is present
-        """
-        apiVersion: stable.example.com/v1
-        kind: Backend
-        metadata:
-            name: ssa-1-service
-        spec:
-            image: docker.io/postgres
-            imageName: postgres
-            dbName: db-demo
-        status:
-            data:
-                dbCredentials: ssa-1-secret
-        """
-        When Service Binding is applied
-        """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ServiceBinding
-        metadata:
-            name: ssa-1
-        spec:
-            services:
-              - group: stable.example.com
-                version: v1
-                kind: Backend
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
                 name: ssa-1-service
-            application:
+            spec:
+                image: docker.io/postgres
+                imageName: postgres
+                dbName: db-demo
+            status:
+                data:
+                    dbCredentials: ssa-1-secret
+            """
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
                 name: ssa-1
-                group: apps
-                version: v1
-                resource: deployments
-        """
-        Then The application env var "BACKEND_USERNAME" has value "AzureDiamond"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "ssa-1" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "ssa-1" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "ssa-1" should be changed to "True"
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: ssa-1-service
+                application:
+                    name: ssa-1
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding "ssa-1" is ready
+        And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
 
     Scenario: Inject into app all keys from a secret referred within service resource
-            Binding definition is declared on service CRD.
+        Binding definition is declared on service CRD.
 
         Given OLM Operator "backend" is running
         And Generic test application "ssa-2" is running
         And The Custom Resource Definition is present
-        """
-        apiVersion: apiextensions.k8s.io/v1beta1
-        kind: CustomResourceDefinition
-        metadata:
-            name: backends.stable.example.com
-            annotations:
-                service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
-        spec:
-            group: stable.example.com
-            versions:
-              - name: v1
-                served: true
-                storage: true
-            scope: Namespaced
-            names:
-                plural: backends
-                singular: backend
-                kind: Backend
-                shortNames:
-                  - bk
-        """
+            """
+            apiVersion: apiextensions.k8s.io/v1beta1
+            kind: CustomResourceDefinition
+            metadata:
+                name: backends.stable.example.com
+                annotations:
+                    service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
+            spec:
+                group: stable.example.com
+                versions:
+                  - name: v1
+                    served: true
+                    storage: true
+                scope: Namespaced
+                names:
+                    plural: backends
+                    singular: backend
+                    kind: Backend
+                    shortNames:
+                      - bk
+            """
         And The Secret is present
-        """
-        apiVersion: v1
-        kind: Secret
-        metadata:
-            name: ssa-2-secret
-        stringData:
-            username: AzureDiamond
-            password: hunter2
-        """
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: ssa-2-secret
+            stringData:
+                username: AzureDiamond
+                password: hunter2
+            """
         And The Custom Resource is present
-        """
-        apiVersion: stable.example.com/v1
-        kind: Backend
-        metadata:
-            name: ssa-2-service
-        spec:
-            image: docker.io/postgres
-            imageName: postgres
-            dbName: db-demo
-        status:
-            data:
-                dbCredentials: ssa-2-secret
-        """
-        When Service Binding is applied
-        """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ServiceBinding
-        metadata:
-            name: ssa-2
-        spec:
-            services:
-              - group: stable.example.com
-                version: v1
-                kind: Backend
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
                 name: ssa-2-service
-            application:
+            spec:
+                image: docker.io/postgres
+                imageName: postgres
+                dbName: db-demo
+            status:
+                data:
+                    dbCredentials: ssa-2-secret
+            """
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
                 name: ssa-2
-                group: apps
-                version: v1
-                resource: deployments
-        """
-        Then The application env var "BACKEND_USERNAME" has value "AzureDiamond"
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: ssa-2-service
+                application:
+                    name: ssa-2
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding "ssa-2" is ready
+        And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "ssa-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "ssa-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "ssa-2" should be changed to "True"
-
 
     Scenario: Inject into app a key from a secret referred within service resource
-                Binding definition is declared via OLM descriptor.
+        Binding definition is declared via OLM descriptor.
 
         Given Generic test application "ssd-1" is running
         And The Custom Resource Definition is present
-        """
-        apiVersion: apiextensions.k8s.io/v1beta1
-        kind: CustomResourceDefinition
-        metadata:
-          name: backends.stable.example.com
-        spec:
-          group: stable.example.com
-          versions:
-            - name: v1
-              served: true
-              storage: true
-          scope: Namespaced
-          names:
-            plural: backends
-            singular: backend
-            kind: Backend
-            shortNames:
-              - bk
-
-        """
-        And The Custom Resource is present
-        """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ClusterServiceVersion
-        metadata:
-          annotations:
-            capabilities: Basic Install
-          name: backend-operator.v0.1.0
-        spec:
-          customresourcedefinitions:
-            owned:
-            - description: Backend is the Schema for the backend API
-              kind: Backend
-              name: backends.stable.example.com
-              version: v1
-              specDescriptors:
-                - description: Host address
-                  displayName: Host address
-                  path: host
-                  x-descriptors:
-                    - service.binding:host
-              statusDescriptors:
-                  - description: db credentials
-                    displayName: db credentials
-                    path: data.dbCredentials
-                    x-descriptors:
-                        - urn:alm:descriptor:io.kubernetes:Secret
-                        - service.binding:username:sourceValue=username
-          displayName: Backend Operator
-          install:
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ClusterServiceVersion
+            metadata:
+              annotations:
+                capabilities: Basic Install
+              name: backend-operator.v0.1.0
             spec:
-              deployments:
-              - name: backend-operator
+              customresourcedefinitions:
+                owned:
+                - description: Backend is the Schema for the backend API
+                  kind: Backend
+                  name: backends.stable.example.com
+                  version: v1
+                  specDescriptors:
+                    - description: Host address
+                      displayName: Host address
+                      path: host
+                      x-descriptors:
+                        - service.binding:host
+                  statusDescriptors:
+                      - description: db credentials
+                        displayName: db credentials
+                        path: data.dbCredentials
+                        x-descriptors:
+                            - urn:alm:descriptor:io.kubernetes:Secret
+                            - service.binding:username:sourceValue=username
+              displayName: Backend Operator
+              install:
                 spec:
-                  replicas: 1
-                  selector:
-                    matchLabels:
-                      name: backend-operator
-                  strategy: {}
-                  template:
-                    metadata:
-                      labels:
-                        name: backend-operator
+                  deployments:
+                  - name: backend-operator
                     spec:
-                      containers:
-                      - command:
-                        - backend-operator
-                        env:
-                        - name: WATCH_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                              fieldPath: metadata.annotations['olm.targetNamespaces']
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                              fieldPath: metadata.name
-                        - name: OPERATOR_NAME
-                          value: backend-operator
-                        image: REPLACE_IMAGE
-                        imagePullPolicy: Always
-                        name: backend-operator
-                        resources: {}
-            strategy: deployment
-        """
+                      replicas: 1
+                      selector:
+                        matchLabels:
+                          name: backend-operator
+                      strategy: {}
+                      template:
+                        metadata:
+                          labels:
+                            name: backend-operator
+                        spec:
+                          containers:
+                          - command:
+                            - backend-operator
+                            env:
+                            - name: WATCH_NAMESPACE
+                              valueFrom:
+                                fieldRef:
+                                  fieldPath: metadata.annotations['olm.targetNamespaces']
+                            - name: POD_NAME
+                              valueFrom:
+                                fieldRef:
+                                  fieldPath: metadata.name
+                            - name: OPERATOR_NAME
+                              value: backend-operator
+                            image: REPLACE_IMAGE
+                            imagePullPolicy: Always
+                            name: backend-operator
+                            resources: {}
+                strategy: deployment
+            """
         And The Secret is present
-        """
-        apiVersion: v1
-        kind: Secret
-        metadata:
-            name: ssd-1-secret
-        stringData:
-            username: AzureDiamond
-        """
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: ssd-1-secret
+            stringData:
+                username: AzureDiamond
+            """
         And The Custom Resource is present
-        """
-        apiVersion: stable.example.com/v1
-        kind: Backend
-        metadata:
-            name: ssd-1-service
-        spec:
-            host: example.com
-        status:
-            data:
-                dbCredentials: ssd-1-secret
-        """
-        When Service Binding is applied
-        """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ServiceBinding
-        metadata:
-            name: ssd-1
-        spec:
-            services:
-              - group: stable.example.com
-                version: v1
-                kind: Backend
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
                 name: ssd-1-service
-            application:
+            spec:
+                host: example.com
+            status:
+                data:
+                    dbCredentials: ssd-1-secret
+            """
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
                 name: ssd-1
-                group: apps
-                version: v1
-                resource: deployments
-        """
-        Then The application env var "BACKEND_USERNAME" has value "AzureDiamond"
-        Then The application env var "BACKEND_HOST" has value "example.com"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "ssd-1" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "ssd-1" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "ssd-1" should be changed to "True"
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: ssd-1-service
+                application:
+                    name: ssd-1
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding "ssd-1" is ready
+        And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
+        And The application env var "BACKEND_HOST" has value "example.com"
 
     Scenario: Inject into app all keys from a secret referred within service resource
-                Binding definition is declared via OLM descriptor.
+        Binding definition is declared via OLM descriptor.
 
         Given Generic test application "ssd-2" is running
         And The Custom Resource Definition is present
-    """
-        apiVersion: apiextensions.k8s.io/v1beta1
-        kind: CustomResourceDefinition
-        metadata:
-            name: backends.stable.example.com
-        spec:
-            group: stable.example.com
-            versions:
-              - name: v1
-                served: true
-                storage: true
-            scope: Namespaced
-            names:
-                plural: backends
-                singular: backend
-                kind: Backend
-                shortNames:
-                  - bk
-        """
-        And The Custom Resource is present
-        """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ClusterServiceVersion
-        metadata:
-          annotations:
-            capabilities: Basic Install
-          name: backend-operator.v0.1.0
-        spec:
-          customresourcedefinitions:
-            owned:
-            - description: Backend is the Schema for the backend API
-              kind: Backend
-              name: backends.stable.example.com
-              version: v1
-              specDescriptors:
-                - description: Host address
-                  displayName: Host address
-                  path: host
-                  x-descriptors:
-                    - service.binding:host
-              statusDescriptors:
-                  - description: db credentials
-                    displayName: db credentials
-                    path: data.dbCredentials
-                    x-descriptors:
-                        - urn:alm:descriptor:io.kubernetes:Secret
-                        - service.binding:elementType=map
-          displayName: Backend Operator
-          install:
+            """
+            apiVersion: apiextensions.k8s.io/v1beta1
+            kind: CustomResourceDefinition
+            metadata:
+                name: backends.stable.example.com
             spec:
-              deployments:
-              - name: backend-operator
-                spec:
-                  replicas: 1
-                  selector:
-                    matchLabels:
-                      name: backend-operator
-                  strategy: {}
-                  template:
-                    metadata:
-                      labels:
-                        name: backend-operator
-                    spec:
-                      containers:
-                      - command:
-                        - backend-operator
-                        env:
-                        - name: WATCH_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                              fieldPath: metadata.annotations['olm.targetNamespaces']
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                              fieldPath: metadata.name
-                        - name: OPERATOR_NAME
-                          value: backend-operator
-                        image: REPLACE_IMAGE
-                        imagePullPolicy: Always
-                        name: backend-operator
-                        resources: {}
-            strategy: deployment
-        """
-        And The Secret is present
-        """
-        apiVersion: v1
-        kind: Secret
-        metadata:
-            name: ssd-2-secret
-        stringData:
-            username: AzureDiamond
-            password: hunter2
-        """
+                group: stable.example.com
+                versions:
+                  - name: v1
+                    served: true
+                    storage: true
+                scope: Namespaced
+                names:
+                    plural: backends
+                    singular: backend
+                    kind: Backend
+                    shortNames:
+                      - bk
+            """
         And The Custom Resource is present
-        """
-        apiVersion: stable.example.com/v1
-        kind: Backend
-        metadata:
-            name: ssd-2-service
-        spec:
-            image: docker.io/postgres
-            imageName: postgres
-            dbName: db-demo
-        status:
-            data:
-                dbCredentials: ssd-2-secret
-        """
-        When Service Binding is applied
-        """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ServiceBinding
-        metadata:
-            name: ssd-2
-        spec:
-            services:
-              - group: stable.example.com
-                version: v1
-                kind: Backend
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ClusterServiceVersion
+            metadata:
+              annotations:
+                capabilities: Basic Install
+              name: backend-operator.v0.1.0
+            spec:
+              customresourcedefinitions:
+                owned:
+                - description: Backend is the Schema for the backend API
+                  kind: Backend
+                  name: backends.stable.example.com
+                  version: v1
+                  specDescriptors:
+                    - description: Host address
+                      displayName: Host address
+                      path: host
+                      x-descriptors:
+                        - service.binding:host
+                  statusDescriptors:
+                      - description: db credentials
+                        displayName: db credentials
+                        path: data.dbCredentials
+                        x-descriptors:
+                            - urn:alm:descriptor:io.kubernetes:Secret
+                            - service.binding:elementType=map
+              displayName: Backend Operator
+              install:
+                spec:
+                  deployments:
+                  - name: backend-operator
+                    spec:
+                      replicas: 1
+                      selector:
+                        matchLabels:
+                          name: backend-operator
+                      strategy: {}
+                      template:
+                        metadata:
+                          labels:
+                            name: backend-operator
+                        spec:
+                          containers:
+                          - command:
+                            - backend-operator
+                            env:
+                            - name: WATCH_NAMESPACE
+                              valueFrom:
+                                fieldRef:
+                                  fieldPath: metadata.annotations['olm.targetNamespaces']
+                            - name: POD_NAME
+                              valueFrom:
+                                fieldRef:
+                                  fieldPath: metadata.name
+                            - name: OPERATOR_NAME
+                              value: backend-operator
+                            image: REPLACE_IMAGE
+                            imagePullPolicy: Always
+                            name: backend-operator
+                            resources: {}
+                strategy: deployment
+            """
+        And The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: ssd-2-secret
+            stringData:
+                username: AzureDiamond
+                password: hunter2
+            """
+        And The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
                 name: ssd-2-service
-            application:
+            spec:
+                image: docker.io/postgres
+                imageName: postgres
+                dbName: db-demo
+            status:
+                data:
+                    dbCredentials: ssd-2-secret
+            """
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
                 name: ssd-2
-                group: apps
-                version: v1
-                resource: deployments
-        """
-        Then The application env var "BACKEND_USERNAME" has value "AzureDiamond"
-        Then The application env var "BACKEND_PASSWORD" has value "hunter2"
-        And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "ssd-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "ssd-2" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "ssd-2" should be changed to "True"
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: ssd-2-service
+                application:
+                    name: ssd-2
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding "ssd-2" is ready
+        And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
+        And The application env var "BACKEND_PASSWORD" has value "hunter2"

--- a/test/acceptance/features/bindKnativeService.feature
+++ b/test/acceptance/features/bindKnativeService.feature
@@ -1,20 +1,20 @@
 Feature: Bind knative service to a service
 
-  As a user of Service Binding Operator
-  I want to bind knative service to services it depends on
+    As a user of Service Binding Operator
+    I want to bind knative service to services it depends on
 
-  Background:
-    Given Namespace [TEST_NAMESPACE] is used
-    * Service Binding Operator is running
-    * PostgreSQL DB operator is installed
+    Background:
+        Given Namespace [TEST_NAMESPACE] is used
+        * Service Binding Operator is running
+        * PostgreSQL DB operator is installed
 
-  Scenario: Bind an imported quarkus app which is deployed as knative service to PostgreSQL database
-    Given Openshift Serverless Operator is running
-    * Knative serving is running
-    * DB "db-demo-knative" is running
-    * Quarkus application "knative-app" is imported as Knative service
-    When Service Binding is applied
-      """
+    Scenario: Bind an imported quarkus app which is deployed as knative service to PostgreSQL database
+        Given Openshift Serverless Operator is running
+        * Knative serving is running
+        * DB "db-demo-knative" is running
+        * Quarkus application "knative-app" is imported as Knative service
+        When Service Binding is applied
+            """
             apiVersion: operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
@@ -38,9 +38,7 @@ Feature: Bind knative service to a service
                   value: "{{ .knav.status.dbCredentials.user }}"
                 - name: DB_PASSWORD
                   value: "{{ .knav.status.dbCredentials.password }}"
-      """
-    Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-knative" should be changed to "True"
-    And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-knative" should be changed to "True"
-    And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-knative" should be changed to "True"
-    And deployment must contain intermediate secret "binding-request-knative"
-    And application should be connected to the DB "db-demo-knative"
+            """
+        Then Service Binding "binding-request-knative" is ready
+        And deployment must contain intermediate secret "binding-request-knative"
+        And application should be connected to the DB "db-demo-knative"

--- a/test/acceptance/features/customEnvVar.feature
+++ b/test/acceptance/features/customEnvVar.feature
@@ -1,16 +1,16 @@
 Feature: Inject custom env variable into application
 
-  As a user of Service Binding Operator
-  I want to inject into application context an env variable
-  whose value might be generated from values available in service resources
+    As a user of Service Binding Operator
+    I want to inject into application context an env variable
+    whose value might be generated from values available in service resources
 
-  Background:
-    Given Namespace [TEST_NAMESPACE] is used
-    * Service Binding Operator is running
+    Background:
+        Given Namespace [TEST_NAMESPACE] is used
+        * Service Binding Operator is running
 
-  Scenario: Sequence from service resource is injected into application using custom env variables without specifying annotations
-    Given OLM Operator "backend" is running
-    * The Custom Resource is present
+    Scenario: Sequence from service resource is injected into application using custom env variables without specifying annotations
+        Given OLM Operator "backend" is running
+        * The Custom Resource is present
             """
             apiVersion: "stable.example.com/v1"
             kind: Backend
@@ -22,8 +22,8 @@ Feature: Inject custom env variable into application
                     - "centos7-12.3"
                     - 123
             """
-    * Generic test application "foo" is running
-    When Service Binding is applied
+        * Generic test application "foo" is running
+        When Service Binding is applied
             """
             apiVersion: operators.coreos.com/v1alpha1
             kind: ServiceBinding
@@ -45,14 +45,12 @@ Feature: Inject custom env variable into application
                    - name: TAGS
                      value: '{{ .backend.spec.tags }}'
             """
-    Then The application env var "TAGS" has value "[centos7-12.3 123]"
-    And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "custom-env-var-from-sequence" should be changed to "True"
-    And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "custom-env-var-from-sequence" should be changed to "True"
-    And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "custom-env-var-from-sequence" should be changed to "True"
+        Then Service Binding "custom-env-var-from-sequence" is ready
+        And The application env var "TAGS" has value "[centos7-12.3 123]"
 
-  Scenario: Map from service resource is injected into application using custom env variables without specifying annotations
-    Given OLM Operator "backend" is running
-    * The Custom Resource is present
+    Scenario: Map from service resource is injected into application using custom env variables without specifying annotations
+        Given OLM Operator "backend" is running
+        * The Custom Resource is present
             """
             apiVersion: "stable.example.com/v1"
             kind: Backend
@@ -64,8 +62,8 @@ Feature: Inject custom env variable into application
                     archive: "false"
                     environment: "demo"
             """
-    * Generic test application "foo2" is running
-    When Service Binding is applied
+        * Generic test application "foo2" is running
+        When Service Binding is applied
             """
             apiVersion: operators.coreos.com/v1alpha1
             kind: ServiceBinding
@@ -87,15 +85,12 @@ Feature: Inject custom env variable into application
                    - name: USER_LABELS
                      value: '{{ .backend.spec.userLabels }}'
             """
-    Then The application env var "USER_LABELS" has value "map[archive:false environment:demo]"
-    And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "custom-env-var-from-map" should be changed to "True"
-    And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "custom-env-var-from-map" should be changed to "True"
-    And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "custom-env-var-from-map" should be changed to "True"
+        Then Service Binding "custom-env-var-from-map" is ready
+        And The application env var "USER_LABELS" has value "map[archive:false environment:demo]"
 
-
-  Scenario: Scalar from service resource is injected into application using custom env variables without specifying annotations
-    Given OLM Operator "backend" is running
-    * The Custom Resource is present
+    Scenario: Scalar from service resource is injected into application using custom env variables without specifying annotations
+        Given OLM Operator "backend" is running
+        * The Custom Resource is present
             """
             apiVersion: "stable.example.com/v1"
             kind: Backend
@@ -107,8 +102,8 @@ Feature: Inject custom env variable into application
                     archive: "false"
                     environment: "demo"
             """
-    * Generic test application "foo3" is running
-    When Service Binding is applied
+        * Generic test application "foo3" is running
+        When Service Binding is applied
             """
             apiVersion: operators.coreos.com/v1alpha1
             kind: ServiceBinding
@@ -130,7 +125,6 @@ Feature: Inject custom env variable into application
                    - name: USER_LABELS_ARCHIVE
                      value: '{{ .backend.spec.userLabels.archive }}'
             """
-    Then The application env var "USER_LABELS_ARCHIVE" has value "false"
-    And jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "custom-env-var-from-scalar" should be changed to "True"
-    And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "custom-env-var-from-scalar" should be changed to "True"
-    And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "custom-env-var-from-scalar" should be changed to "True"
+        Then Service Binding "custom-env-var-from-scalar" is ready
+        And The application env var "USER_LABELS_ARCHIVE" has value "false"
+

--- a/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
+++ b/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
@@ -72,9 +72,7 @@ Feature: Insert service binding to a custom location in application resource
                     id: zzz
                     envVarPrefix: qiye
             """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-csp" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-csp" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-csp" should be changed to "True"
+        Then Service Binding "binding-request-csp" is ready
         And Secret "binding-request-csp" has been injected in to CR "demo-appconfig-csp" of kind "AppConfig" at path "{.spec.spec.containers[0].envFrom[0].secretRef.name}"
 
     Scenario: Specify secret's path in Service Binding
@@ -112,7 +110,5 @@ Feature: Insert service binding to a custom location in application resource
                     id: zzz
                     envVarPrefix: qiye
             """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-ssp" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-request-ssp" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-ssp" should be changed to "True"
+        Then Service Binding "binding-request-ssp" is ready
         And Secret "binding-request-ssp" has been injected in to CR "demo-appconfig-ssp" of kind "AppConfig" at path "{.spec.spec.secret}"

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -247,6 +247,13 @@ def sbo_jq_is(context, jq_expression, sbr_name, json_value):
                   ignore_exceptions=(json.JSONDecodeError,))
 
 
+@step(u'Service Binding "{sbr_name}" is ready')
+def sbo_is_ready(context, sbr_name):
+    sbo_jq_is(context, '.status.conditions[] | select(.type=="CollectionReady").status', sbr_name, 'True')
+    sbo_jq_is(context, '.status.conditions[] | select(.type=="InjectionReady").status', sbr_name, 'True')
+    sbo_jq_is(context, '.status.conditions[] | select(.type=="Ready").status', sbr_name, 'True')
+
+
 @given(u'Openshift Serverless Operator is running')
 def given_serverless_operator_is_running(context):
     """


### PR DESCRIPTION
### Motivation

Currently in a lot of acceptance testing  scenarios 3 steps together are used to verify that the service binding has finished and is ready with by checking the particular status conditions like the following:

```feature
Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "{name}" should be changed to "True"
And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "{name}" should be changed to "True"
And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "{name}" should be changed to "True"
```
All the scenarios that have those steps share a common pattern that only differs with the name of the Service Binding resource.

This can be simplified in a single step such as `Service Binding "{name}" is ready`.

### Changes

This PR:
* Replaces all occurencies the above 3 `status.conditions` checking steps with a single simplified one.

### Testing

`make test-acceptance`