### PR TITLE
Make operator package name configurable in install.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,6 +491,7 @@ deploy-from-index-image:
 	$(info "Installing SBO using a Catalog Source from '$(OPERATOR_INDEX_IMAGE_REF)' index image")
 	$(Q)OPERATOR_INDEX_IMAGE=$(OPERATOR_INDEX_IMAGE_REF) \
 		OPERATOR_CHANNEL=$(OPERATOR_CHANNEL) \
+		OPERATOR_PACKAGE=$(CSV_PACKAGE_NAME) \
 		SKIP_REGISTRY_LOGIN=true \
 		./install.sh
 

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 
 OLM_VERSION=0.17.0
 OPERATOR_CHANNEL=${OPERATOR_CHANNEL:-beta}
+OPERATOR_PACKAGE=${OPERATOR_PACKAGE:-service-binding-operator}
 DOCKER_CFG=${DOCKER_CFG:-$HOME/.docker/config.json}
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 
@@ -78,12 +79,12 @@ else
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: service-binding-operator
+  name: $OPERATOR_PACKAGE
   namespace: $OPERATOR_NAMESPACE
 spec:
   channel: $OPERATOR_CHANNEL
   installPlanApproval: Automatic
-  name: service-binding-operator
+  name: $OPERATOR_PACKAGE
   source: $CATSRC_NAME
   sourceNamespace: $CATSRC_NAMESPACE
 EOD


### PR DESCRIPTION
### Motivation

Currently in `install.sh` script SBO's package name in subscription is hard-coded to be `service-binding-operator`. However there are situations where the name of the package is different - such is the case of Red Hat's productized version of SBO, where the package name is actually `rh-service-binding-operator`. So currently the installation fails because of the package name mismatch. 

### Changes

This PR:
* Introduces an optional parameter (`OPERATOR_PACKAGE` env variable) that can be used to specify the desired name of the package. The default value remains `service-binding-operator`.

### Testing

* Run tests with OpenShift and Red Hat oficial bundle:
```sh
OPERATOR_INDEX_IMAGE_REF=registry.redhat.io/redhat/redhat-operator-index:v4.6 OPERATOR_CHANNEL=preview CSV_PACKAGE_NAME=rh-service-binding-operator make test-acceptance-with-bundle
```
