### PR TITLE
Fix regression: previously create test namespace is used across test runs

### DIFF
--- a/hack/get-test-namespace
+++ b/hack/get-test-namespace
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+OUTPUT_DIR=$1
+NS_FILE=${OUTPUT_DIR}/test-namespace
+
+# https://gist.github.com/markusfisch/6110640
+uuid()
+{
+    local N B C='89ab'
+
+    for (( N=0; N < 16; ++N ))
+    do
+        B=$(( $RANDOM%256 ))
+
+        case $N in
+            6)
+                printf '4%x' $(( B%16 ))
+                ;;
+            8)
+                printf '%c%x' ${C:$RANDOM%${#C}:1} $(( B%16 ))
+                ;;
+            3 | 5 | 7 | 9)
+                printf '%02x-' $B
+                ;;
+            *)
+                printf '%02x' $B
+                ;;
+        esac
+    done
+
+    echo
+}
+
+mkdir -p "$OUTPUT_DIR"
+
+[ -f "$NS_FILE" ] || echo "test-namespace-$(uuid | cut -d '-' -f 5)" > "$NS_FILE"
+
+cat "$NS_FILE"


### PR DESCRIPTION
This fixes regression introduced in PR #848 - we should reuse created test namespace
across multiple runs of acceptance tests

### Testing

Two consecutive runs of `make test-acceptance` should create just single
test namespace.