### PR TITLE
Take into account outputName in mapFromDataFieldDefinition (#817)

### DIFF
--- a/pkg/controller/servicebinding/binding/definition.go
+++ b/pkg/controller/servicebinding/binding/definition.go
@@ -199,7 +199,11 @@ func (d *mapFromDataFieldDefinition) Apply(u *unstructured.Unstructured) (Value,
 		} else {
 			n = v
 		}
-		outputVal[k] = string(n)
+		if len(d.sourceValue) > 0 && len(d.outputName) > 0 {
+			outputVal[d.outputName] = string(n)
+		} else {
+			outputVal[k] = string(n)
+		}
 	}
 
 	return &value{v: outputVal}, nil

--- a/pkg/controller/servicebinding/binding/definition_test.go
+++ b/pkg/controller/servicebinding/binding/definition_test.go
@@ -241,3 +241,30 @@ func TestMapFromConfigMapDataField(t *testing.T) {
 	}
 	require.Equal(t, v, val.Get())
 }
+
+func TestMapFromConfigMapDataFieldWithOutputNameAndSourceValue(t *testing.T) {
+	f := mocks.NewFake(t, "test-namespace")
+	f.AddMockedUnstructuredConfigMap("dbCredentials-configMap")
+	d := &mapFromDataFieldDefinition{
+		kubeClient:  f.FakeDynClient(),
+		objectType:  configMapObjectType,
+		sourceValue: "username",
+		outputName:  "user",
+		path:        []string{"status", "dbCredentials"},
+	}
+	val, err := d.Apply(&unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"namespace": "test-namespace",
+			},
+			"status": map[string]interface{}{
+				"dbCredentials": "dbCredentials-configMap",
+			},
+		},
+	})
+	require.NoError(t, err)
+	v := map[string]string{
+		"user": "user",
+	}
+	require.Equal(t, v, val.Get())
+}


### PR DESCRIPTION
### Motivation

`outputName` is not honoured in `mapFromDataFieldDefinition` implementation.

Closes #817.

### Testing

make test-unit

Thanks !