### PR TITLE
Add `prepare-operatorhub-pr` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,3 +490,9 @@ dev-release:
 validate-release: setup-venv
 	$(Q)$(PYTHON_VENV_DIR)/bin/pip install yq==2.10.0
 	BUNDLE_VERSION=$(BASE_BUNDLE_VERSION) CHANNEL="beta" ./hack/validate-release.sh
+
+.PHONY: prepare-operatorhub-pr
+## prepare files for OperatorHub PR
+## use this target when the operator needs to be released as upstream operator
+prepare-operatorhub-pr:
+	./hack/prepare-operatorhub-pr.sh $(OPERATOR_VERSION) $(OPERATOR_BUNDLE_IMAGE_REF)

--- a/hack/prepare-operatorhub-pr.sh
+++ b/hack/prepare-operatorhub-pr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env -S bash -e
+
+# Required CLIs
+# - https://github.com/opencontainers/umoci
+# - https://github.com/containers/skopeo
+
+# Usage:
+# prepare-operatorhu-pr.sh <version> <bundle-image-ref>
+
+TMP_OCI_PATH=$(mktemp -d out/sbo-bundle-oci.XXX)
+
+skopeo copy docker://$2 oci:$TMP_OCI_PATH:bundle
+umoci unpack --image $TMP_OCI_PATH:bundle --rootless ${TMP_OCI_PATH}-unpacked
+rm -rf out/operatorhub-pr-files
+mkdir out/operatorhub-pr-files/service-binding-operator -p
+mv ${TMP_OCI_PATH}-unpacked/rootfs out/operatorhub-pr-files/service-binding-operator/$1
+
+cat <<EOD
+Done.
+
+Now you can copy the content of out/operatorhub-pr-files/service-binding-operator
+into 'upstream-community-operators/service-binding-operator' folder of your local clone of
+
+  github.com/operator-framework/community-operators
+
+and submit a pull request.
+EOD


### PR DESCRIPTION
The target extracts files from published bundle image (default: for the current HEAD commit)
and place them into `out/operatorhub-pr-files/service-binding-operator` folder so that they
could be easily copied into local clone of `github.com/operator-framework/community-operators`,
creating PR afterwards.



### Motivation

The added target makes the operator publishing to the upstream easier:

* Use already bundles published from master, no need to build any images
* The existing bundles are already verified, i.e. acceptance tests passed on
  them
* The bundles refer images using shas, so the published upstream operator
has already support for air-gapped installations