### PR TITLE
Generating release.yaml

### DIFF
--- a/.github/actions/setup-cli/action.yaml
+++ b/.github/actions/setup-cli/action.yaml
@@ -1,0 +1,35 @@
+# action.yml
+name: 'Setup Tools'
+description: 'Setup CLI configuration with kubectl operator-sdk opm minikube, setup path, kubeconfig, minikube and docker info '
+runs:
+  using: "composite"
+  steps:
+    - id: setup-path
+      run: |
+        mkdir -p $GITHUB_WORKSPACE/bin/
+        echo "PATH=$PATH:$GITHUB_WORKSPACE/bin/" >> $GITHUB_ENV
+      shell: bash
+
+    - run: $GITHUB_ACTION_PATH/setup_tools.sh
+      shell: bash
+
+    - id: set-kubeconfig
+      run: |
+        KUBECONFIG=$GITHUB_WORKSPACE/miniconfig
+        echo "KUBECONFIG=$KUBECONFIG" >> $GITHUB_ENV
+        touch $KUBECONFIG
+      shell: bash
+
+    - id: setup-minikube
+      run: |
+        ./hack/start-minikube.sh start --kubernetes-version=v${K8S_VERSION} --driver=$CONTAINER_RUNTIME --cpus $(nproc) --memory 5g
+      shell: bash
+
+    - id: docker-info
+      run: |
+        eval $(minikube docker-env)
+        docker ps
+        kubectl get nodes -o yaml
+        kubectl cluster-info
+        docker info
+      shell: bash

--- a/.github/actions/setup-cli/setup_tools.sh
+++ b/.github/actions/setup-cli/setup_tools.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${SDK_VERSION}/operator-sdk_linux_amd64
+chmod +x operator-sdk
+mv -v operator-sdk $GITHUB_WORKSPACE/bin/
+
+curl -Lo opm https://github.com/operator-framework/operator-registry/releases/download/v${OPM_VERSION}/linux-amd64-opm
+chmod +x opm
+mv -v opm $GITHUB_WORKSPACE/bin/
+
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl
+chmod +x kubectl
+mv -v kubectl $GITHUB_WORKSPACE/bin/
+
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_VERSION}/minikube-linux-amd64
+chmod +x minikube
+mv -v minikube $GITHUB_WORKSPACE/bin/

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -7,11 +7,19 @@ on:
 
 env:
   GO111MODULE: on
+  SDK_VERSION: "1.3.0"
+  OPM_VERSION: "1.15.2"
+  MINIKUBE_WANTUPDATENOTIFICATION: false
+  MINIKUBE_WANTREPORTERRORPROMPT: false
+  K8S_VERSION: "1.19.2"
+  MINIKUBE_VERSION: "1.15.1"
+  TEST_ACCEPTANCE_CLI: "kubectl"
+  CONTAINER_RUNTIME: "docker"
 
 jobs:
   lint:
     name: Code Quality
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Set up Go
@@ -33,7 +41,7 @@ jobs:
 
   unit:
     name: Unit Tests with Code coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Set up Go
@@ -56,28 +64,49 @@ jobs:
           fail_ci_if_error: true
 
   acceptance:
-    name: Acceptance Tests with Kubernetes
-    runs-on: ubuntu-latest
+    name: Acceptance Tests with Kubernetes and using OLM
+    runs-on: ubuntu-20.04
 
     env:
-      SDK_VERSION: "1.3.0"
-      OPM_VERSION: "1.15.2"
-      MINIKUBE_WANTUPDATENOTIFICATION: false
-      MINIKUBE_WANTREPORTERRORPROMPT: false
-      K8S_VERSION: "1.19.2"
-      MINIKUBE_VERSION: "1.15.1"
       EXTRA_BEHAVE_ARGS: "--tags=~@knative --tags=~@openshift"
-      TEST_ACCEPTANCE_CLI: "kubectl"
-      CONTAINER_RUNTIME: "docker"
 
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v2
 
-      - name: Set up PATH
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.15.6"
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+          architecture: "x64"
+
+      - name: Setup-cli
+        uses: ./.github/actions/setup-cli
+
+      - name: Acceptance tests
+        timeout-minutes: 60
         run: |
