### PR TITLE
Fix Docker image pull limits 

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,7 +1,12 @@
 # On CI, use
 # FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.15 AS builder
 
-FROM openshift/origin-release:golang-1.15 AS builder
+# The following image is a mirror of CI image, performed as:
+# * Copy the oc login command from https://api.ci.openshift.org/oauth/token/request
+# * oc login api.ci.openshift.org ... # command from the web page
+# * oc registry login
+# * skopeo copy docker://registry.svc.ci.openshift.org/ocp/builder:golang-1.15 docker:/quay.io/redhat-developer/servicebinding-operator:builder-golang-1.15
+FROM quay.io/redhat-developer/servicebinding-operator:builder-golang-1.15 AS builder
 
 ENV LANG=en_US.utf8
 ENV GIT_COMMITTER_NAME devtools


### PR DESCRIPTION
Due to recently introduced image pull limits, we see occasionally job failures at Travis.

Hence, openshift/origin-release:golang-1.15 image got mirrored to quay
and that image is now our base build image.