### PR TITLE
Add implementation to support flexible naming strategies to prepare binding names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ testbin/*
 
 bundle
 bundle.Dockerfile
+
+config/crd/bases/_.yaml

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ connect to a backing service (for example, a database):
 
 * Support Binding with backing services represented by Kubernetes resources including third-party CRD-backed resources.
 * Support binding with multiple-backing services.
-* Extract binding information based on annotations present in CRDs/CRs/resources. 
+* Extract binding information based on annotations present in CRDs/CRs/resources.
 * Extract binding values based on annotations present in OLM descriptors.
 * Project binding values as volume mounts.
 * Project binding values as environment variables.
@@ -99,6 +99,20 @@ Follow [OperatorHub instructions](https://operatorhub.io/operator/service-bindin
 ### Running Operator Locally
 
 Clone the repository and run `make run` using an existing `kube:admin` kube context.
+
+## Key Features
+
+* Support Binding with backing services represented by Kubernetes resources including third-party CRD-backed resources.
+* Support binding with multiple-backing services.
+* Extract binding information based on annotations present in CRDs/CRs/resources.
+* Extract binding values based on annotations present in OLM descriptors.
+* Project binding values as volume mounts.
+* Project binding values as environment variables.
+* Binding of PodSpec-based workloads.
+* Binding of non-PodSpec-based Kubernetes resources.
+* Custom binding variables composed from one or more backing services.
+* Auto-detect binding resources in the absence of binding decorators.
+
 
 ## Getting Started
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -109,11 +109,6 @@ func (in *Service) DeepCopyInto(out *Service) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.NamePrefix != nil {
-		in, out := &in.NamePrefix, &out.NamePrefix
-		*out = new(string)
-		**out = **in
-	}
 	if in.Id != nil {
 		in, out := &in.Id, &out.Id
 		*out = new(string)

--- a/config/crd/bases/operators.coreos.com_servicebindings.yaml
+++ b/config/crd/bases/operators.coreos.com_servicebindings.yaml
@@ -164,9 +164,12 @@ spec:
                   `/bindings` When mountPath is used, the file will be mounted directly
                   under that directory Otherwise it will be under `SERVICE_BINDING_ROOT`/<SERVICE-BINDING-NAME>
                 type: string
-              namePrefix:
-                description: NamePrefix is the prefix for environment variables or
-                  file name
+              namingStrategy:
+                description: NamingStrategy defines custom string template for preparing
+                  binding names. It can be pre-defined strategies(i.e none,uppercase),
+                  in case strategy provided in this field isn't defined we are going
+                  to treat the value as a custom template and prepare binding names
+                  accordingly.
                 type: string
               services:
                 description: Services is used to identify multiple backing services.
@@ -183,8 +186,6 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                         TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                    namePrefix:
                       type: string
                     namespace:
                       type: string

--- a/controllers/service.go
+++ b/controllers/service.go
@@ -213,7 +213,8 @@ func getOwnedResources(
 func buildOwnedResourceContext(
 	client dynamic.Interface,
 	obj *unstructured.Unstructured,
-	ownerNamePrefix *string,
+	namingTemplate string,
+	isBindAsFiles bool,
 	restMapper meta.RESTMapper,
 	inputPath string,
 	outputPath string,
@@ -224,7 +225,8 @@ func buildOwnedResourceContext(
 		obj.GetNamespace(),
 		obj.GetObjectKind().GroupVersionKind(),
 		obj.GetName(),
-		ownerNamePrefix,
+		namingTemplate,
+		isBindAsFiles,
 		restMapper,
 		nil,
 	)
@@ -238,7 +240,8 @@ func buildOwnedResourceContext(
 func buildOwnedResourceContexts(
 	client dynamic.Interface,
 	objs []*unstructured.Unstructured,
-	ownerNamePrefix *string,
+	namingTemplate string,
+	isBindAsFiles bool,
 	restMapper meta.RESTMapper,
 ) ([]*serviceContext, error) {
 	ctxs := make(serviceContextList, 0)
@@ -251,7 +254,8 @@ func buildOwnedResourceContexts(
 			svcCtx, err := buildOwnedResourceContext(
 				client,
 				obj,
-				ownerNamePrefix,
+				namingTemplate,
+				isBindAsFiles,
 				restMapper,
 				br.inputPath,
 				br.outputPath,

--- a/controllers/service_test.go
+++ b/controllers/service_test.go
@@ -203,21 +203,21 @@ func TestLoadDescriptor(t *testing.T) {
 
 func TestBuildOwnerResourceContext(t *testing.T) {
 	ns := "planner"
+	namingTemplate := "{{ .service.kind | upper }}_{{ .name | upper }}"
+
 	f := mocks.NewFake(t, ns)
 
 	obj := f.AddMockedUnstructuredSecret("secret")
 
 	type testCase struct {
-		inputPath       string
-		outputPath      string
-		ownerNamePrefix *string
+		inputPath  string
+		outputPath string
 	}
 
 	testCases := []testCase{
 		{
-			inputPath:       "data.user",
-			outputPath:      "user",
-			ownerNamePrefix: nil,
+			inputPath:  "data.user",
+			outputPath: "user",
 		},
 	}
 
@@ -225,7 +225,8 @@ func TestBuildOwnerResourceContext(t *testing.T) {
 		got, err := buildOwnedResourceContext(
 			f.FakeDynClient(),
 			obj,
-			tc.ownerNamePrefix,
+			namingTemplate,
+			false,
 			testutils.BuildTestRESTMapper(),
 			tc.inputPath,
 			tc.outputPath,

--- a/controllers/servicebinder.go
+++ b/controllers/servicebinder.go
@@ -246,7 +246,6 @@ func (b *serviceBinder) onError(
 func isApplicationEmpty(
 	application *v1alpha1.Application,
 ) bool {
-	fmt.Println("Current APPLICATION IS : ", application)
 	if application == nil {
 		return true
 	}
@@ -463,10 +462,10 @@ func buildBinding(
 	client dynamic.Interface,
 	mappings []v1alpha1.Mapping,
 	svcCtxs serviceContextList,
-	globalNamePrefix string,
+	namingTemplate string,
 ) (*internalBinding, error) {
 	envVars, err := NewRetriever(client).
-		ProcessServiceContexts(globalNamePrefix, svcCtxs, mappings)
+		ProcessServiceContexts(namingTemplate, svcCtxs, mappings)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pod_spec_path/README.md
+++ b/examples/pod_spec_path/README.md
@@ -95,7 +95,6 @@ kind: ServiceBinding
 metadata:
     name: binding-request-sample
 spec:
-    namePrefix: qiye111
     application:
         name: demo-appconfig
         group: stable.example.com
@@ -109,7 +108,6 @@ spec:
         kind: Database
         name: db-demo
         id: zzz
-        namePrefix: qiye
 EOD
 ```
 

--- a/examples/route_k8s_resource/README.md
+++ b/examples/route_k8s_resource/README.md
@@ -57,7 +57,7 @@ deployment.apps/hello-app created
 We can verify that the app is running by checking the Deployment is available:
 
 ``` shell
-$ kubectl get deployment hello-app -n service-binding-demo -o wide                             
+$ kubectl get deployment hello-app -n service-binding-demo -o wide
 NAME        READY   UP-TO-DATE   AVAILABLE   AGE    CONTAINERS        IMAGES                      SELECTOR
 hello-app   1/1     1            1           3m2s   hello-openshift   openshift/hello-openshift   app=hello-app
 ```

--- a/pkg/envvars/envvars.go
+++ b/pkg/envvars/envvars.go
@@ -89,7 +89,6 @@ func buildEnvVarName(path []string) string {
 	}
 	envVar := strings.Join(newPath, "_")
 	envVar = strings.ReplaceAll(envVar, ".", "_")
-	envVar = strings.ToUpper(envVar)
 	return envVar
 }
 

--- a/pkg/envvars/envvars_test.go
+++ b/pkg/envvars/envvars_test.go
@@ -19,9 +19,9 @@ func TestBuild(t *testing.T) {
 		{
 			name: "should create envvars without prefix",
 			expected: map[string]string{
-				"STATUS_LISTENERS_0_TYPE":             "secure",
-				"STATUS_LISTENERS_0_ADDRESSES_0_HOST": "my-cluster-kafka-bootstrap.coffeeshop.svc",
-				"STATUS_LISTENERS_0_ADDRESSES_0_PORT": "9093",
+				"status_listeners_0_type":             "secure",
+				"status_listeners_0_addresses_0_host": "my-cluster-kafka-bootstrap.coffeeshop.svc",
+				"status_listeners_0_addresses_0_port": "9093",
 			},
 			src: map[string]interface{}{
 				"status": map[string]interface{}{
@@ -42,9 +42,9 @@ func TestBuild(t *testing.T) {
 		{
 			name: "should create envvars with service prefix",
 			expected: map[string]string{
-				"KAFKA_STATUS_LISTENERS_0_TYPE":             "secure",
-				"KAFKA_STATUS_LISTENERS_0_ADDRESSES_0_HOST": "my-cluster-kafka-bootstrap.coffeeshop.svc",
-				"KAFKA_STATUS_LISTENERS_0_ADDRESSES_0_PORT": "9093",
+				"kafka_status_listeners_0_type":             "secure",
+				"kafka_status_listeners_0_addresses_0_host": "my-cluster-kafka-bootstrap.coffeeshop.svc",
+				"kafka_status_listeners_0_addresses_0_port": "9093",
 			},
 			path: []string{"kafka"},
 			src: map[string]interface{}{
@@ -66,9 +66,9 @@ func TestBuild(t *testing.T) {
 		{
 			name: "should create envvars with binding and service prefixes",
 			expected: map[string]string{
-				"BINDING_KAFKA_STATUS_LISTENERS_0_TYPE":             "secure",
-				"BINDING_KAFKA_STATUS_LISTENERS_0_ADDRESSES_0_HOST": "my-cluster-kafka-bootstrap.coffeeshop.svc",
-				"BINDING_KAFKA_STATUS_LISTENERS_0_ADDRESSES_0_PORT": "9093",
+				"binding_kafka_status_listeners_0_type":             "secure",
+				"binding_kafka_status_listeners_0_addresses_0_host": "my-cluster-kafka-bootstrap.coffeeshop.svc",
+				"binding_kafka_status_listeners_0_addresses_0_port": "9093",
 			},
 			path: []string{"binding", "kafka"},
 			src: map[string]interface{}{
@@ -90,9 +90,9 @@ func TestBuild(t *testing.T) {
 		{
 			name: "should create envvars without prefix",
 			expected: map[string]string{
-				"STATUS_LISTENERS_0_TYPE":             "secure",
-				"STATUS_LISTENERS_0_ADDRESSES_0_HOST": "my-cluster-kafka-bootstrap.coffeeshop.svc",
-				"STATUS_LISTENERS_0_ADDRESSES_0_PORT": "9093",
+				"status_listeners_0_type":             "secure",
+				"status_listeners_0_addresses_0_host": "my-cluster-kafka-bootstrap.coffeeshop.svc",
+				"status_listeners_0_addresses_0_port": "9093",
 			},
 			path: []string{""},
 			src: map[string]interface{}{
@@ -114,7 +114,7 @@ func TestBuild(t *testing.T) {
 		{
 			name: "should create envvar for int64 type",
 			expected: map[string]string{
-				"STATUS_VALUE": "-9223372036",
+				"status_value": "-9223372036",
 			},
 			src: map[string]interface{}{
 				"status": map[string]interface{}{
@@ -139,9 +139,9 @@ func TestBuild(t *testing.T) {
 		{
 			name: "should create envvars for each string in slice",
 			expected: map[string]string{
-				"TAGS_0": "knowledge",
-				"TAGS_1": "is",
-				"TAGS_2": "power",
+				"tags_0": "knowledge",
+				"tags_1": "is",
+				"tags_2": "power",
 			},
 			src: map[string]interface{}{
 				"tags": []string{

--- a/pkg/naming/naming.go
+++ b/pkg/naming/naming.go
@@ -1,0 +1,52 @@
+package naming
+
+import (
+	"bytes"
+	"errors"
+	"html/template"
+	"strings"
+)
+
+var TemplateError = errors.New("please check the namingStrategy template provided")
+
+var templateFunctions = map[string]interface{}{
+	"upper": strings.ToUpper,
+	"title": strings.Title,
+	"lower": strings.ToLower,
+}
+
+type namingTemplate struct {
+	template       *template.Template
+	data           map[string]interface{}
+	namingTemplate string
+}
+
+// NewTemplate creates template instance which handles how binding names should be prepared
+// templateStr is being used to format binding name.
+func NewTemplate(templateStr string, data map[string]interface{}) (*namingTemplate, error) {
+	t, err := template.New("template").Funcs(templateFunctions).Parse(templateStr)
+	if err != nil {
+		return nil, err
+	}
+	return &namingTemplate{
+		template:       t,
+		namingTemplate: templateStr,
+		data:           data,
+	}, nil
+}
+
+// GetBindingName prepares binding name which accepts binding name from the OLM descriptor/annotation
+// namingTemplate uses string template provided to build final binding name.
+func (n *namingTemplate) GetBindingName(bindingName string) (string, error) {
+	d := map[string]interface{}{
+		"service": n.data,
+		"name":    bindingName,
+	}
+
+	var tpl bytes.Buffer
+	err := n.template.Execute(&tpl, d)
+	if err != nil {
+		return "", TemplateError
+	}
+	return tpl.String(), nil
+}

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -1,0 +1,57 @@
+package naming
+
+import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBuildNamingStrategy(t *testing.T) {
+	data := map[string]interface{}{
+		"name": "database",
+		"kind": "Service",
+	}
+
+	dataProvider := []struct {
+		namingTemplate      string
+		bindingName         string
+		expectedBindingName string
+		expectedError       error
+	}{
+		{
+			namingTemplate:      "{{ .service.kind | upper }}",
+			bindingName:         "db",
+			expectedBindingName: "SERVICE",
+		},
+		{
+			namingTemplate:      "{{ .service.kind | upper }}_{{ .name }}",
+			bindingName:         "db",
+			expectedBindingName: "SERVICE_db",
+		},
+		{
+			namingTemplate:      "{{ .service.kind | upper }}_{{ .name | upper }}",
+			bindingName:         "db",
+			expectedBindingName: "SERVICE_DB",
+		},
+		{
+			namingTemplate:      "{{ .wrongfield | upper }}",
+			bindingName:         "db",
+			expectedBindingName: "",
+			expectedError:       errors.New("please check the namingStrategy template provided"),
+		},
+	}
+
+	for _, tt := range dataProvider {
+		t.Run(fmt.Sprintf("Process %s with %s gives %s", tt.bindingName, tt.namingTemplate, tt.expectedBindingName), func(t *testing.T) {
+			template, err := NewTemplate(tt.namingTemplate, data)
+			assert.NoError(t, err)
+			bindingName, err := template.GetBindingName(tt.bindingName)
+			if err != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+			}
+			assert.EqualValues(t, tt.expectedBindingName, bindingName)
+		})
+	}
+
+}

--- a/test/acceptance/features/bindAppToService.feature
+++ b/test/acceptance/features/bindAppToService.feature
@@ -319,7 +319,6 @@ Feature: Bind an application to a service
             metadata:
                 name: binding-request-a-d-c
             spec:
-                namePrefix: REDHAT
                 application:
                     name: nodejs-rest-http-crud-a-d-c
                     group: apps
@@ -331,7 +330,6 @@ Feature: Bind an application to a service
                     kind: Database
                     name: db-demo-a-d-c
                     id: postgresDB
-                    namePrefix: DEVTOOLS
                 mappings:
                     - name: SOME_KEY
                       value: 'SOME_VALUE:{{ .postgresDB.status.dbConnectionPort }}:{{ .postgresDB.status.dbName }}'
@@ -528,6 +526,7 @@ Feature: Bind an application to a service
             metadata:
               name: binding-request-etcd
             spec:
+              namingStrategy: "ETCDCLUSTER_{{ .name | upper }}"
               application:
                 group: apps
                 version: v1

--- a/test/acceptance/features/bindWithCustomNamingStrategies.feature
+++ b/test/acceptance/features/bindWithCustomNamingStrategies.feature
@@ -1,0 +1,235 @@
+Feature: Bind an application to a service using custom naming strategies
+
+    As a user of Service Binding Operator
+    I want to bind applications to services it depends on
+
+    Background:
+        Given Namespace [TEST_NAMESPACE] is used
+        * Service Binding Operator is running
+        * PostgreSQL DB operator is installed
+
+    Scenario: Bind an application to a service with no naming strategy specified
+        * OLM Operator "backend" is running
+        * The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: backend-no-naming
+                annotations:
+                    service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
+            spec:
+                host_cross_ns_service: cross.ns.service.stable.example.com
+            """
+        * Generic test application "myapp-no-naming" is running
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-request-no-naming
+            spec:
+                application:
+                    name: myapp-no-naming
+                    group: apps
+                    version: v1
+                    resource: deployments
+                services:
+                -   group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: backend-no-naming
+            """
+        Then Service Binding "binding-request-no-naming" is ready
+        And The application env var "BACKEND_HOST_CROSS_NS_SERVICE" has value "cross.ns.service.stable.example.com"
+
+
+    Scenario: Bind an application to a service with naming strategy none
+        * OLM Operator "backend" is running
+        * The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: backend-naming-none
+                annotations:
+                    service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
+            spec:
+                host_cross_ns_service: cross.ns.service.stable.example.com
+            """
+        * Generic test application "myapp-naming-none" is running
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-request-naming-none
+            spec:
+                namingStrategy: none
+                application:
+                    name: myapp-naming-none
+                    group: apps
+                    version: v1
+                    resource: deployments
+                services:
+                -   group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: backend-naming-none
+            """
+        Then Service Binding "binding-request-naming-none" is ready
+        And The application env var "host_cross_ns_service" has value "cross.ns.service.stable.example.com"
+
+    Scenario: Bind an application to a service with custom naming strategy
+        * OLM Operator "backend" is running
+        * The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: backend-custom-naming
+                annotations:
+                    service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
+            spec:
+                host_cross_ns_service: cross.ns.service.stable.example.com
+            """
+        * Generic test application "myapp-custom-naming" is running
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-request-custom-naming
+            spec:
+                namingStrategy: "PREFIX_{{ .service.kind | upper }}_{{ .name | upper }}_SUFFIX"
+                application:
+                    name: myapp-custom-naming
+                    group: apps
+                    version: v1
+                    resource: deployments
+                services:
+                -   group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: backend-custom-naming
+            """
+        Then Service Binding "binding-request-custom-naming" is ready
+        And The application env var "PREFIX_BACKEND_HOST_CROSS_NS_SERVICE_SUFFIX" has value "cross.ns.service.stable.example.com"
+
+    Scenario: Bind an application to a service with bind as file and no naming strategy
+        * OLM Operator "backend" is running
+        * The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: backend-bind-files
+                annotations:
+                    service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
+            spec:
+                host_cross_ns_service: cross.ns.service.stable.example.com
+            """
+        * Generic test application "myapp-bind-files" is running
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-request-bind-files
+            spec:
+                bindAsFiles: true
+                application:
+                    name: myapp-bind-files
+                    group: apps
+                    version: v1
+                    resource: deployments
+                services:
+                -   group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: backend-bind-files
+            """
+        Then Service Binding "binding-request-bind-files" is ready
+        And The env var "host_cross_ns_service" is not available to the application
+        And Content of file "/bindings/binding-request-bind-files/host_cross_ns_service" in application pod is
+            """
+            cross.ns.service.stable.example.com
+            """
+
+    Scenario: Bind an application to a service with bind files and custom naming strategy
+        * OLM Operator "backend" is running
+        * The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: backend-custom-file-naming
+                annotations:
+                    service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
+            spec:
+                host_cross_ns_service: cross.ns.service.stable.example.com
+            """
+        * Generic test application "myapp-custom-file-naming" is running
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-request-custom-file-naming
+            spec:
+                namingStrategy: "PREFIX_{{ .service.kind | upper }}_{{ .name | upper }}_SUFFIX"
+                mountPath: "/foo/bar"
+                bindAsFiles: true
+                application:
+                    name: myapp-custom-file-naming
+                    group: apps
+                    version: v1
+                    resource: deployments
+                services:
+                -   group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: backend-custom-file-naming
+            """
+        Then Service Binding "binding-request-custom-file-naming" is ready
+        And Content of file "/foo/bar/PREFIX_BACKEND_HOST_CROSS_NS_SERVICE_SUFFIX" in application pod is
+            """
+            cross.ns.service.stable.example.com
+            """
+
+    @error-naming
+    Scenario: Bind an application to a service with naming strategy error
+        * OLM Operator "backend" is running
+        * The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: backend-naming-error
+                annotations:
+                    service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
+            spec:
+                host_cross_ns_service: cross.ns.service.stable.example.com
+            """
+        * Generic test application "myapp-naming-error" is running
+        When Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-request-naming-error
+            spec:
+                namingStrategy: "{{ .service.test.name | lower }}_incorrect"
+                application:
+                    name: myapp-naming-error
+                    group: apps
+                    version: v1
+                    resource: deployments
+                services:
+                -   group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: backend-naming-error
+            """
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-naming-error" should be changed to "False"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").reason" of Service Binding "binding-request-naming-error" should be changed to "NamingStrategyError"

--- a/test/acceptance/features/deleteBackendServiceAndRecreate.feature
+++ b/test/acceptance/features/deleteBackendServiceAndRecreate.feature
@@ -6,7 +6,7 @@ Feature: Reconcile when BackingService CR got deleted and recreated
     Background:
         Given Namespace [TEST_NAMESPACE] is used
         * Service Binding Operator is running
-    Scenario: Reconcile when BackingService CR got deleted and recreated 
+    Scenario: Reconcile when BackingService CR got deleted and recreated
         Given OLM Operator "backend" is running
         And Generic test application "ssa-3" is running
         And The Custom Resource Definition is present

--- a/test/acceptance/features/injectBindingsAsFiles.feature
+++ b/test/acceptance/features/injectBindingsAsFiles.feature
@@ -51,15 +51,15 @@ Feature: Bindings get injected as files in application
             """
         Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-backend-vm-01" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-backend-vm-01" should be changed to "True"
-        And The env var "BACKEND_HOST" is not available to the application
-        And The env var "BACKEND_PORT" is not available to the application
+        And The env var "host" is not available to the application
+        And The env var "port" is not available to the application
         And The env var "MYHOST" is not available to the application
         And The application env var "SERVICE_BINDING_ROOT" has value "/var/data"
-        And Content of file "/var/data/binding-backend-vm-01/BACKEND_HOST" in application pod is
+        And Content of file "/var/data/binding-backend-vm-01/host" in application pod is
             """
             example.common
             """
-        And Content of file "/var/data/binding-backend-vm-01/BACKEND_PORT" in application pod is
+        And Content of file "/var/data/binding-backend-vm-01/port" in application pod is
             """
             8080
             """
@@ -105,14 +105,14 @@ Feature: Bindings get injected as files in application
             """
         Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-backend-vm-02" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-backend-vm-02" should be changed to "True"
-        And The env var "BACKEND_HOST" is not available to the application
-        And The env var "BACKEND_PORT" is not available to the application
+        And The env var "host" is not available to the application
+        And The env var "port" is not available to the application
         And The application env var "SERVICE_BINDING_ROOT" has value "/bindings"
-        And Content of file "/bindings/binding-backend-vm-02/BACKEND_HOST" in application pod is
+        And Content of file "/bindings/binding-backend-vm-02/host" in application pod is
             """
             example.common
             """
-        And Content of file "/bindings/binding-backend-vm-02/BACKEND_PORT" in application pod is
+        And Content of file "/bindings/binding-backend-vm-02/port" in application pod is
             """
             8080
             """
@@ -155,14 +155,14 @@ Feature: Bindings get injected as files in application
             """
         Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-backend-vm-03" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-backend-vm-03" should be changed to "True"
-        And The env var "BACKEND_HOST" is not available to the application
-        And The env var "BACKEND_PORT" is not available to the application
+        And The env var "host" is not available to the application
+        And The env var "port" is not available to the application
         And The env var "SERVICE_BINDING_ROOT" is not available to the application
-        And Content of file "/foo/bar/BACKEND_HOST" in application pod is
+        And Content of file "/foo/bar/host" in application pod is
             """
             example.common
             """
-        And Content of file "/foo/bar/BACKEND_PORT" in application pod is
+        And Content of file "/foo/bar/port" in application pod is
             """
             8080
             """
@@ -210,14 +210,14 @@ Feature: Bindings get injected as files in application
             """
         Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-backend-vm-04" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-backend-vm-04" should be changed to "True"
-        And The env var "BACKEND_HOST" is not available to the application
-        And The env var "BACKEND_PORT" is not available to the application
+        And The env var "host" is not available to the application
+        And The env var "port" is not available to the application
         And The application env var "SERVICE_BINDING_ROOT" has value "/var/data"
-        And Content of file "/var/data/binding-backend-vm-04/BACKEND_HOST" in application pod is
+        And Content of file "/var/data/binding-backend-vm-04/host" in application pod is
             """
             example.common
             """
-        And Content of file "/var/data/binding-backend-vm-04/BACKEND_PORT" in application pod is
+        And Content of file "/var/data/binding-backend-vm-04/port" in application pod is
             """
             8080
             """
@@ -255,7 +255,6 @@ Feature: Bindings get injected as files in application
                     version: v1
                     kind: Backend
                     name: backend-demo-05
-                    namePrefix: ""
 
                 application:
                     name: generic-app-a-d-u-5
@@ -265,14 +264,14 @@ Feature: Bindings get injected as files in application
             """
         Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-backend-vm-05" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-backend-vm-05" should be changed to "True"
-        And The env var "HOST" is not available to the application
-        And The env var "PORT" is not available to the application
+        And The env var "host" is not available to the application
+        And The env var "port" is not available to the application
         And The env var "SERVICE_BINDING_ROOT" is not available to the application
-        And Content of file "/foo/bar/HOST" in application pod is
+        And Content of file "/foo/bar/host" in application pod is
             """
             example.common
             """
-        And Content of file "/foo/bar/PORT" in application pod is
+        And Content of file "/foo/bar/port" in application pod is
             """
             8080
             """
@@ -315,14 +314,14 @@ Feature: Bindings get injected as files in application
             """
         Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-backend-vm-06" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-backend-vm-06" should be changed to "True"
-        And The env var "BACKEND_HOST" is not available to the application
-        And The env var "BACKEND_PORT" is not available to the application
+        And The env var "host" is not available to the application
+        And The env var "port" is not available to the application
         And The env var "SERVICE_BINDING_ROOT" is not available to the application
-        And Content of file "/foo/bar/BACKEND_HOST" in application pod is
+        And Content of file "/foo/bar/host" in application pod is
             """
             example.common
             """
-        And Content of file "/foo/bar/BACKEND_PORT" in application pod is
+        And Content of file "/foo/bar/port" in application pod is
             """
             8080
             """
@@ -349,14 +348,14 @@ Feature: Bindings get injected as files in application
             """
         Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-backend-vm-06" should be changed to "True"
         And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "binding-backend-vm-06" should be changed to "True"
-        And The env var "BACKEND_HOST" is not available to the application
-        And The env var "BACKEND_PORT" is not available to the application
+        And The env var "host" is not available to the application
+        And The env var "port" is not available to the application
         And The env var "SERVICE_BINDING_ROOT" is not available to the application
-        And Content of file "/foo/newbar/BACKEND_HOST" in application pod is
+        And Content of file "/foo/newbar/host" in application pod is
             """
             example.common
             """
-        And Content of file "/foo/newbar/BACKEND_PORT" in application pod is
+        And Content of file "/foo/newbar/port" in application pod is
             """
             8080
             """

--- a/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
+++ b/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
@@ -59,7 +59,6 @@ Feature: Insert service binding to a custom location in application resource
             metadata:
                 name: binding-request-csp
             spec:
-                namePrefix: qiye111
                 application:
                     name: demo-appconfig-csp
                     group: stable.example.com
@@ -73,7 +72,6 @@ Feature: Insert service binding to a custom location in application resource
                     kind: Database
                     name: db-demo-csp
                     id: zzz
-                    namePrefix: qiye
             """
         Then Service Binding "binding-request-csp" is ready
         And Secret "binding-request-csp" has been injected in to CR "demo-appconfig-csp" of kind "AppConfig" at path "{.spec.spec.containers[0].envFrom[0].secretRef.name}"
@@ -97,7 +95,6 @@ Feature: Insert service binding to a custom location in application resource
             metadata:
                 name: binding-request-ssp
             spec:
-                namePrefix: qiye111
                 application:
                     name: demo-appconfig-ssp
                     group: stable.example.com
@@ -111,7 +108,6 @@ Feature: Insert service binding to a custom location in application resource
                     kind: Database
                     name: db-demo-ssp
                     id: zzz
-                    namePrefix: qiye
             """
         Then Service Binding "binding-request-ssp" is ready
         And Secret "binding-request-ssp" has been injected in to CR "demo-appconfig-ssp" of kind "AppConfig" at path "{.spec.spec.secret}"


### PR DESCRIPTION
## **Why ?** 
At the moment, binding names declared through annotations or CSV descriptors are processed before injected into the application according to the following strategy:

- names are upper-cased
- service resource kind is upper-cased and prepended to the name

Currently there is no way to build custom environment variable key except using naming prefix, This PR provides a way to have go template in the service field of SB request which can then be used to prepare environment variable name.

## **How ?**
With this PR we can define `namingStrategy`, a template which can be used in the preparation for env variable key.
sample SB request would look like
```
apiVersion: operators.coreos.com/v1alpha1
kind: ServiceBinding
metadata:
    name: binding-example
spec:
    namingStrategy: '{{ .service.kind | lower }}_custom_svc_{{ .name | lower }}'
    services:
    -   group: stable.example.com
        version: v1
        kind: Backend
        name: backend-demo
    application:
        name: generic-app
        group: apps
        version: v1
        resource: deployments
```

Above applied naming strategy would yield following env variable ` database_custom_svc_namefield`

## ****Predefined naming strategies****
1. none - `{{ .name  }}` -  if namingStrategy is set to 'none', then there won't any changes in the env variable key.
2. uppercase - `{{ .service.kind | upper }}_{{ .name | upper }}` - if no namingStrategy is set then `default` strategy would be used.
3. lowercase - `{{ .name | lower }}` - If `bindAsFiles` set to true then binding names would be lowercased.

Note: If `namingStrategy` provided isn't in the above list then value would be treated as template string.

## **Deprecation of features**
Following old features would be removed as a part of this PR.
1. Support of `namePrefix` and `globalNamePrefix` would be removed, since this can now be added as a part of naming strategy template.
2. In case we have not provided any namingStrategy then environment variable key would be uppercased name. i.e `HOST`, earlier we used to append kind as a prefix . i.e `BACKEND_HOST`.

## **TODO**

- [x]  Define global naming strategy.
- [x] Remove `globalNamePrefix` and `namePrefix` references in the code.
- [x] Fix acceptance tests based on the updates in the env variable keys.
- [x] Update documentation.

Ref: https://issues.redhat.com/browse/APPSVC-774