-          mkdir -p $GITHUB_WORKSPACE/bin/
-          echo "PATH=$PATH:$GITHUB_WORKSPACE/bin/" >> $GITHUB_ENV
+          eval $(minikube docker-env)
+          make OPERATOR_REPO_REF=$(minikube ip):5000/sbo SKIP_REGISTRY_LOGIN=true release-operator -o registry-login test-acceptance-with-bundle
+
+
+  acceptance_without_olm:
+    name: Acceptance tests running on Kubernetes without using OLM
+    runs-on: ubuntu-20.04
+
+    env:
+      EXTRA_BEHAVE_ARGS: "--tags=~@knative --tags=~@openshift --tags=~@olm"
+      UMOCI_VERSION: "0.4.5"
+      OPERATOR_VERSION: "0.4.0"
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v2
 
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -91,43 +120,18 @@ jobs:
           architecture: "x64"
 
       - name: Set up CLI
+        uses: ./.github/actions/setup-cli
+
+      - name: Setup umoci cli
         run: |
-          curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${SDK_VERSION}/operator-sdk_linux_amd64
-          chmod +x operator-sdk
-          mv -v operator-sdk $GITHUB_WORKSPACE/bin/
+          curl -Lo umoci https://github.com/opencontainers/umoci/releases/download/v${UMOCI_VERSION}/umoci.amd64
+          chmod +x umoci
+          mv -v umoci $GITHUB_WORKSPACE/bin/
 
-          curl -Lo opm https://github.com/operator-framework/operator-registry/releases/download/v${OPM_VERSION}/linux-amd64-opm
-          chmod +x opm
-          mv -v opm $GITHUB_WORKSPACE/bin/
-
-          curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl
-          chmod +x kubectl
-          mv -v kubectl $GITHUB_WORKSPACE/bin/
-
-          curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_VERSION}/minikube-linux-amd64
-          chmod +x minikube
-          mv -v minikube $GITHUB_WORKSPACE/bin/
-
-      - name: Set KUBECONFIG
-        run: |
-          KUBECONFIG=$GITHUB_WORKSPACE/miniconfig
-          echo "KUBECONFIG=$KUBECONFIG" >> $GITHUB_ENV
-          touch $KUBECONFIG
-
-      - name: Set up minikube
-        run: |
-          ./hack/start-minikube.sh start --kubernetes-version=v${K8S_VERSION} --driver=$CONTAINER_RUNTIME --cpus $(nproc) --memory 5g
-
-      - name: Docker Info
-        run: |
-          eval $(minikube docker-env)
-          docker ps
-          kubectl get nodes -o yaml
-          kubectl cluster-info
-          docker info
-
-      - name: Acceptance tests
+      - name: Acceptance tests against vanilla k8s without OLM
         timeout-minutes: 60
         run: |
           eval $(minikube docker-env)
-          make OPERATOR_REPO_REF=$(minikube ip):5000/sbo SKIP_REGISTRY_LOGIN=true release-operator -o registry-login test-acceptance-with-bundle
+          make OPERATOR_REPO_REF=$(minikube ip):5000/sbo SKIP_REGISTRY_LOGIN=true release-operator -o registry-login release-manifests
+          kubectl apply -f out/release.yaml
+          make test-acceptance

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ release-operator: push-image push-bundle-image push-index-image
 ## prepare files for OperatorHub PR
 ## use this target when the operator needs to be released as upstream operator
 prepare-operatorhub-pr:
-	./hack/prepare-operatorhub-pr.sh $(OPERATOR_VERSION) $(OPERATOR_BUNDLE_IMAGE_REF)
+	./hack/prepare-operatorhub-pr.sh $(VERSION) $(OPERATOR_BUNDLE_IMAGE_REF)
 
 .PHONY: deploy-from-index-image
 ## deploy the operator from a given index image
@@ -301,3 +301,9 @@ test-acceptance-generate-report:
 ## Serves acceptance tests report at http://localhost:8088
 test-acceptance-serve-report:
 	$(Q)CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) $(HACK_DIR)/allure-report.sh serve
+
+.PHONY: release-manifests
+## prepare a manifest file for releasing operator on vanilla k8s cluster
+release-manifests: setup-venv prepare-operatorhub-pr
+	$(Q)$(PYTHON_VENV_DIR)/bin/pip install -q -r hack/check-python/requirements.txt
+	$(Q)$(PYTHON_VENV_DIR)/bin/python3 ./hack/release-manifest.py  $(OUTPUT_DIR)/operatorhub-pr-files/service-binding-operator/$(VERSION)/manifests/

