### PR TITLE
Fix reading codecov.io token from CODECOV_TOKEN_PATH.

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -27,6 +27,8 @@ coverage:
     - "manifests/*"
     - "openshift-ci/*"
     - "vendor/*"
+    - "Makefile"
+    - ".travis.yml"
 
 # See http://docs.codecov.io/docs/pull-request-comments-1
 comment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,15 @@ jobs:
       script:
         - make release-operator
 
+    - stage: Unit tests with code coverage for merge-to-master commits
+      if: branch = master AND type = push
+      env:
+        - CODECOV_TOKEN_PATH=.codecov.token
+      install:
+        - echo $CODECOV_TOKEN > $CODECOV_TOKEN_PATH
+      script:
+        - make PR_COMMIT=null VERBOSE=2 BASE_COMMIT=$TRAVIS_COMMIT REPO_SLUG=$TRAVIS_REPO_SLUG test-unit-with-coverage upload-codecov-report
+
     - stage: Acceptance tests
       if: type = pull_request
       env:

--- a/Makefile
+++ b/Makefile
@@ -393,22 +393,23 @@ clean:
 ## Uploads the test coverage reports to codecov.io.
 ## DO NOT USE LOCALLY: must only be called by OpenShift CI when processing new PR and when a PR is merged!
 upload-codecov-report:
+	$(eval REPO_SLUG ?= $(REPO_OWNER)/$(REPO_NAME))
 ifneq ($(PR_COMMIT), null)
 	@echo "uploading test coverage report for pull-request #$(PULL_NUMBER)..."
 	@/bin/bash <(curl -s https://codecov.io/bash) \
-		-t $(shell tr -d ' \n' <$CODECOV_TOKEN_PATH) \
+		-t $(shell tr -d ' \n' <$(CODECOV_TOKEN_PATH)) \
 		-f $(GOCOV_DIR)/*.txt \
 		-C $(PR_COMMIT) \
-		-r $(REPO_OWNER)/$(REPO_NAME) \
+		-r $(REPO_SLUG) \
 		-P $(PULL_NUMBER) \
 		-Z > codecov-upload.log
 else
 	@echo "uploading test coverage report after PR was merged..."
 	@/bin/bash <(curl -s https://codecov.io/bash) \
-		-t $(shell tr -d ' \n' <$CODECOV_TOKEN_PATH) \
+		-t $(shell tr -d ' \n' <$(CODECOV_TOKEN_PATH)) \
 		-f $(GOCOV_DIR)/*.txt \
 		-C $(BASE_COMMIT) \
-		-r $(REPO_OWNER)/$(REPO_NAME) \
+		-r $(REPO_SLUG) \
 		-Z > codecov-upload.log
 endif
 


### PR DESCRIPTION
### Motivation

Currently codecov.io reports are not being uploaded for unit tests due to a typo in shell script to read from `CODECOV_TOKEN_PATH` that leads to the following complain:
```sh
/bin/bash: ODECOV_TOKEN_PATH: No such file or directory
```

### Changes

This PR:
* Fixes the `upload-codecov-report` Makefile target to properly use variable `CODECOV_TOKEN_PATH` to pass the token file.
* Adds a Travis CI merge-to-master job to upload codecov report for master commits to be used as baselines for PRs

### Testing
 
`4.6-unit` PR check tests it