### PR TITLE
Makefile GIT_COMMIT_ID length set to 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ GOCOV_DIR ?= $(ARTIFACT_DIR)/test-coverage
 GOCOV_FILE_TEMPL ?= $(GOCOV_DIR)/REPLACE_TEST.txt
 GOCOV ?= "-covermode=atomic -coverprofile REPLACE_FILE"
 
-GIT_COMMIT_ID ?= $(shell git rev-parse --short HEAD)
+GIT_COMMIT_ID ?= $(shell git rev-parse --short=8 HEAD)
 
 OPERATOR_VERSION ?= 0.4.0
 OPERATOR_REGISTRY ?= quay.io


### PR DESCRIPTION
When reading short sha using `git rev-parse --short`, the default length might be different on various machines.
Since short commit id used in many places in the release process, we need to fix to a known size to avoid surprises.

[This Travis job](https://travis-ci.org/github/redhat-developer/service-binding-operator/builds/748306646#L272) shows for example that `GIT_COMMIT_ID` was of size 7, but on my machine its size is 8.