### PR TITLE
Move user-relevant constant to API package

### DIFF
--- a/pkg/apis/operators/v1alpha1/register.go
+++ b/pkg/apis/operators/v1alpha1/register.go
@@ -14,6 +14,8 @@ var (
 	// SchemeGroupVersion is group version used to register these objects
 	SchemeGroupVersion = schema.GroupVersion{Group: "operators.coreos.com", Version: "v1alpha1"}
 
+	GroupVersionKind = SchemeGroupVersion.WithKind("ServiceBinding")
+
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 )

--- a/pkg/apis/operators/v1alpha1/servicebinding_types.go
+++ b/pkg/apis/operators/v1alpha1/servicebinding_types.go
@@ -6,6 +6,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// BindingReady indicates that the overall sbr succeeded
+	BindingReady conditionsv1.ConditionType = "Ready"
+	// CollectionReady indicates readiness for collection and persistance of intermediate manifests
+	CollectionReady conditionsv1.ConditionType = "CollectionReady"
+	// InjectionReady indicates readiness to change application manifests to use those intermediate manifests
+	// If status is true, it indicates that the binding succeeded
+	InjectionReady conditionsv1.ConditionType = "InjectionReady"
+	// EmptyServiceSelectorsReason is used when the ServiceBinding has empty
+	// services.
+	EmptyServiceSelectorsReason = "EmptyServiceSelectors"
+	// EmptyApplicationReason is used when the ServiceBinding has empty
+	// application.
+	EmptyApplicationReason = "EmptyApplication"
+	// ApplicationNotFoundReason is used when the application is not found.
+	ApplicationNotFoundReason = "ApplicationNotFound"
+	// ServiceNotFoundReason is used when the service is not found.
+	ServiceNotFoundReason = "ServiceNotFound"
+)
+
 // Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 
 // ServiceBindingSpec defines the desired state of ServiceBinding

