### PR TITLE
[WIP]Fix ServiceBinding removal when app does not exist

### DIFF
--- a/controllers/servicebinder.go
+++ b/controllers/servicebinder.go
@@ -143,6 +143,10 @@ func (b *serviceBinder) unbind() (reconcile.Result, error) {
 	}
 
 	if err := b.binder.unbind(); err != nil {
+		if errors.Is(err, errApplicationNotFound) {
+			b.logger.Error(err, "Bound application has been deleted!", "sbr.Namespace", b.binder.sbr.Namespace, "sbr.Name", b.binder.sbr.Name)
+			return noRequeue(err)
+		}
 		logger.Error(err, "On unbinding related objects")
 		return requeueError(err)
 	}

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -394,6 +394,8 @@ def apply_yaml(context):
 # STEP
 @given(u'BackingService is deleted')
 @when(u'BackingService is deleted')
+@given(u'App is deleted')
+@when(u'App is deleted')
 def delete_yaml(context):
     openshift = Openshift()
     metadata = yaml.full_load(context.text)["metadata"]

--- a/test/acceptance/features/unbindAppToService.feature
+++ b/test/acceptance/features/unbindAppToService.feature
@@ -106,3 +106,53 @@ Feature: Unbind an application from a service
 
         Then The env var "BACKEND_HOST" is not available to the application
         And The env var "BACKEND_USERNAME" is not available to the application
+    
+    Scenario: Unbind a generic test application from the backing service when the test application has been deleted
+        Given OLM Operator "backend" is running
+        * The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: Backend
+            metadata:
+                name: example-backend
+                annotations:
+                    service.binding/host: path={.spec.host}
+                    service.binding/username: path={.spec.username}
+            spec:
+                host: example.com
+                username: foo
+            """
+        * Generic test application "generic-app-a-d-u" is running
+        * Service Binding is applied
+            """
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-request-a-d-u
+            spec:
+                application:
+                    name: generic-app-a-d-u
+                    group: apps
+                    version: v1
+                    resource: deployments
+                services:
+                -   group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: example-backend
+                    id: backend
+            """
+        * The application env var "BACKEND_HOST" has value "example.com"
+        * The application env var "BACKEND_USERNAME" has value "foo"
+
+        When App is deleted
+          """
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: generic-app-a-d-u
+          """
+        When Service binding "binding-request-a-d-u" is deleted
+
+        Then The env var "BACKEND_HOST" is not available to the application
+        And The env var "BACKEND_USERNAME" is not available to the application


### PR DESCRIPTION
If the app has been deleted, then when it tries to delete the SBR, the reconcile process will fail and the SBR can not be deleted.
The error log is as below:

```
{"level":"error","ts":"2021-01-29T08:01:11.139Z","logger":"reconciler.unbind.Unbind","msg":"On unbinding related objects","Request.Namespace":"5bfsxfxbzdi","Request.Name":"backend-job-job-service-binding","error":"application not found","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/redhat-developer/service-binding-operator/pkg/log.(*Log).Error\n\t/go/src/github.com/redhat-developer/service-binding-operator/pkg/log/log.go:35\ngithub.com/redhat-developer/service-binding-operator/pkg/controller/servicebinding.(*serviceBinder).unbind\n\t/go/src/github.com/redhat-developer/service-binding-operator/pkg/controller/servicebinding/servicebinder.go:157\ngithub.com/redhat-developer/service-binding-operator/pkg/controller/servicebinding.(*reconciler).Reconcile\n\t/go/src/github.com/redhat-developer/service-binding-operator/pkg/controller/servicebinding/reconciler.go:141\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
{"level":"error","ts":"2021-01-29T08:01:11.139Z","logger":"controller-runtime.controller","msg":"Reconciler error","controller":"servicebinding-controller","request":"5bfsxfxbzdi/backend-job-job-service-binding","error":"application not found","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:258\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```