### PR TITLE
Fix: service binding removal when application is not found

### DIFF
--- a/controllers/servicebinder.go
+++ b/controllers/servicebinder.go
@@ -142,8 +142,11 @@ func (b *serviceBinder) unbind() (reconcile.Result, error) {
 	}
 
 	if err := b.binder.unbind(); err != nil {
-		logger.Error(err, "On unbinding related objects")
-		return requeueError(err)
+		if !errors.Is(err, errApplicationNotFound) {
+			logger.Error(err, "On unbinding related objects")
+			return requeueError(err)
+		}
+		b.logger.Info("Bound application has been deleted! Will not requeue the error and continue to remove the finalizer", "sbr.Namespace", b.binder.sbr.Namespace, "sbr.Name", b.binder.sbr.Name)
 	}
 
 	logger.Debug("Removing resource finalizers...")

--- a/test/acceptance/features/steps/app.py
+++ b/test/acceptance/features/steps/app.py
@@ -29,6 +29,11 @@ class App(object):
                                            check_success=lambda v: v != "", step=1, timeout=100)
         return running
 
+    def delete(self):
+        (output, exit_code) = self.cmd.run(
+            f"{ctx.cli} delete --wait=true --timeout=120s deployment/{self.name} -n {self.namespace}")
+        assert exit_code == 0, f"Unexpected exit code ({exit_code}) while deleting application '{self.name}': {output}"
+
     def install(self, bindingRoot=None):
         self.openshift.new_app(self.name, self.app_image, self.namespace, bindingRoot)
         self.openshift.expose_service_route(self.name, self.namespace, self.port)

--- a/test/acceptance/features/steps/generic_testapp.py
+++ b/test/acceptance/features/steps/generic_testapp.py
@@ -49,6 +49,12 @@ def is_running(context, application_name, bindingRoot=None):
     context.latest_application_generation = application.get_generation()
 
 
+@step(u'Application "{application_name}" is deleted')
+def delete_application(context, application_name):
+    application = GenericTestApp(application_name, context.namespace.name)
+    application.delete()
+
+
 @step(u'The application env var "{name}" has value "{value}"')
 def check_env_var_value(context, name, value):
     found = polling2.poll(lambda: context.application.get_env_var_value(name) == value, step=5, timeout=400)

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -224,7 +224,7 @@ def then_app_is_connected_to_db(context, db_name):
     polling2.poll(lambda: context.application.get_response_from_api(endpoint=db_endpoint) == db_name, step=5, timeout=600)
 
 
-@when(u'Service binding "{sb_name}" is deleted')
+@step(u'Service binding "{sb_name}" is deleted')
 def service_binding_is_deleted(context, sb_name):
     openshift = Openshift()
     openshift.delete_service_binding(sb_name, context.namespace.name)
@@ -413,8 +413,7 @@ def apply_yaml(context):
 
 
 # STEP
-@given(u'BackingService is deleted')
-@when(u'BackingService is deleted')
+@step(u'BackingService is deleted')
 def delete_yaml(context):
     openshift = Openshift()
     metadata = yaml.full_load(context.text)["metadata"]

--- a/test/acceptance/features/unbindAppToService.feature
+++ b/test/acceptance/features/unbindAppToService.feature
@@ -107,3 +107,44 @@ Feature: Unbind an application from a service
 
         Then The env var "BACKEND_HOST" is not available to the application
         And The env var "BACKEND_USERNAME" is not available to the application
+    
+
+    Scenario: Remove binding when application does not exist anymore
+        Given The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: Backend
+            metadata:
+                name: example-backend
+                annotations:
+                    service.binding/host: path={.spec.host}
+                    service.binding/username: path={.spec.username}
+            spec:
+                host: example.com
+                username: foo
+            """
+        * Generic test application "generic-app-a-d-u" is running
+        * Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-request-a-d-u
+            spec:
+                application:
+                    name: generic-app-a-d-u
+                    group: apps
+                    version: v1
+                    resource: deployments
+                services:
+                -   group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: example-backend
+                    id: backend
+            """
+        * The application env var "BACKEND_HOST" has value "example.com"
+        * The application env var "BACKEND_USERNAME" has value "foo"
+
+        When Application "generic-app-a-d-u" is deleted
+        Then Service binding "binding-request-a-d-u" is deleted


### PR DESCRIPTION
If the app has been deleted, then when it tries to delete the SBR, the reconcile process will fail and the SBR can not be deleted.
The error log is as below:
```
{"level":"error","ts":"2021-01-29T08:01:11.139Z","logger":"reconciler.unbind.Unbind","msg":"On unbinding related objects","Request.Namespace":"5bfsxfxbzdi","Request.Name":"backend-job-job-service-binding","error":"application not found","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/redhat-developer/service-binding-operator/pkg/log.(*Log).Error\n\t/go/src/github.com/redhat-developer/service-binding-operator/pkg/log/log.go:35\ngithub.com/redhat-developer/service-binding-operator/pkg/controller/servicebinding.(*serviceBinder).unbind\n\t/go/src/github.com/redhat-developer/service-binding-operator/pkg/controller/servicebinding/servicebinder.go:157\ngithub.com/redhat-developer/service-binding-operator/pkg/controller/servicebinding.(*reconciler).Reconcile\n\t/go/src/github.com/redhat-developer/service-binding-operator/pkg/controller/servicebinding/reconciler.go:141\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
{"level":"error","ts":"2021-01-29T08:01:11.139Z","logger":"controller-runtime.controller","msg":"Reconciler error","controller":"servicebinding-controller","request":"5bfsxfxbzdi/backend-job-job-service-binding","error":"application not found","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:258\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/redhat-developer/service-binding-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}

```


The problem happens in race condition ...

If you delete a ksvc First,  then the sbr status will be 
```
status:
  conditions:
  - lastHeartbeatTime: "2021-02-05T05:20:21Z"
    lastTransitionTime: "2021-02-05T05:20:10Z"
    status: "True"
    type: CollectionReady
  - lastHeartbeatTime: "2021-02-05T05:20:21Z"
    lastTransitionTime: "2021-02-05T05:20:21Z"
    message: application not found
    reason: ApplicationNotFound
    status: "False"
    type: InjectionReady
  - lastHeartbeatTime: "2021-02-05T05:20:21Z"
    lastTransitionTime: "2021-02-05T05:20:21Z"
    status: "False"
    type: Ready
  secret: binding-request-knative
```
and the finalized is removed in 
https://github.com/redhat-developer/service-binding-operator/blob/8d2ae041a91fb8e51304277a987339ae9624f22a/pkg/controller/servicebinding/servicebinder.go#L284-L291
then, the further `delete sbr` won't have problems.

But if you delete sbr and ksvc at the same time, i.e. 
```
kubectl  delete sbr binding-request-knative &
kubectl  delete ksvc knative-vcap &
```
the sbr will go through unbind() process first since the finalizer in present ..  
Then, it reported a reconcile error as ksvc can't be found at all , and repeated the error again and again. 

The solution is to allow the Finalizer removal as well in this condition