### PR TITLE
Fix (revert) accidental replacement of word Docker in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,7 @@ endif
 merge-to-master-release:
 	echo "${QUAY_TOKEN}" | $(CONTAINER_RUNTIME) login -u "redhat-developer+travis" --password-stdin quay.io
 	$(eval COMMIT_COUNT := $(shell git rev-list --count HEAD))
-	$(Q)$(CONTAINER_RUNTIME) build -f $(CONTAINER_RUNTIME)file.rhel -t $(OPERATOR_IMAGE_REF) .
+	$(Q)$(CONTAINER_RUNTIME) build -f Dockerfile.rhel -t $(OPERATOR_IMAGE_REF) .
 	$(CONTAINER_RUNTIME) push "$(OPERATOR_IMAGE_REF)"
 
 


### PR DESCRIPTION
### Motivation

Recent merge of https://github.com/redhat-developer/service-binding-operator/pull/677/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R459 accidentally replaced `Docker` in name of `Dockerfile.rhel`

### Changes

This PR reverts that replacement to original file name.

### Testing
