### PR TITLE
Automate building of SBO bundle and index images usable in CatalogSources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/_output
 build/_test
 build/bin
+bundle_tmp*
 
 # operator-courier
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 build/_output
 build/_test
 build/bin
-bundle_tmp*
 
 # operator-courier
 tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ git:
 env:
   global:
     - SDK_VERSION="0.16.0"
+    - OPM_VERSION="1.15.2"
     - GO111MODULE=on
     - USER="redhat-developer"
     - EMAIL="openshift-dev-services@redhat.com"
@@ -37,11 +38,13 @@ jobs:
         - chmod +x operator-sdk
         - mv operator-sdk $GOPATH/bin/
 
+        # Download OPM tool
+        - curl -Lo opm https://github.com/operator-framework/operator-registry/releases/download/v${OPM_VERSION}/linux-amd64-opm
+        - chmod +x opm
+        - mv opm $GOPATH/bin/
+
       script:
-        # Run merge-to-master-release
-        - make merge-to-master-release
-        - make push-to-manifest-repo
-        - make prepare-bundle-to-quay
+        - make release-operator-bundle
 
       after_success:
         - MESSAGE=($TRAVIS_COMMIT)

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
   include:
     - stage: Push bundle and index images to Quay ()
       #if: branch = master AND type = push
-      if: pull_request
+      if: type = pull_request
       install:
 
         # Download Operator SDK

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,6 @@ jobs:
         - git add .
         - git commit -m ${MESSAGE}
         - git push "https://${GITHUB_TOKEN}@${GH_REMOTE_REPO}" master > /dev/null 2>&1
-        - cd ..
-        - make push-bundle-to-quay
     - stage: Acceptance tests
       if: type = pull_request
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ addons:
 
 jobs:
   include:
-    - stage: Push dev image to Quay
-      if: branch = master AND type = push
+    - stage: Push bundle and index images to Quay ()
+      #if: branch = master AND type = push
+      if: pull_request
       install:
 
         # Download Operator SDK

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,5 +83,4 @@ jobs:
         - kubectl cluster-info
         # install OLM
         - curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v${OLM_VERSION}/install.sh | bash -s v${OLM_VERSION}
-      script: make test-acceptance
-
+      script: travis_wait 60 make test-acceptance

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
         - git config user.name ${USER}
         - git add .
         - git commit -m ${MESSAGE}
-        - git push "https://${GITHUB_TOKEN}@${GH_REMOTE_REPO}" master > /dev/null 2>&1
+        #- git push "https://${GITHUB_TOKEN}@${GH_REMOTE_REPO}" master > /dev/null 2>&1
     - stage: Acceptance tests
       if: type = pull_request
       env:

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,9 @@ GIT_COMMIT_ID ?= $(shell git rev-parse --short HEAD)
 
 OPERATOR_VERSION ?= 0.3.0
 OPERATOR_GROUP ?= ${GO_PACKAGE_ORG_NAME}
-OPERATOR_IMAGE ?= quay.io/${OPERATOR_GROUP}/${GO_PACKAGE_REPO_NAME}
-OPERATOR_IMAGE_REL ?= quay.io/${OPERATOR_GROUP}/app-binding-operator
+#OPERATOR_BUNDLE_IMAGE ?= quay.io/${OPERATOR_GROUP}/${GO_PACKAGE_REPO_NAME}
+OPERATOR_BUNDLE_IMAGE ?= quay.io/${OPERATOR_GROUP}/servicebinding-operator
+OPERATOR_IMAGE ?= quay.io/${OPERATOR_GROUP}/app-binding-operator
 OPERATOR_TAG_SHORT ?= $(OPERATOR_VERSION)
 OPERATOR_TAG_LONG ?= $(OPERATOR_VERSION)-$(GIT_COMMIT_ID)
 OPERATOR_IMAGE_BUILDER ?= buildah
@@ -135,7 +136,7 @@ OPERATOR_SDK_EXTRA_ARGS ?= "--debug"
 COMMIT_COUNT := $(shell git rev-list --count HEAD)
 BASE_BUNDLE_VERSION ?= $(OPERATOR_VERSION)
 BUNDLE_VERSION ?= $(BASE_BUNDLE_VERSION)-$(COMMIT_COUNT)
-OPERATOR_IMAGE_REF ?= $(OPERATOR_IMAGE_REL):$(GIT_COMMIT_ID)
+OPERATOR_IMAGE_REF ?= $(OPERATOR_IMAGE):$(GIT_COMMIT_ID)
 CSV_PACKAGE_NAME ?= $(GO_PACKAGE_REPO_NAME)
 CSV_CREATION_TIMESTAMP ?= $(shell TZ=GMT date '+%FT%TZ')
 
@@ -454,22 +455,22 @@ prepare-bundle-to-quay:
 .PHONY: build-bundle-image
 ## build bundle image
 build-bundle-image:
-	$(Q)operator-sdk bundle create --directory $(MANIFESTS_TMP)/$(BUNDLE_VERSION) -b $(CONTAINER_RUNTIME) --package $(CSV_PACKAGE_NAME) --channels beta,alpha --default-channel beta $(VERBOSE_FLAG) "quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME):$(BUNDLE_VERSION)"
+	$(Q)operator-sdk bundle create --directory $(MANIFESTS_TMP)/$(BUNDLE_VERSION) -b $(CONTAINER_RUNTIME) --package $(CSV_PACKAGE_NAME) --channels beta,alpha --default-channel beta $(VERBOSE_FLAG) "$(OPERATOR_BUNDLE_IMAGE):$(BUNDLE_VERSION)"
 
 .PHONY: push-bundle-image
 ## push bundle image
 push-bundle-image:
-	$(Q)$(CONTAINER_RUNTIME) push "quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME):$(BUNDLE_VERSION)"
+	$(Q)$(CONTAINER_RUNTIME) push "$(OPERATOR_BUNDLE_IMAGE):$(BUNDLE_VERSION)"
 
 .PHONY: build-bundle-index-image
 ## build bundle index image
 build-bundle-index-image:
-	$(Q)opm index add -u $(CONTAINER_RUNTIME) --bundles quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME):$(BUNDLE_VERSION) --tag "quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME):index"
+	$(Q)opm index add -u $(CONTAINER_RUNTIME) --bundles "$(OPERATOR_BUNDLE_IMAGE):$(BUNDLE_VERSION)" --tag "$(OPERATOR_BUNDLE_IMAGE):index"
 
 .PHONY: push-bundle-index-image
 ## push bundle index image
 push-bundle-index-image:
-	$(Q)$(CONTAINER_RUNTIME) push "quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME):index"
+	$(Q)$(CONTAINER_RUNTIME) push "$(OPERATOR_BUNDLE_IMAGE):index"
 
 .PHONY: release-operator-bundle
 ## Build and release operator bundle and operator bundle index

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ OPERATOR_IMAGE_REF ?= $(OPERATOR_IMAGE):$(GIT_COMMIT_ID)
 CSV_PACKAGE_NAME ?= $(GO_PACKAGE_REPO_NAME)
 CSV_CREATION_TIMESTAMP ?= $(shell TZ=GMT date '+%FT%TZ')
 
-QUAY_USERNAME ?= redhat-developer+travis
+QUAY_USERNAME ?= redhat-developer+deployer
 QUAY_TOKEN ?= ""
 QUAY_BUNDLE_TOKEN ?= ""
 

--- a/Makefile
+++ b/Makefile
@@ -509,12 +509,12 @@ push-bundle-image:
 .PHONY: build-bundle-index-image
 ## build bundle index image
 build-bundle-index-image:
-	$(Q)opm index add -u $(CONTAINER_RUNTIME) --bundles quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME)-bundle:$(BUNDLE_VERSION) --tag "quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME)-index:$(BUNDLE_VERSION)"
+	$(Q)opm index add -u $(CONTAINER_RUNTIME) --bundles quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME)-bundle:$(BUNDLE_VERSION) --tag "quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME)-index:master"
 
 .PHONY: push-bundle-index-image
 ## push bundle index image
 push-bundle-index-image:
-	$(Q)$(CONTAINER_RUNTIME) push "quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME)-index:$(BUNDLE_VERSION)"
+	$(Q)$(CONTAINER_RUNTIME) push "quay.io/$(OPERATOR_GROUP)/$(GO_PACKAGE_REPO_NAME)-index:master"
 
 .PHONY: release-operator-bundle
 ## Build and release operator bundle and operator bundle index


### PR DESCRIPTION
### Motivation

Currently there is no direct way to produce SBO bundle and index images.

Jira issue: [APPSVC-766](https://issues.redhat.com/browse/APPSVC-766)

### Changes

This PR:
* Adds Makefile targets for building such operator bundle index image that can be used in `CatalogSources`.
* Adds `release-operator-bundle` Makefile target to run all the necessary steps to do a release to quay such as building operator, operator bundle and bundle index, and pushing it to quay.
* Adds that release target into Travis job that builds operator bundle for each merge-to-master, so that an index image is build for each merge to master, too.

### Testing

1. Set the following env variables:
* `QUAY_TOKEN`
* `QUAY_USERNAME`
* `OPERATOR_GROUP` ... usually same as Quay username
2. Run `make release-operator-bundle`
3. Create a catalog source referencing the above index image
```sh
kubectl apply -f - << EOD
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: sbo-test-catalog
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: REPLACE_IMAGE
  displayName: Community Operators
  publisher: Red Hat
EOD
```
4. Install SBO via OperatorHub or Subscription YAML as usual with the appropriate CSV version