--- a/hack/check-python/requirements.txt
+++ b/hack/check-python/requirements.txt
@@ -3,3 +3,4 @@ pyflakes==2.2.0
 vulture==2.1
 radon==4.3.1
 flake8_polyfill==1.0.2
+PyYAML==5.4.1

--- a/hack/prepare-operatorhub-pr.sh
+++ b/hack/prepare-operatorhub-pr.sh
@@ -9,7 +9,7 @@
 
 TMP_OCI_PATH=$(mktemp -d out/sbo-bundle-oci.XXX)
 
-skopeo copy docker://$2 oci:$TMP_OCI_PATH:bundle
+skopeo copy --src-tls-verify=false docker://$2 oci:$TMP_OCI_PATH:bundle
 umoci unpack --image $TMP_OCI_PATH:bundle --rootless ${TMP_OCI_PATH}-unpacked
 rm -rf out/operatorhub-pr-files
 mkdir out/operatorhub-pr-files/service-binding-operator -p

--- a/hack/release-manifest.py
+++ b/hack/release-manifest.py
@@ -1,0 +1,113 @@
+import os
+import yaml
+import sys
+from pathlib import Path
+
+MANIFEST_DIR = str(sys.argv[1])
+path = os.getcwd()
+release_yaml = path + "/out/release.yaml"
+Path(release_yaml).touch()
+
+def release_manifest():
+    res = list()
+    ns = create_service_binding_operator_ns()
+    res.append(ns)
+    for filename in os.listdir(MANIFEST_DIR):
+        with open(os.path.join(MANIFEST_DIR, filename), 'r') as f:
+            data = yaml.load(f)
+        if data["kind"] == "ClusterServiceVersion":
+            cluster_role = create_cluster_role_yaml(os.path.join(MANIFEST_DIR, filename))
+            res.append(cluster_role)
+            depl = create_operator_deployment(os.path.join(MANIFEST_DIR, filename))
+            res.append(depl)
+        elif data["kind"] == "ConfigMap" or data["kind"] == "Service":
+            metadata  = data["metadata"]
+            metadata.update({"namespace" : 'service-binding-operator'})
+            res.append(data)
+        else:
+            with open(os.path.join(MANIFEST_DIR, filename), "r") as stream:
+                res.extend(list(yaml.safe_load_all(stream)))
+    clusterrolebinding = create_clusterrolebinding_yaml()
+    res.append(clusterrolebinding)
+    service_account = create_service_account()
+    res.append(service_account)
+    with open(release_yaml, "a") as stream:
+        yaml.dump_all(
+            res,
+            stream,
+            default_flow_style=False
+        )  
+
+def create_cluster_role_yaml(csv):
+    role_data = {
+    "apiVersion" : 'rbac.authorization.k8s.io/v1',
+    "kind" : 'ClusterRole',
+    "metadata" : {
+        "name" : 'service-binding-operator',
+    },
+    }
+    with open(csv, 'r') as f:
+        data = yaml.load(f)
+    roles = data["spec"]["install"]["spec"]["clusterPermissions"][0]
+    roles.pop('serviceAccountName')
+    role_data.update(roles)
+    return role_data
+
+def create_clusterrolebinding_yaml():
+    # namespace = str(sys.argv[3])
+    role_binding = {
+    "apiVersion" : 'rbac.authorization.k8s.io/v1',
+    "kind" : 'ClusterRoleBinding',
+    "metadata" : {
+        "name" : 'service-binding-operator',
+    },
+    "roleRef" : {
+        "apiGroup" : 'rbac.authorization.k8s.io',
+        "kind" : 'ClusterRole',
+        "name" : 'service-binding-operator',
+    },
+    "subjects":
+        [{"kind" : 'ServiceAccount', "name": 'service-binding-operator', "namespace": 'service-binding-operator'},],
+}
+    return role_binding
+
+def create_operator_deployment(csv):
+    depl = {
+    "apiVersion" : 'apps/v1',
+    "kind" : 'Deployment',
+    "metadata" : {
+        "name" : 'service-binding-operator',
+        "annotations": {"olm.targetNamespaces" : ""},
+        "namespace" : 'service-binding-operator',
+    },
+}
+    with open(csv, 'r') as f:
+        data = yaml.load(f)
+    roles = data["spec"]["install"]["spec"]["deployments"][0]
+    del roles['name']
+    depl.update(roles)
+    return depl
+
+def create_service_account():
+    service_account = {
+    "apiVersion" : 'v1',
+    "kind" : 'ServiceAccount',
+    "metadata" : {
+        "name" : 'service-binding-operator',
+        "namespace" : 'service-binding-operator'
+    },
+}
+    return service_account
+
+def create_service_binding_operator_ns():
+    namespace = {
+    "apiVersion" : 'v1',
+    "kind" : 'Namespace',
+    "metadata" : {
+        "name" : 'service-binding-operator'
+    },
+}
+    return namespace
+
+## prepares release.yaml manifest to be added with GitHub releases/tags
+release_manifest()

