### PR TITLE
Step "Content of file in application pod" does not fail in case of connection errors

### DIFF
--- a/test/acceptance/features/steps/generic_testapp.py
+++ b/test/acceptance/features/steps/generic_testapp.py
@@ -21,7 +21,7 @@ class GenericTestApp(App):
 
     def get_file_value(self, file_path):
         resp = polling2.poll(lambda: requests.get(url=f"http://{self.route_url}{file_path}"),
-                             check_success=lambda r: r.status_code == 200, step=5, timeout=400)
+                             check_success=lambda r: r.status_code == 200, step=5, timeout=400, ignore_exceptions=(requests.exceptions.ConnectionError,))
         print(f'file endpoint response: {resp.text} code: {resp.status_code}')
         return resp.text
 


### PR DESCRIPTION
The issue was detected in https://travis-ci.org/github/redhat-developer/service-binding-operator/builds/747368812

polling call in `GenericTestApp.get_file_value()` ignores now `ConnectionError`
and keeps trying to retrieve the file until reaching the given timeout.