--- a/pkg/controller/servicebinding/common.go
+++ b/pkg/controller/servicebinding/common.go
@@ -10,8 +10,6 @@ import (
 const (
 	// serviceBindingRequestResource the name of ServiceBinding resource.
 	serviceBindingRequestResource = "servicebindings"
-	// serviceBindingRequestKind defines the name of the CRD kind.
-	serviceBindingRequestKind = "ServiceBinding"
 	// clusterServiceVersionKind the name of ClusterServiceVersion kind.
 	clusterServiceVersionKind = "ClusterServiceVersion"
 	// secretResource defines the resource name for Secrets.

--- a/pkg/controller/servicebinding/reconciler.go
+++ b/pkg/controller/servicebinding/reconciler.go
@@ -20,25 +20,6 @@ import (
 	"github.com/redhat-developer/service-binding-operator/pkg/log"
 )
 
-const (
-	// BindingReady indicates that the overall sbr succeeded
-	BindingReady conditionsv1.ConditionType = "Ready"
-	// CollectionReady indicates readiness for collection and persistance of intermediate manifests
-	CollectionReady conditionsv1.ConditionType = "CollectionReady"
-	// InjectionReady indicates readiness to change application manifests to use those intermediate manifests
-	// If status is true, it indicates that the binding succeeded
-	InjectionReady conditionsv1.ConditionType = "InjectionReady"
-	// EmptyServiceSelectorsReason is used when the ServiceBinding has empty
-	// services.
-	EmptyServiceSelectorsReason = "EmptyServiceSelectors"
-	// EmptyApplicationReason is used when the ServiceBinding has empty
-	// application.
-	EmptyApplicationReason = "EmptyApplication"
-	// ApplicationNotFoundReason is used when the application is not found.
-	ApplicationNotFoundReason = "ApplicationNotFound"
-	// ServiceNotFoundReason is used when the service is not found.
-	ServiceNotFoundReason = "ServiceNotFound"
-)
 
 // Reconciler reconciles a ServiceBinding object
 type reconciler struct {
@@ -131,17 +112,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 			r.dynClient,
 			sbr,
 			conditionsv1.Condition{
-				Type:    CollectionReady,
+				Type:    v1alpha1.CollectionReady,
 				Status:  corev1.ConditionFalse,
-				Reason:  EmptyServiceSelectorsReason,
+				Reason:  v1alpha1.EmptyServiceSelectorsReason,
 				Message: errEmptyServices.Error(),
 			},
 			conditionsv1.Condition{
-				Type:   InjectionReady,
+				Type:   v1alpha1.InjectionReady,
 				Status: corev1.ConditionFalse,
 			},
 			conditionsv1.Condition{
-				Type:   BindingReady,
+				Type:   v1alpha1.BindingReady,
 				Status: corev1.ConditionFalse,
 			},
 		)
@@ -169,17 +150,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		if k8serrors.IsNotFound(err) {
 			err = updateSBRConditions(r.dynClient, sbr,
 				conditionsv1.Condition{
-					Type:    CollectionReady,
+					Type:    v1alpha1.CollectionReady,
 					Status:  corev1.ConditionFalse,
-					Reason:  ServiceNotFoundReason,
+					Reason:  v1alpha1.ServiceNotFoundReason,
 					Message: err.Error(),
 				},
 				conditionsv1.Condition{
-					Type:   InjectionReady,
+					Type:   v1alpha1.InjectionReady,
 					Status: corev1.ConditionFalse,
 				},
 				conditionsv1.Condition{
-					Type:   BindingReady,
+					Type:   v1alpha1.BindingReady,
 					Status: corev1.ConditionFalse,
 				},
 			)

--- a/pkg/controller/servicebinding/reconciler_test.go
+++ b/pkg/controller/servicebinding/reconciler_test.go
@@ -131,9 +131,9 @@ func TestApplicationByName(t *testing.T) {
 		sbrOutput, err := r.getServiceBinding(namespacedName)
 		require.NoError(t, err)
 
-		requireConditionPresentAndTrue(t, CollectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, InjectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, BindingReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.InjectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.BindingReady, sbrOutput.Status.Conditions)
 
 		require.Equal(t, 1, len(sbrOutput.Status.Applications))
 		expectedStatus := v1alpha1.BoundApplication{
@@ -195,9 +195,9 @@ func TestReconcilerReconcileUsingSecret(t *testing.T) {
 		sbrOutput, err := r.getServiceBinding(namespacedName)
 		require.NoError(t, err)
 
-		requireConditionPresentAndTrue(t, CollectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, InjectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, BindingReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.InjectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.BindingReady, sbrOutput.Status.Conditions)
 
 		require.Equal(t, reconcilerName, sbrOutput.Status.Secret)
 
@@ -282,9 +282,9 @@ func TestServiceNotFound(t *testing.T) {
 	sbrOutput, err := r.getServiceBinding(namespacedName)
 	require.NoError(t, err)
 
-	requireConditionPresentAndFalse(t, CollectionReady, sbrOutput.Status.Conditions)
-	requireConditionPresentAndFalse(t, InjectionReady, sbrOutput.Status.Conditions)
-	requireConditionPresentAndFalse(t, BindingReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndFalse(t, v1alpha1.CollectionReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndFalse(t, v1alpha1.InjectionReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndFalse(t, v1alpha1.BindingReady, sbrOutput.Status.Conditions)
 	require.Len(t, sbrOutput.Status.Applications, 0)
 
 	// Reconcile with service
@@ -306,9 +306,9 @@ func TestServiceNotFound(t *testing.T) {
 	sbrOutput2, err := r.getServiceBinding(namespacedName)
 	require.NoError(t, err)
 
-	requireConditionPresentAndTrue(t, CollectionReady, sbrOutput2.Status.Conditions)
-	requireConditionPresentAndTrue(t, InjectionReady, sbrOutput2.Status.Conditions)
-	requireConditionPresentAndTrue(t, BindingReady, sbrOutput2.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput2.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.InjectionReady, sbrOutput2.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.BindingReady, sbrOutput2.Status.Conditions)
 
 	require.Equal(t, reconcilerName, sbrOutput2.Status.Secret)
 	require.Equal(t, 1, len(sbrOutput2.Status.Applications))
@@ -341,9 +341,9 @@ func TestApplicationNotFound(t *testing.T) {
 	sbrOutput, err := r.getServiceBinding(namespacedName)
 	require.NoError(t, err)
 
-	requireConditionPresentAndTrue(t, CollectionReady, sbrOutput.Status.Conditions)
-	requireConditionPresentAndFalse(t, InjectionReady, sbrOutput.Status.Conditions)
-	requireConditionPresentAndFalse(t, BindingReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndFalse(t, v1alpha1.InjectionReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndFalse(t, v1alpha1.BindingReady, sbrOutput.Status.Conditions)
 	require.Len(t, sbrOutput.Status.Applications, 0)
 
 	// Reconcile with deployment
@@ -364,9 +364,9 @@ func TestApplicationNotFound(t *testing.T) {
 	sbrOutput2, err := r.getServiceBinding(namespacedName)
 	require.NoError(t, err)
 
-	requireConditionPresentAndTrue(t, CollectionReady, sbrOutput2.Status.Conditions)
-	requireConditionPresentAndTrue(t, InjectionReady, sbrOutput2.Status.Conditions)
-	requireConditionPresentAndTrue(t, BindingReady, sbrOutput2.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput2.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.InjectionReady, sbrOutput2.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.BindingReady, sbrOutput2.Status.Conditions)
 
 	require.Equal(t, reconcilerName, sbrOutput2.Status.Secret)
 	require.Equal(t, 1, len(sbrOutput2.Status.Applications))
@@ -416,9 +416,9 @@ func TestReconcilerUpdateCredentials(t *testing.T) {
 	sbrOutput3, err := r.getServiceBinding(namespacedName)
 	require.NoError(t, err)
 
-	requireConditionPresentAndTrue(t, CollectionReady, sbrOutput3.Status.Conditions)
-	requireConditionPresentAndTrue(t, InjectionReady, sbrOutput3.Status.Conditions)
-	requireConditionPresentAndTrue(t, BindingReady, sbrOutput3.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput3.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.InjectionReady, sbrOutput3.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.BindingReady, sbrOutput3.Status.Conditions)
 
 	require.Equal(t, reconcilerName, sbrOutput3.Status.Secret)
 	require.Equal(t, s.Data["password"], []byte("abc123"))
@@ -476,9 +476,9 @@ func TestReconcilerReconcileWithConflictingAppSelc(t *testing.T) {
 			},
 		}
 
-		requireConditionPresentAndTrue(t, CollectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, InjectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, BindingReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.InjectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.BindingReady, sbrOutput.Status.Conditions)
 
 		require.Equal(t, reconcilerName, sbrOutput.Status.Secret)
 		require.Len(t, sbrOutput.Status.Applications, 1)
@@ -506,9 +506,9 @@ func TestEmptyApplication(t *testing.T) {
 	sbrOutput, err := r.getServiceBinding(namespacedName)
 	require.NoError(t, err)
 
-	requireConditionPresentAndTrue(t, CollectionReady, sbrOutput.Status.Conditions)
-	requireConditionPresentAndFalse(t, InjectionReady, sbrOutput.Status.Conditions)
-	requireConditionPresentAndTrue(t, BindingReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndFalse(t, v1alpha1.InjectionReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndTrue(t, v1alpha1.BindingReady, sbrOutput.Status.Conditions)
 }
 
 // TestEmptyServiceSelector tests that CollectionReady,InjectionReady and BindingReady are all successfully updated to True when ServiceSelector is empty
@@ -530,9 +530,9 @@ func TestEmptyServiceSelectorAndAllConditionAreSetToFalse(t *testing.T) {
 	sbrOutput, err := r.getServiceBinding(namespacedName)
 	require.NoError(t, err)
 
-	requireConditionPresentAndFalse(t, CollectionReady, sbrOutput.Status.Conditions)
-	requireConditionPresentAndFalse(t, InjectionReady, sbrOutput.Status.Conditions)
-	requireConditionPresentAndFalse(t, BindingReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndFalse(t, v1alpha1.CollectionReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndFalse(t, v1alpha1.InjectionReady, sbrOutput.Status.Conditions)
+	requireConditionPresentAndFalse(t, v1alpha1.BindingReady, sbrOutput.Status.Conditions)
 
 }
 
@@ -588,9 +588,9 @@ func TestBindTwoSbrsWithSingleApplication(t *testing.T) {
 			},
 		}
 
-		requireConditionPresentAndTrue(t, CollectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, InjectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, BindingReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.InjectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.BindingReady, sbrOutput.Status.Conditions)
 		require.Equal(t, sbrName1, sbrOutput.Status.Secret)
 		require.Len(t, sbrOutput.Status.Applications, 1)
 		require.True(t, reflect.DeepEqual(expectedStatus, sbrOutput.Status.Applications[0]))
@@ -626,9 +626,9 @@ func TestBindTwoSbrsWithSingleApplication(t *testing.T) {
 			},
 		}
 
-		requireConditionPresentAndTrue(t, CollectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, InjectionReady, sbrOutput.Status.Conditions)
-		requireConditionPresentAndTrue(t, BindingReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.CollectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.InjectionReady, sbrOutput.Status.Conditions)
+		requireConditionPresentAndTrue(t, v1alpha1.BindingReady, sbrOutput.Status.Conditions)
 		require.Equal(t, sbrName2, sbrOutput.Status.Secret)
 		require.Len(t, sbrOutput.Status.Applications, 1)
 		require.True(t, reflect.DeepEqual(expectedStatus, sbrOutput.Status.Applications[0]))

--- a/pkg/controller/servicebinding/sbrcontroller.go
+++ b/pkg/controller/servicebinding/sbrcontroller.go
@@ -271,9 +271,8 @@ func buildSBRPredicate(logger *log.Log) predicate.Funcs {
 
 // addSBRWatch creates a watchon ServiceBinding GVK.
 func (s *sbrController) addSBRWatch() error {
-	gvk := v1alpha1.SchemeGroupVersion.WithKind(serviceBindingRequestKind)
-	l := s.logger.WithValues("GKV", gvk)
-	src := s.createSourceForGVK(gvk)
+	l := s.logger.WithValues("GKV", v1alpha1.GroupVersionKind)
+	src := s.createSourceForGVK(v1alpha1.GroupVersionKind)
 	err := s.Controller.Watch(src, s.newEnqueueRequestsForSBR(), buildSBRPredicate(l))
 	if err != nil {
 		l.Error(err, "on creating watch for ServiceBinding")

--- a/pkg/controller/servicebinding/servicebinder.go
+++ b/pkg/controller/servicebinding/servicebinder.go
@@ -227,13 +227,13 @@ func (b *serviceBinder) onError(
 		b.setApplicationObjects(sbrStatus, objs)
 	}
 	conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
-		Type:    InjectionReady,
+		Type:    v1alpha1.InjectionReady,
 		Status:  corev1.ConditionFalse,
 		Reason:  bindingFail,
 		Message: b.message(err),
 	})
 	conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
-		Type:   BindingReady,
+		Type:   v1alpha1.BindingReady,
 		Status: corev1.ConditionFalse,
 	})
 	newSbr, errStatus := b.updateStatusServiceBinding(sbr, sbrStatus)
@@ -306,19 +306,19 @@ func (b *serviceBinder) bind() (reconcile.Result, error) {
 	sbrStatus.Secret = secretObj.GetName()
 
 	conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
-		Type:   CollectionReady,
+		Type:   v1alpha1.CollectionReady,
 		Status: corev1.ConditionTrue,
 	})
 
 	if isApplicationEmpty(b.sbr.Spec.Application) {
 		conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
-			Type:    InjectionReady,
+			Type:    v1alpha1.InjectionReady,
 			Status:  corev1.ConditionFalse,
-			Reason:  EmptyApplicationReason,
+			Reason:  v1alpha1.EmptyApplicationReason,
 			Message: errEmptyApplication.Error(),
 		})
 		conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
-			Type:   BindingReady,
+			Type:   v1alpha1.BindingReady,
 			Status: corev1.ConditionTrue,
 		})
 		return b.handleApplicationError(errEmptyApplication, sbrStatus)
@@ -328,13 +328,13 @@ func (b *serviceBinder) bind() (reconcile.Result, error) {
 		b.logger.Error(err, "On binding application.")
 		if errors.Is(err, errApplicationNotFound) {
 			conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
-				Type:    InjectionReady,
+				Type:    v1alpha1.InjectionReady,
 				Status:  corev1.ConditionFalse,
-				Reason:  ApplicationNotFoundReason,
+				Reason:  v1alpha1.ApplicationNotFoundReason,
 				Message: errApplicationNotFound.Error(),
 			})
 			conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
-				Type:   BindingReady,
+				Type:   v1alpha1.BindingReady,
 				Status: corev1.ConditionFalse,
 			})
 			return b.handleApplicationError(errApplicationNotFound, sbrStatus)
@@ -344,11 +344,11 @@ func (b *serviceBinder) bind() (reconcile.Result, error) {
 	b.setApplicationObjects(sbrStatus, updatedObjects)
 
 	conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
-		Type:   InjectionReady,
+		Type:   v1alpha1.InjectionReady,
 		Status: corev1.ConditionTrue,
 	})
 	conditionsv1.SetStatusCondition(&sbrStatus.Conditions, conditionsv1.Condition{
-		Type:   BindingReady,
+		Type:   v1alpha1.BindingReady,
 		Status: corev1.ConditionTrue,
 	})
 

--- a/pkg/controller/servicebinding/servicebinder_test.go
+++ b/pkg/controller/servicebinding/servicebinder_test.go
@@ -430,15 +430,15 @@ func TestServiceBinder_Bind(t *testing.T) {
 		},
 		wantConditions: []wantedCondition{
 			{
-				Type:   CollectionReady,
+				Type:   v1alpha1.CollectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:   InjectionReady,
+				Type:   v1alpha1.InjectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:   BindingReady,
+				Type:   v1alpha1.BindingReady,
 				Status: corev1.ConditionTrue,
 			},
 		},
@@ -476,15 +476,15 @@ func TestServiceBinder_Bind(t *testing.T) {
 		},
 		wantConditions: []wantedCondition{
 			{
-				Type:   CollectionReady,
+				Type:   v1alpha1.CollectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:   InjectionReady,
+				Type:   v1alpha1.InjectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:   BindingReady,
+				Type:   v1alpha1.BindingReady,
 				Status: corev1.ConditionTrue,
 			},
 		},
@@ -523,15 +523,15 @@ func TestServiceBinder_Bind(t *testing.T) {
 		},
 		wantConditions: []wantedCondition{
 			{
-				Type:   CollectionReady,
+				Type:   v1alpha1.CollectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:   InjectionReady,
+				Type:   v1alpha1.InjectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:   BindingReady,
+				Type:   v1alpha1.BindingReady,
 				Status: corev1.ConditionTrue,
 			},
 		},
@@ -550,17 +550,17 @@ func TestServiceBinder_Bind(t *testing.T) {
 		},
 		wantConditions: []wantedCondition{
 			{
-				Type:   CollectionReady,
+				Type:   v1alpha1.CollectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:    InjectionReady,
+				Type:    v1alpha1.InjectionReady,
 				Status:  corev1.ConditionFalse,
-				Reason:  EmptyApplicationReason,
+				Reason:  v1alpha1.EmptyApplicationReason,
 				Message: errEmptyApplication.Error(),
 			},
 			{
-				Type:   BindingReady,
+				Type:   v1alpha1.BindingReady,
 				Status: corev1.ConditionTrue,
 			},
 		},
@@ -579,17 +579,17 @@ func TestServiceBinder_Bind(t *testing.T) {
 		},
 		wantConditions: []wantedCondition{
 			{
-				Type:   CollectionReady,
+				Type:   v1alpha1.CollectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:    InjectionReady,
+				Type:    v1alpha1.InjectionReady,
 				Status:  corev1.ConditionFalse,
-				Reason:  ApplicationNotFoundReason,
+				Reason:  v1alpha1.ApplicationNotFoundReason,
 				Message: errApplicationNotFound.Error(),
 			},
 			{
-				Type:   BindingReady,
+				Type:   v1alpha1.BindingReady,
 				Status: corev1.ConditionFalse,
 			},
 		},
@@ -620,15 +620,15 @@ func TestServiceBinder_Bind(t *testing.T) {
 		},
 		wantConditions: []wantedCondition{
 			{
-				Type:   CollectionReady,
+				Type:   v1alpha1.CollectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:   InjectionReady,
+				Type:   v1alpha1.InjectionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type:   BindingReady,
+				Type:   v1alpha1.BindingReady,
 				Status: corev1.ConditionTrue,
 			},
 		},


### PR DESCRIPTION
API consumer would like to bring a minimal set of transitive dependencies in his project,
when adding service binding API as one of the dependencies. Thus, following constants
need to be moved our of controller/servicebinding to api/operators/v1alpha package:

* GroupVersionKind of ServiceBinding
* several condition types


Fizes #375