### PR TITLE
run acceptance tests on Travis against the operator installed in the cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     - GH_REMOTE_REPO="github.com/${USER}/service-binding-operator-manifests"
     - MINIKUBE_VERSION="1.15.1"
     - K8S_VERSION="1.19.2"
-    - OLM_VERSION="0.17.0"
 
 services:
   - docker
@@ -65,7 +64,19 @@ jobs:
         # exclude knative and example annotated tests
         - EXTRA_BEHAVE_ARGS="--tags=~@knative --tags=~@examples"
         - TEST_ACCEPTANCE_CLI="kubectl"
+        - TEST_ACCEPTANCE_START_SBO="remote"
+        - SBO_NAMESPACE=operators
       install:
+        # Download Operator SDK
+        - curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${SDK_VERSION}/operator-sdk-v${SDK_VERSION}-x86_64-linux-gnu
+        - chmod +x operator-sdk
+        - mv operator-sdk $GOPATH/bin/
+
+        # Download OPM tool
+        - curl -Lo opm https://github.com/operator-framework/operator-registry/releases/download/v${OPM_VERSION}/linux-amd64-opm
+        - chmod +x opm
+        - mv opm $GOPATH/bin/
+
         # install kubectl
         - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl
         - chmod +x kubectl
@@ -76,10 +87,13 @@ jobs:
         - sudo mv minikube /usr/local/bin/
         # start minikube
         - touch $KUBECONFIG
-        - minikube start --kubernetes-version=v${K8S_VERSION} --cpus $(nproc) --memory $(free -tm | grep "Total:" | awk '{print $2}')m
+        - ./hack/start-minikube.sh start --kubernetes-version=v${K8S_VERSION} --cpus $(nproc) --memory $(free -tm | grep "Total:" | awk '{print $2}')m
+        - eval $(minikube docker-env)
         - kubectl get nodes -o yaml
         - kubectl cluster-info
-        # install OLM
-        - curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v${OLM_VERSION}/install.sh | bash -s v${OLM_VERSION}
-      script: travis_wait 60 make test-acceptance
+        - docker info
+      script:
+        - OPERATOR_REPO_REF=$(minikube ip):5000/sbo make release-operator -o registry-login
+        - OPERATOR_INDEX_IMAGE=$(minikube ip):5000/sbo:index SKIP_REGISTRY_LOGIN=true ./install.sh
+        - travis_wait 60 make test-acceptance
 

--- a/hack/start-minikube.sh
+++ b/hack/start-minikube.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+minikube start --addons=registry --insecure-registry=0.0.0.0/0 "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,42 +1,57 @@
 #!/bin/bash -e
-set -u
+
+OLM_VERSION=0.17.0
+OPERATOR_INDEX_IMAGE=${OPERATOR_INDEX_IMAGE:-registry.redhat.io/redhat/community-operator-index:latest}
+OPERATOR_REGISTRY_REF=$(echo $OPERATOR_INDEX_IMAGE | cut -f 1 -d '/')
+OPERATOR_CHANNEL=${OPERATOR_CHANNEL:-beta}
+DOCKER_CFG=${DOCKER_CFG:-$HOME/.docker/config.json}
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 
 #The SBO can also be installed in a vanilla kubernetes cluster. A prerequisite for this would be to add credentials for the registry.redhat.io in the cluster. Steps to be followed to achieve the same are listed below:
 #1) Follow [Red Hat Container Registry Authentication Steps](https://access.redhat.com/RegistryAuthentication)
 #2) Verify that your credentials are correct using docker login -u <your_username> -p <your_passwd> registry.redhat.io
