### PR TITLE
Restructure Travis CI conf to allow additional jobs in future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-go_import_path: github.com/redhat-developer/service-binding-operator
-sudo: required
 dist: focal
 language: go
 
@@ -20,31 +18,41 @@ env:
     - GH_REPO="github.com/${USER}/${REPO}.git"
     - GH_REMOTE_REPO="github.com/${USER}/service-binding-operator-manifests"
 
-before_install:
-  # Install deps
-  - sudo apt-get update -y
-  - sudo apt-get install python3 python3-venv -y
+services:
+  - docker
 
-  # Download Operator SDK
-  - curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${SDK_VERSION}/operator-sdk-v${SDK_VERSION}-x86_64-linux-gnu && chmod +x operator-sdk && mv operator-sdk $GOPATH/bin/
+addons:
+  apt_packages:
+    - python3
+    - python3-venv
 
-script:
-  # Run merge-to-master-release
-  - if [ "$TRAVIS_BRANCH" = "master" ]; then
-    make merge-to-master-release &&
-    make push-to-manifest-repo &&
-    make prepare-bundle-to-quay || exit 1;
-    fi
+jobs:
+  include:
+    - stage: Push dev image to Quay
+      if: branch = master AND type = push
+      install:
 
-after_success:
-  - MESSAGE=($TRAVIS_COMMIT)
-  - git clone git://${GH_REMOTE_REPO}
-  - cp -r ${FILES} ./service-binding-operator-manifests
-  - cd service-binding-operator-manifests
-  - git config user.email ${EMAIL}
-  - git config user.name ${USER}
-  - git add .
-  - git commit -m ${MESSAGE}
-  - git push "https://${GITHUB_TOKEN}@${GH_REMOTE_REPO}" master > /dev/null 2>&1
-  - cd ..
-  - make push-bundle-to-quay
+        # Download Operator SDK
+        - curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${SDK_VERSION}/operator-sdk-v${SDK_VERSION}-x86_64-linux-gnu
+        - chmod +x operator-sdk
+        - mv operator-sdk $GOPATH/bin/
+
+      script:
+        # Run merge-to-master-release
+        - make merge-to-master-release
+        - make push-to-manifest-repo
+        - make prepare-bundle-to-quay
+
+      after_success:
+        - MESSAGE=($TRAVIS_COMMIT)
+        - git clone git://${GH_REMOTE_REPO}
+        - cp -r ${FILES} ./service-binding-operator-manifests
+        - cd service-binding-operator-manifests
+        - git config user.email ${EMAIL}
+        - git config user.name ${USER}
+        - git add .
+        - git commit -m ${MESSAGE}
+        - git push "https://${GITHUB_TOKEN}@${GH_REMOTE_REPO}" master > /dev/null 2>&1
+        - cd ..
+        - make push-bundle-to-quay
+


### PR DESCRIPTION
* The change opens up the possibility to add additional jobs that will be triggered on PR submission.
* The actual image publishing from master has been moved into stage "Push dev image to Quay"
* The job gets executed only if changes are pushed or merged to `master` branch

