### PR TITLE
Increase Travis waiting to 30mins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,5 +80,5 @@ jobs:
         - kubectl cluster-info
         # install OLM
         - curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v${OLM_VERSION}/install.sh | bash -s v${OLM_VERSION}
-      script: make test-acceptance
+      script: travis_wait 30 make test-acceptance
 


### PR DESCRIPTION
By default Travis cancel the job if no new output is produced within 10 minutes. Some of our acceptance test steps can be slower on some infrastructures/VMs. Hence, let's increase the timeout to prevent premature job cancellation.