-docker login registry.redhat.io
+
+if [ -z "$SKIP_REGISTRY_LOGIN" ]; then
+  if [ -z "$OPERATOR_REGISTRY_USERNAME" ]; then
+    ${CONTAINER_RUNTIME} login $OPERATOR_REGISTRY_REF
+  else
+    ${CONTAINER_RUNTIME} login -u "$OPERATOR_REGISTRY_USERNAME" --pasword-stdin $OPERATOR_REGISTRY_REF <<<$OPERATOR_REGISTRY_PASSWORD
+  fi
+fi
 
 #3) Start a kubernetes cluster. Any Kubernetes cluster can be used as well. The script assumes that a Kubernetes is up and running and the user has logged into it.
 
 #4) Enable [OLM](https://github.com/operator-framework/operator-lifecycle-manager) in the cluster by running the following command
-curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.16.1/install.sh | bash -s 0.16.1
+curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v${OLM_VERSION}/install.sh | bash -s v${OLM_VERSION}
 #On minikube you can alternatively install OLM by running `minikube addons enable olm`
 
 #5) Create a new image pull secret out of your local .docker/config.json file
-kubectl create secret generic community-operators-secrets -n olm --from-file=.dockerconfigjson=$HOME/.docker/config.json --type=kubernetes.io/dockerconfigjson
+if [ -r "$DOCKER_CFG" ]; then
+  kubectl create secret generic sbo-operators-secrets -n olm --from-file=.dockerconfigjson=$DOCKER_CFG --type=kubernetes.io/dockerconfigjson
 
-#6) Add that pull secret to the default account in olm namespace
-kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "community-operators-secrets"}]}' -n=olm
+  #6) Add that pull secret to the default account in olm namespace
+  kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "sbo-operators-secrets"}]}' -n=olm
+fi
 
 #7) Install the operator by running the following commands
-#Apply CatalogSource for obtaining catalog of community operators
+#Apply CatalogSource for obtaining catalog of SBO operators
 kubectl apply -f - << EOD
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: community-operators
+  name: sbo-operators
   namespace: olm
 spec:
-  displayName: Community Operators
-  image: registry.redhat.io/redhat/community-operator-index:latest
+  displayName: SBO Operators
+  image: $OPERATOR_INDEX_IMAGE
   sourceType: grpc
   publisher: Red Hat
   updateStrategy:
     registryPoll:
       interval: 10m0s
 EOD
-#Apply subscription for subscribing to the beta channel of the service binding operator
+#Apply subscription for subscribing to the requested channel of the service binding operator
 kubectl apply -f - << EOD
 ---
 apiVersion: operators.coreos.com/v1alpha1
@@ -45,10 +60,10 @@ metadata:
   name: service-binding-operator
   namespace: operators
 spec:
-  channel: 'beta'
+  channel: $OPERATOR_CHANNEL
   installPlanApproval: Automatic
   name: service-binding-operator
-  source: community-operators
+  source: sbo-operators
   sourceNamespace: olm
 EOD
 #This Operator will be installed in the "operators" namespace and will be usable from all namespaces in the cluster.


### PR DESCRIPTION
Such approach is much closer to reality and can catch various packaging and installation issues.

`install.sh` script got updated to support:
* Installing an arbitrary index image, configurable via `OPERATOR_INDEX_IMAGE` env var
* Installing from an arbitrary channel, configurable via `OPERATOR_CHANNEL` env var
* container runtime can be specified via `CONTAINER_RUNTIME` env var (default: docker)
* installed OLM version is now 0.17.0
* Registries authentication can be skipped by setting `SKIP_REGISTRY_LOGIN` env var
* Non interactive registry logins are supported via setting `OPERATOR_REGISTRY_USERNAME` and `OPERATOR_REGISTRY_PASSWORD` env vars
* Location of Docker `config.json` file can be customized through `DOCKER_CFG` env var. In combination with
  non-interactive logins, the script can push to clusters authorization tokens for multiple registries, if needed

Travis configuration:
* Operator, bundle and index image are ephemeral and therefore not pushed to quay
  Instead, minikube registry addon is enabled (`hack/start-minikube.sh`), and minikube docker engine is used for building
  and pushing of all needed images
* The operator is installed in the minikube cluster using `install.sh`
* Acceptance tests are configure to run in remote mode.