--- a/test/acceptance/features/bindAppToServiceAnnotations.feature
+++ b/test/acceptance/features/bindAppToServiceAnnotations.feature
@@ -135,7 +135,6 @@ Feature: Bind an application to a service using annotations
         And The application env var "BACKEND_SPEC_IMAGENAME" has value "postgres"
         And The application env var "BACKEND_SPEC_DBNAME" has value "db-demo"
 
-
     Scenario: Each value in referred slice of strings from service resource gets injected into app as separate env variable
         Given Generic test application "slos-app" is running
         And The Custom Resource Definition is present
@@ -325,6 +324,7 @@ Feature: Bind an application to a service using annotations
         And The application env var "BACKEND_WEBARROWS_SECONDARY" has value "secondary.example.com"
         And The application env var "BACKEND_WEBARROWS_404" has value "black-hole.example.com"
 
+    @olm
     Scenario: Backend Service metadata annotations update for service bindings gets propagated to the binding secret
         Given OLM Operator "backend" is running
         * The Custom Resource is present
@@ -379,6 +379,7 @@ Feature: Bind an application to a service using annotations
 
 
     @negative
+    @olm
     Scenario: Backend Service metadata annotations update not specific to service bindings does not get propagated to the binding secret
         Given OLM Operator "backend" is running
         * The Custom Resource is present

--- a/test/acceptance/features/bindAppToServiceUsingConfigMap.feature
+++ b/test/acceptance/features/bindAppToServiceUsingConfigMap.feature
@@ -7,6 +7,7 @@ Feature: Bind values from a config map referred in backing service resource
         Given Namespace [TEST_NAMESPACE] is used
         * Service Binding Operator is running
 
+    @olm
     Scenario: Inject into app a key from a config map referred within service resource
         Binding definition is declared on service CRD.
 
@@ -78,6 +79,7 @@ Feature: Bind values from a config map referred in backing service resource
         Then Service Binding "cmsa-1" is ready
         And The application env var "BACKEND_CERTIFICATE" has value "certificate value"
 
+    @olm
     Scenario: Inject into app all keys from a config map referred within service resource
         Binding definition is declared on service CRD.
 

--- a/test/acceptance/features/bindAppToServiceUsingSecret.feature
+++ b/test/acceptance/features/bindAppToServiceUsingSecret.feature
@@ -7,6 +7,7 @@ Feature: Bind values from a secret referred in backing service resource
         Given Namespace [TEST_NAMESPACE] is used
         * Service Binding Operator is running
 
+    @olm
     Scenario: Inject into app a key from a secret referred within service resource
         Binding definition is declared on service CRD.
         Given OLM Operator "backend" is running
@@ -77,6 +78,7 @@ Feature: Bind values from a secret referred in backing service resource
         Then Service Binding "ssa-1" is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
 
+    @olm
     Scenario: Inject into app all keys from a secret referred within service resource
 
         Given OLM Operator "backend" is running
@@ -149,6 +151,7 @@ Feature: Bind values from a secret referred in backing service resource
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
+    @olm
     Scenario: Inject into app a key from a secret referred within service resource Binding definition is declared via OLM descriptor.
 
         Given Generic test application "ssd-1" is running
@@ -259,6 +262,7 @@ Feature: Bind values from a secret referred in backing service resource
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_HOST" has value "example.com"
 
