### PR TITLE
[acceptance-tests] Change catalog source for etcd operator to operatorhub.io

### DIFF
--- a/test/acceptance/features/steps/etcdoperator.py
+++ b/test/acceptance/features/steps/etcdoperator.py
@@ -1,13 +1,11 @@
 from olm import Operator
-from environment import ctx
 
 
 class EtcdOperator(Operator):
 
-    operator_catalog_source_name = "operatorhubio-catalog" if ctx.cli == "kubectl" else "community-operators"
+    operator_catalog_source_name = "operatorhubio-catalog"
     operator_catalog_channel = "clusterwide-alpha"
 
     def __init__(self, name="etcd"):
         self.name = name
-        self.operator_catalog_channel = "clusterwide-alpha"
         self.package_name = "etcd"

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -420,8 +420,10 @@ def verify_injected_secretRef(context, secret_ref, cr_name, crd_name, json_path)
 @given(u'Etcd operator running')
 def etcd_operator_is_running(context):
     """
-    Checks if the etcd operator is up and running
+    Ensures that the etcd operator is up and running
     """
+    openshift = Openshift()
+    openshift.create_catalog_source("operatorhubio-catalog", "quay.io/operatorhubio/catalog:latest")
     etcd_operator = EtcdOperator()
     if not etcd_operator.is_running():
         print("Etcd operator is not installed, installing...")


### PR DESCRIPTION
### Motivation

Currently `etcd` related tests installs etcd operator from `community-operators` catalog source. Recently etcd was removed from that catalog source which caues constant failures of the etcd-related acceptance tests. However, etcd operator is available in `operatorhub.io`.

### Changes

This PR:
* Fixes failing acceptance tests in CI by changing catalog source for etcd operator for acceptance tests to be `operatorhub.io`

### Testing

`make test-acceptance`