### PR TITLE
Automate building of SBO bundle index images usable in CatalogSources on each merge to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ git:
 env:
   global:
     - SDK_VERSION="0.16.0"
+    - OPM_VERSION="1.15.2"
     - GO111MODULE=on
     - USER="redhat-developer"
     - EMAIL="openshift-dev-services@redhat.com"
@@ -28,7 +29,7 @@ addons:
 
 jobs:
   include:
-    - stage: Push dev image to Quay
+    - stage: Release operator on Quay.io
       if: branch = master AND type = push
       install:
 
@@ -37,11 +38,13 @@ jobs:
         - chmod +x operator-sdk
         - mv operator-sdk $GOPATH/bin/
 
+        # Download OPM tool
+        - curl -Lo opm https://github.com/operator-framework/operator-registry/releases/download/v${OPM_VERSION}/linux-amd64-opm
+        - chmod +x opm
+        - mv opm $GOPATH/bin/
+
       script:
-        # Run merge-to-master-release
-        - make merge-to-master-release
-        - make push-to-manifest-repo
-        - make prepare-bundle-to-quay
+        - make release-operator
 
       after_success:
         - MESSAGE=($TRAVIS_COMMIT)
@@ -53,8 +56,6 @@ jobs:
         - git add .
         - git commit -m ${MESSAGE}
         - git push "https://${GITHUB_TOKEN}@${GH_REMOTE_REPO}" master > /dev/null 2>&1
-        - cd ..
-        - make push-bundle-to-quay
     - stage: Acceptance tests
       if: type = pull_request
       env:


### PR DESCRIPTION
### Motivation

Currently there is no direct way to produce SBO bundle and index images.

Jira issue: [APPSVC-766](https://issues.redhat.com/browse/APPSVC-766)

### Changes

This PR:
* Adds Makefile targets for building such operator bundle index image that can be used in `CatalogSources`.
* Adds `release-operator` Makefile target to run all the necessary steps to do a release to quay such as building operator, operator bundle and bundle index, and pushing it to quay.
* Adds that release target into Travis job that builds operator bundle for each merge-to-master, so that an index image is build for each merge to master, too.
* Replaces versioning scheme from `<operator_version>-<commit_count>` to `<operator_version>-<commit_short_sha>`
* Replaces operator image ref in CSV to use `@sha256:...` digest instead of tag.

### Testing

1. Set the following env variables:
* `export QUAY_TOKEN=...`
* `export QUAY_USERNAME=...`
* `export OPERATOR_REPO_REF=quay.io/$QUAY_USERNAME/servicebinding-operator`
2. Run `make release-operator`
3. Create a catalog source referencing the above index image
```sh
kubectl apply -f - << EOD
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
    name: rhd-servicebinding-operator
    namespace: openshift-marketplace
spec:
    sourceType: grpc
    image: quay.io/$QUAY_USERNAME/servicebinding-operator:index
    displayName: Red Hat Developer Service Binding Operator (latest master)
EOD
```
4. Install SBO via OperatorHub or Subscription YAML as usual with the appropriate CSV version
5. Run smoke tests:
```sh
SBO_NAMESPACE=openshift-operators TEST_ACCEPTANCE_START_SBO=remote  make test-acceptance-smoke
```