### PR TITLE
Update API group to binding.operators.coreos.com

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,10 +1,10 @@
-domain: coreos.com
+domain: operators.coreos.com
 layout: go.kubebuilder.io/v3
 projectName: service-binding-operator
 repo: github.com/redhat-developer/service-binding-operator
 resources:
 - crdVersion: v1
-  group: operators
+  group: binding
   kind: ServiceBinding
   version: v1alpha1
 version: 3-alpha

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ connect to a backing service (for example, a database):
 #### Binding a Java Application with a Database
 
 ``` yaml
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the operators v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=operators.coreos.com
+// +groupName=binding.operators.coreos.com
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "operators.coreos.com", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "binding.operators.coreos.com", Version: "v1alpha1"}
 
 	GroupVersionResource = GroupVersion.WithResource("servicebindings")
 

--- a/config/crd/bases/binding.operators.coreos.com_servicebindings.yaml
+++ b/config/crd/bases/binding.operators.coreos.com_servicebindings.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: servicebindings.operators.coreos.com
+  name: servicebindings.binding.operators.coreos.com
 spec:
-  group: operators.coreos.com
+  group: binding.operators.coreos.com
   names:
     kind: ServiceBinding
     listKind: ServiceBindingList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/operators.coreos.com_servicebindings.yaml
+- bases/binding.operators.coreos.com_servicebindings.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/crd/patches/cainjection_in_servicebindings.yaml
+++ b/config/crd/patches/cainjection_in_servicebindings.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: servicebindings.operators.coreos.com
+  name: servicebindings.binding.operators.coreos.com

--- a/config/crd/patches/webhook_in_servicebindings.yaml
+++ b/config/crd/patches/webhook_in_servicebindings.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: servicebindings.operators.coreos.com
+  name: servicebindings.binding.operators.coreos.com
 spec:
   conversion:
     strategy: Webhook

--- a/config/manifests/bases/service-binding-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/service-binding-operator.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
@@ -18,7 +18,7 @@ spec:
     - description: ServiceBinding expresses intent to bind an operator-backed service with an application workload.
       displayName: Service Binding
       kind: ServiceBinding
-      name: servicebindings.operators.coreos.com
+      name: servicebindings.binding.operators.coreos.com
       version: v1alpha1
   description: " The Service Binding Operator enables application developers to more
                    easily bind applications together with operator managed backing services such

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -45,7 +45,7 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - operators.coreos.com
+  - binding.operators.coreos.com
   resources:
   - servicebindings
   verbs:
@@ -57,13 +57,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - operators.coreos.com
+  - binding.operators.coreos.com
   resources:
   - servicebindings/finalizers
   verbs:
   - update
 - apiGroups:
-  - operators.coreos.com
+  - binding.operators.coreos.com
   resources:
   - servicebindings/status
   verbs:

--- a/config/rbac/servicebinding_editor_role.yaml
+++ b/config/rbac/servicebinding_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: servicebinding-editor-role
 rules:
 - apiGroups:
-  - operators.coreos.com
+  - binding.operators.coreos.com
   resources:
   - servicebindings
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - operators.coreos.com
+  - binding.operators.coreos.com
   resources:
   - servicebindings/status
   verbs:

--- a/config/rbac/servicebinding_viewer_role.yaml
+++ b/config/rbac/servicebinding_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: servicebinding-viewer-role
 rules:
 - apiGroups:
-  - operators.coreos.com
+  - binding.operators.coreos.com
   resources:
   - servicebindings
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - operators.coreos.com
+  - binding.operators.coreos.com
   resources:
   - servicebindings/status
   verbs:

--- a/config/samples/operators_v1alpha1_servicebinding.yaml
+++ b/config/samples/operators_v1alpha1_servicebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: example-servicebinding

--- a/controllers/mapper_test.go
+++ b/controllers/mapper_test.go
@@ -20,7 +20,7 @@ func TestSBRRequestMapperMap(t *testing.T) {
 	sbr := &v1alpha1.ServiceBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceBinding",
-			APIVersion: "operators.coreos.com/v1alpha1",
+			APIVersion: v1alpha1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "mapper-unit",

--- a/controllers/secret_test.go
+++ b/controllers/secret_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"github.com/redhat-developer/service-binding-operator/api/v1alpha1"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ var secretOwnerReference = v1.OwnerReference{
 	Name:       "binding-request",
 	UID:        "c77ca1ae-72d0-4fdd-809f-58fdd37facf3",
 	Kind:       "ServiceBinding",
-	APIVersion: "operators.coreos.com/v1alpha1",
+	APIVersion: v1alpha1.GroupVersion.String(),
 	Controller: &ownerRefController,
 }
 

--- a/controllers/servicebinder_test.go
+++ b/controllers/servicebinder_test.go
@@ -201,7 +201,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 	// create the ServiceBinding
 	sbrSingleService := &v1alpha1.ServiceBinding{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operators.coreos.com/v1alpha1",
+			APIVersion: v1alpha1.GroupVersion.String(),
 			Kind:       "ServiceBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -237,7 +237,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 
 	sbrSingleServiceWithMappings := &v1alpha1.ServiceBinding{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operators.coreos.com/v1alpha1",
+			APIVersion: v1alpha1.GroupVersion.String(),
 			Kind:       "ServiceBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -284,7 +284,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 	// create the ServiceBinding
 	sbrMultipleServices := &v1alpha1.ServiceBinding{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operators.coreos.com/v1alpha1",
+			APIVersion: v1alpha1.GroupVersion.String(),
 			Kind:       "ServiceBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -328,7 +328,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 
 	sbrSingleServiceWithNonExistedApp := &v1alpha1.ServiceBinding{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operators.coreos.com/v1alpha1",
+			APIVersion: v1alpha1.GroupVersion.String(),
 			Kind:       "ServiceBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -363,7 +363,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 
 	sbrEmptyAppSelector := &v1alpha1.ServiceBinding{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operators.coreos.com/v1alpha1",
+			APIVersion: v1alpha1.GroupVersion.String(),
 			Kind:       "ServiceBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -390,7 +390,7 @@ func TestServiceBinder_Bind(t *testing.T) {
 
 	sbrEmptyServices := &v1alpha1.ServiceBinding{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operators.coreos.com/v1alpha1",
+			APIVersion: v1alpha1.GroupVersion.String(),
 			Kind:       "ServiceBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -42,9 +42,9 @@ type ServiceBindingReconciler struct {
 	restMapper      meta.RESTMapper
 }
 
-// +kubebuilder:rbac:groups=operators.coreos.com,resources=servicebindings,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=operators.coreos.com,resources=servicebindings/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=operators.coreos.com,resources=servicebindings/finalizers,verbs=update
+// +kubebuilder:rbac:groups=binding.operators.coreos.com,resources=servicebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=binding.operators.coreos.com,resources=servicebindings/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=binding.operators.coreos.com,resources=servicebindings/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=pods;services;endpoints;persistentvolumeclaims;events;configmaps;secrets,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch

--- a/docs/User_Guide.md
+++ b/docs/User_Guide.md
@@ -32,7 +32,7 @@
 A Service Binding involves connecting an application to one or more backing services using a binding secret generated for the purpose of storing information to be consumed by the application.
 
 ``` yaml
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request
@@ -134,7 +134,7 @@ Example, the backing service CR may expose the host, port and database user in s
 
 
 ``` yaml
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: multi-service-binding
@@ -197,7 +197,7 @@ The Service Binding Operator binds all information 'dependent' to the backing se
 The binding is initiated by the setting this `detectBindingResources: true` in the `ServiceBinding` CR's `spec`.
 
 ``` yaml
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: etcdbinding
@@ -228,7 +228,7 @@ The binding secret generated for the `ServiceBinding` may be associated with the
 
 
 ``` yaml
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request
@@ -286,7 +286,7 @@ bindings
 Instead of `/bindings`, you can specify a custom binding root path by specifying the same in `spec.mountPath`, example,
 
 ``` yaml
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request
@@ -427,7 +427,7 @@ If your application is to be deployed as a non-podSPec-based workload such that 
 
 
 ``` yaml
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request

--- a/examples/java_postgresql_customvar/README.md
+++ b/examples/java_postgresql_customvar/README.md
@@ -183,7 +183,7 @@ Create the following `ServiceBinding`:
 ```shell
 kubectl apply -f - << EOD
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request