+    @olm
     Scenario: Inject into app all keys from a secret referred within service resource Binding definition is declared via OLM descriptor.
 
         Given Generic test application "ssd-2" is running

--- a/test/acceptance/features/bindWithCustomNamingStrategies.feature
+++ b/test/acceptance/features/bindWithCustomNamingStrategies.feature
@@ -1,3 +1,4 @@
+@olm
 Feature: Bind an application to a service using custom naming strategies
 
     As a user of Service Binding Operator
@@ -42,7 +43,6 @@ Feature: Bind an application to a service using custom naming strategies
             """
         Then Service Binding "binding-request-no-naming" is ready
         And The application env var "BACKEND_HOST_CROSS_NS_SERVICE" has value "cross.ns.service.stable.example.com"
-
 
     Scenario: Bind an application to a service with naming strategy none
         * OLM Operator "backend" is running

--- a/test/acceptance/features/customEnvVar.feature
+++ b/test/acceptance/features/customEnvVar.feature
@@ -8,6 +8,7 @@ Feature: Inject custom env variable into application
         Given Namespace [TEST_NAMESPACE] is used
         * Service Binding Operator is running
 
+    @olm
     Scenario: Sequence from service resource is injected into application using custom env variables without specifying annotations
         Given OLM Operator "backend" is running
         * The Custom Resource is present
@@ -48,6 +49,7 @@ Feature: Inject custom env variable into application
         Then Service Binding "custom-env-var-from-sequence" is ready
         And The application env var "TAGS" has value "[centos7-12.3 123]"
 
+    @olm
     Scenario: Map from service resource is injected into application using custom env variables without specifying annotations
         Given OLM Operator "backend" is running
         * The Custom Resource is present
@@ -88,6 +90,7 @@ Feature: Inject custom env variable into application
         Then Service Binding "custom-env-var-from-map" is ready
         And The application env var "USER_LABELS" has value "map[archive:false environment:demo]"
 
+    @olm
     Scenario: Scalar from service resource is injected into application using custom env variables without specifying annotations
         Given OLM Operator "backend" is running
         * The Custom Resource is present

--- a/test/acceptance/features/deleteBackendServiceAndRecreate.feature
+++ b/test/acceptance/features/deleteBackendServiceAndRecreate.feature
@@ -6,6 +6,8 @@ Feature: Reconcile when BackingService CR got deleted and recreated
     Background:
         Given Namespace [TEST_NAMESPACE] is used
         * Service Binding Operator is running
+
+    @olm
     Scenario: Reconcile when BackingService CR got deleted and recreated
         Given OLM Operator "backend" is running
         And Generic test application "ssa-3" is running

--- a/test/acceptance/features/examples.feature
+++ b/test/acceptance/features/examples.feature
@@ -1,4 +1,5 @@
 @examples
+@openshift
 Feature: Verify examples provided in Service Binding Operator github repository
 
     As a user of Service Binding Operator
@@ -9,7 +10,6 @@ Feature: Verify examples provided in Service Binding Operator github repository
         * Service Binding Operator is running
         * PostgreSQL DB operator is installed
 
-    @openshift
     # https://github.com/redhat-developer/service-binding-operator/blob/master/examples/route_k8s_resource/README.md
     Scenario: Bind an application to an openshift route
         Given The openshift route is present

--- a/test/acceptance/features/injectBindingsAsFiles.feature
+++ b/test/acceptance/features/injectBindingsAsFiles.feature
@@ -1,3 +1,4 @@
+@olm
 Feature: Bindings get injected as files in application
 
     As a user of Service Binding Operator

--- a/test/acceptance/features/unbindAppToService.feature
+++ b/test/acceptance/features/unbindAppToService.feature
@@ -1,3 +1,4 @@
+@olm
 Feature: Unbind an application from a service
 
     As a user of Service Binding Operator


### PR DESCRIPTION
Fixes - https://github.com/redhat-developer/service-binding-operator/issues/799
https://issues.redhat.com/browse/APPSVC-769

The release manifest file can be created by running the make target `release-manifests` . On running the make release-manifests target a release.yaml file is produced in the /out dir. This release.yaml can now be used to install the SBO on a vanilla k8s.
A GitHub action job name `acceptance_without_olm` is configured to test the release manifest file on a vanilla k8s cluster.