--- a/examples/knative_postgresql_customvar/README.md
+++ b/examples/knative_postgresql_customvar/README.md
@@ -152,7 +152,7 @@ Create the following `ServiceBinding`:
 ```shell
 kubectl apply -f - << EOD
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request

--- a/examples/multiple_services/README.md
+++ b/examples/multiple_services/README.md
@@ -124,7 +124,7 @@ on the top right corner and pasting the following:
 
 ```yaml
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: node-todo-git

--- a/examples/nodejs_awsrds_varprefix/README.md
+++ b/examples/nodejs_awsrds_varprefix/README.md
@@ -284,7 +284,7 @@ All we need to do is to create the following [`ServiceBinding`](./service-bindin
 ```shell
 kubectl apply -f - << EOD
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: mydb.to.shell-app

--- a/examples/nodejs_etcd_operator/README.md
+++ b/examples/nodejs_etcd_operator/README.md
@@ -60,7 +60,7 @@ spec:
 ```shell
 kubectl apply -f - << EOD
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request

--- a/examples/nodejs_ibmcloud_operator/README.md
+++ b/examples/nodejs_ibmcloud_operator/README.md
@@ -191,7 +191,7 @@ All we need to do is to create the following `ServiceBinding`:
 ```shell
 kubectl apply -f - << EOD
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: mytranslator.to.nodejs-app

--- a/examples/nodejs_postgresql/README.md
+++ b/examples/nodejs_postgresql/README.md
@@ -122,7 +122,7 @@ Create the following `ServiceBinding`:
 ```shell
 kubectl apply -f - << EOD
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request

--- a/examples/nodejs_postgresql_namespaces/README.md
+++ b/examples/nodejs_postgresql_namespaces/README.md
@@ -130,7 +130,7 @@ Create the following `ServiceBinding`:
 ``` shell
 kubectl apply -f - << EOD
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   name: binding-request

--- a/examples/pod_spec_path/README.md
+++ b/examples/pod_spec_path/README.md
@@ -90,7 +90,7 @@ Create the Service Binding with a custom bind path:
 ```shell
 kubectl apply -f - << EOD
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
     name: binding-request-sample

--- a/examples/route_k8s_resource/README.md
+++ b/examples/route_k8s_resource/README.md
@@ -94,7 +94,7 @@ Now create a Service Binding as below:
 ``` shell
 kubectl apply -f - << EOD
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 
 metadata:
@@ -123,7 +123,7 @@ When the `ServiceBinding` was created the Service Binding Operator's controller 
 kubectl get sbr binding-request -n service-binding-demo -o yaml
 ```
 ```yaml
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
   ...

--- a/test/acceptance/features/bindAppToMultipleServices.feature
+++ b/test/acceptance/features/bindAppToMultipleServices.feature
@@ -15,7 +15,7 @@ Feature: Bind a single application to multiple services
         * DB "db-demo-2" is running
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-1
@@ -33,7 +33,7 @@ Feature: Bind a single application to multiple services
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-2
@@ -81,7 +81,7 @@ Feature: Bind a single application to multiple services
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-1sbr

--- a/test/acceptance/features/bindAppToService.feature
+++ b/test/acceptance/features/bindAppToService.feature
@@ -15,7 +15,7 @@ Feature: Bind an application to a service
         * DB "db-demo-a-d-s" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-a-d-s
@@ -49,7 +49,7 @@ Feature: Bind an application to a service
         Given Imported Nodejs application "nodejs-rest-http-crud-a-s-d" is running
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-a-s-d
@@ -76,7 +76,7 @@ Feature: Bind an application to a service
         Given DB "db-demo-d-s-a" is running
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-d-s-a
@@ -103,7 +103,7 @@ Feature: Bind an application to a service
     Scenario: Bind an imported Node.js application to PostgreSQL database in the following order: Service Binding, Application and DB
         Given Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-s-a-d
@@ -130,7 +130,7 @@ Feature: Bind an application to a service
     Scenario: Bind an imported Node.js application to PostgreSQL database in the following order: Service Binding, DB and Application
         Given Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-s-d-a
@@ -159,7 +159,7 @@ Feature: Bind an application to a service
         * Imported Nodejs application "nodejs-missing-app" is not running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-missing-app
@@ -198,7 +198,7 @@ Feature: Bind an application to a service
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-empty-app
@@ -232,7 +232,7 @@ Feature: Bind an application to a service
             """
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-backend
@@ -290,7 +290,7 @@ Feature: Bind an application to a service
             """
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-backend-new-spec
@@ -314,7 +314,7 @@ Feature: Bind an application to a service
         * DB "db-demo-a-d-c" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-a-d-c
@@ -422,7 +422,7 @@ Feature: Bind an application to a service
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: sbr-csv-secret-cm-descriptors
@@ -447,7 +447,7 @@ Feature: Bind an application to a service
     Scenario: Create binding secret using specDescriptors definitions managed in OLM operator descriptors
         Given Backend service CSV is installed
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ClusterServiceVersion
             metadata:
                 name: some-backend-service.v0.1.0
@@ -499,7 +499,7 @@ Feature: Bind an application to a service
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: sbr-csv-attribute
@@ -521,7 +521,7 @@ Feature: Bind an application to a service
         * Nodejs application "node-todo-git" imported from "quay.io/pmacik/node-todo" image is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
               name: binding-request-etcd
@@ -546,7 +546,7 @@ Feature: Bind an application to a service
     Scenario: Service Binding with empty services is not allowed in the cluster
         When Invalid Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-empty-services
@@ -560,7 +560,7 @@ Feature: Bind an application to a service
     Scenario: Service Binding without gvk of services is not allowed in the cluster
         When Invalid Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-without-gvk
@@ -582,7 +582,7 @@ Feature: Bind an application to a service
             """
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-remove-service
@@ -599,7 +599,7 @@ Feature: Bind an application to a service
         * jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-remove-service" should be changed to "True"
         When Invalid Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-remove-service
@@ -613,7 +613,7 @@ Feature: Bind an application to a service
     Scenario: Service Binding without spec is not allowed in the cluster
         When Invalid Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-without-spec
@@ -625,7 +625,7 @@ Feature: Bind an application to a service
     Scenario: Service Binding with empty spec is not allowed in the cluster
         When Invalid Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-empty-spec
@@ -646,7 +646,7 @@ Feature: Bind an application to a service
             """
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-emptying-spec
@@ -663,7 +663,7 @@ Feature: Bind an application to a service
         * jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-emptying-spec" should be changed to "True"
         When Invalid Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-emptying-spec
@@ -684,7 +684,7 @@ Feature: Bind an application to a service
             """
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-remove-spec
@@ -701,7 +701,7 @@ Feature: Bind an application to a service
         * jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-remove-spec" should be changed to "True"
         When Invalid Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-remove-spec
@@ -733,7 +733,7 @@ Feature: Bind an application to a service
         * Generic test application "myapp-in-sbr-ns" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-cross-ns-service

--- a/test/acceptance/features/bindAppToServiceAnnotations.feature
+++ b/test/acceptance/features/bindAppToServiceAnnotations.feature
@@ -46,7 +46,7 @@ Feature: Bind an application to a service using annotations
             """
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-backend-a
@@ -114,7 +114,7 @@ Feature: Bind an application to a service using annotations
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: rsa-2
@@ -176,7 +176,7 @@ Feature: Bind an application to a service using annotations
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: slos-binding
@@ -240,7 +240,7 @@ Feature: Bind an application to a service using annotations
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: slom-to-slos-binding
@@ -304,7 +304,7 @@ Feature: Bind an application to a service using annotations
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: slom-binding
@@ -342,7 +342,7 @@ Feature: Bind an application to a service using annotations
             """
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-backend-ann-sb
@@ -396,7 +396,7 @@ Feature: Bind an application to a service using annotations
             """
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-backend-ann

--- a/test/acceptance/features/bindAppToServiceUsingConfigMap.feature
+++ b/test/acceptance/features/bindAppToServiceUsingConfigMap.feature
@@ -59,7 +59,7 @@ Feature: Bind values from a config map referred in backing service resource
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: cmsa-1
@@ -131,7 +131,7 @@ Feature: Bind values from a config map referred in backing service resource
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: cmsa-2

--- a/test/acceptance/features/bindAppToServiceUsingSecret.feature
+++ b/test/acceptance/features/bindAppToServiceUsingSecret.feature
@@ -58,7 +58,7 @@ Feature: Bind values from a secret referred in backing service resource
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: ssa-1
@@ -78,7 +78,6 @@ Feature: Bind values from a secret referred in backing service resource
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
 
     Scenario: Inject into app all keys from a secret referred within service resource
-        Binding definition is declared on service CRD.
 
         Given OLM Operator "backend" is running
         And Generic test application "ssa-2" is running
@@ -130,7 +129,7 @@ Feature: Bind values from a secret referred in backing service resource
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: ssa-2
@@ -150,8 +149,7 @@ Feature: Bind values from a secret referred in backing service resource
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
-    Scenario: Inject into app a key from a secret referred within service resource
-        Binding definition is declared via OLM descriptor.
+    Scenario: Inject into app a key from a secret referred within service resource Binding definition is declared via OLM descriptor.
 
         Given Generic test application "ssd-1" is running
         And The Custom Resource Definition is present
@@ -241,7 +239,7 @@ Feature: Bind values from a secret referred in backing service resource
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: ssd-1
@@ -261,8 +259,7 @@ Feature: Bind values from a secret referred in backing service resource
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_HOST" has value "example.com"
 
-    Scenario: Inject into app all keys from a secret referred within service resource
-        Binding definition is declared via OLM descriptor.
+    Scenario: Inject into app all keys from a secret referred within service resource Binding definition is declared via OLM descriptor.
 
         Given Generic test application "ssd-2" is running
         And The Custom Resource Definition is present
@@ -375,7 +372,7 @@ Feature: Bind values from a secret referred in backing service resource
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: ssd-2
@@ -449,7 +446,7 @@ Feature: Bind values from a secret referred in backing service resource
         * Generic test application "ssa-3" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: ssa-3
@@ -520,7 +517,7 @@ Feature: Bind values from a secret referred in backing service resource
         * Generic test application "myapp-x" is running
         When Service Binding is applied
           """
-          apiVersion: operators.coreos.com/v1alpha1
+          apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
               name: sb-inject-secret-data

--- a/test/acceptance/features/bindKnativeService.feature
+++ b/test/acceptance/features/bindKnativeService.feature
@@ -17,7 +17,7 @@ Feature: Bind knative service to a service
         * Quarkus application "knative-app" is imported as Knative service
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
               name: binding-request-knative

--- a/test/acceptance/features/bindWithCustomNamingStrategies.feature
+++ b/test/acceptance/features/bindWithCustomNamingStrategies.feature
@@ -24,7 +24,7 @@ Feature: Bind an application to a service using custom naming strategies
         * Generic test application "myapp-no-naming" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-no-naming
@@ -60,7 +60,7 @@ Feature: Bind an application to a service using custom naming strategies
         * Generic test application "myapp-naming-none" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-naming-none
@@ -96,7 +96,7 @@ Feature: Bind an application to a service using custom naming strategies
         * Generic test application "myapp-custom-naming" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-custom-naming
@@ -132,7 +132,7 @@ Feature: Bind an application to a service using custom naming strategies
         * Generic test application "myapp-bind-files" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-bind-files
@@ -172,7 +172,7 @@ Feature: Bind an application to a service using custom naming strategies
         * Generic test application "myapp-custom-file-naming" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-custom-file-naming
@@ -214,7 +214,7 @@ Feature: Bind an application to a service using custom naming strategies
         * Generic test application "myapp-naming-error" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-naming-error

--- a/test/acceptance/features/customEnvVar.feature
+++ b/test/acceptance/features/customEnvVar.feature
@@ -25,7 +25,7 @@ Feature: Inject custom env variable into application
         * Generic test application "foo" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: custom-env-var-from-sequence
@@ -65,7 +65,7 @@ Feature: Inject custom env variable into application
         * Generic test application "foo2" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: custom-env-var-from-map
@@ -105,7 +105,7 @@ Feature: Inject custom env variable into application
         * Generic test application "foo3" is running
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: custom-env-var-from-scalar

--- a/test/acceptance/features/deleteBackendServiceAndRecreate.feature
+++ b/test/acceptance/features/deleteBackendServiceAndRecreate.feature
@@ -57,7 +57,7 @@ Feature: Reconcile when BackingService CR got deleted and recreated
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: ssa-3

--- a/test/acceptance/features/examples.feature
+++ b/test/acceptance/features/examples.feature
@@ -35,7 +35,7 @@ Feature: Verify examples provided in Service Binding Operator github repository
         * "hello-app" is deployed from image "openshift/hello-openshift"
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: sbr-to-bind-hello-app-to-route
@@ -69,7 +69,7 @@ Feature: Verify examples provided in Service Binding Operator github repository
         * DB "db-cross-ns-service" is running in "database-services" namespace
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: service-binding-cross-ns-service

--- a/test/acceptance/features/injectBindingsAsFiles.feature
+++ b/test/acceptance/features/injectBindingsAsFiles.feature
@@ -26,7 +26,7 @@ Feature: Bindings get injected as files in application
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-backend-vm-01
@@ -85,7 +85,7 @@ Feature: Bindings get injected as files in application
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-backend-vm-02
@@ -134,7 +134,7 @@ Feature: Bindings get injected as files in application
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-backend-vm-03
@@ -184,7 +184,7 @@ Feature: Bindings get injected as files in application
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-backend-vm-04
@@ -243,7 +243,7 @@ Feature: Bindings get injected as files in application
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-backend-vm-05
@@ -293,7 +293,7 @@ Feature: Bindings get injected as files in application
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-backend-vm-06
@@ -327,7 +327,7 @@ Feature: Bindings get injected as files in application
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-backend-vm-06

--- a/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
+++ b/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
@@ -54,7 +54,7 @@ Feature: Insert service binding to a custom location in application resource
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-csp
@@ -90,7 +90,7 @@ Feature: Insert service binding to a custom location in application resource
             """
         When Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-ssp

--- a/test/acceptance/features/steps/service_binding.py
+++ b/test/acceptance/features/steps/service_binding.py
@@ -7,7 +7,7 @@ class ServiceBinding(object):
     openshift = Openshift()
 
     def create(self, yaml, namespace=None):
-        return re.search(r'.*servicebinding.operators.coreos.com/.*(created|configured|unchanged)', self.attempt_to_create(yaml, namespace))
+        return re.search(r'.*servicebinding.binding.operators.coreos.com/.*(created|configured|unchanged)', self.attempt_to_create(yaml, namespace))
 
     def attempt_to_create(self, yaml, namespace=None):
         return self.openshift.apply(yaml, namespace)

--- a/test/acceptance/features/unbindAppToService.feature
+++ b/test/acceptance/features/unbindAppToService.feature
@@ -25,7 +25,7 @@ Feature: Unbind an application from a service
         * Generic test application "generic-app-a-d-u" is running
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-a-d-u
@@ -69,7 +69,7 @@ Feature: Unbind an application from a service
         * Generic test application "generic-app-a-d-u" is running
         * Service Binding is applied
             """
-            apiVersion: operators.coreos.com/v1alpha1
+            apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
                 name: binding-request-a-d-u

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -21,11 +21,9 @@ import (
 const (
 	// Fixme(Akash): This values are tightly coupled with postgresql operator.
 	// Need to make it more dynamic.
-	CRDName            = "postgresql.baiju.dev"
-	CRDVersion         = "v1alpha1"
-	CRDKind            = "Database"
-	OperatorKind       = "ServiceBinding"
-	OperatorAPIVersion = "operators.coreos.com/v1alpha1"
+	CRDName    = "postgresql.baiju.dev"
+	CRDVersion = "v1alpha1"
+	CRDKind    = "Database"
 )
 
 var (
@@ -454,7 +452,7 @@ func ServiceBindingMock(
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceBinding",
-			APIVersion: "operators.coreos.com/v1alpha1",
+			APIVersion: v1alpha1.GroupVersion.String(),
 		},
 		Spec: v1alpha1.ServiceBindingSpec{
 			Mappings: []v1alpha1.Mapping{},


### PR DESCRIPTION
The update is necessary and dictated by the fact that OLM does not allow
deploying webhook for `operator.coreos.com` API group name:

* https://docs.openshift.com/container-platform/4.6/operators/operator_sdk/osdk-generating-csvs.html#olm-webhook-considerations_osdk-generating-csvs
* https://github.com/operator-framework/operator-lifecycle-manager/blob/master/pkg/controller/install/webhook.go#L29


Fixes #857