### PR TITLE
[acceptance-tests] Tag scenarios for smoke-testing disconnected environment

### DIFF
--- a/test/acceptance/features/bindAppToService.feature
+++ b/test/acceptance/features/bindAppToService.feature
@@ -215,7 +215,7 @@ Feature: Bind an application to a service
         And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-request-empty-app" should be changed to "True"
         And Secret "binding-request-empty-app" contains "BACKEND_HOST" key with value "example.common"
         And Secret "binding-request-empty-app" contains "BACKEND_USERNAME" key with value "foo"
-
+    @disconnected
     Scenario: Backend Service status update gets propagated to the binding secret
         Given OLM Operator "backend" is running
         * The Custom Resource is present
@@ -270,7 +270,6 @@ Feature: Bind an application to a service
                 ready: true
             """
         Then Secret "binding-request-backend" contains "CustomReady" key with value "true"
-
 
     Scenario: Backend Service new spec status update gets propagated to the binding secret
         Given OLM Operator "backend-new-spec" is running
@@ -338,7 +337,7 @@ Feature: Bind an application to a service
             """
         Then Service Binding "binding-request-a-d-c" is ready
         And Secret "binding-request-a-d-c" contains "SOME_KEY" key with value "SOME_VALUE:5432:db-demo-a-d-c"
-
+    @disconnected
     Scenario: Creating binding secret from the definitions managed in OLM operator descriptors
         Given Backend service CSV is installed
             """

--- a/test/acceptance/features/bindAppToServiceAnnotations.feature
+++ b/test/acceptance/features/bindAppToServiceAnnotations.feature
@@ -8,7 +8,7 @@ Feature: Bind an application to a service using annotations
     Background:
         Given Namespace [TEST_NAMESPACE] is used
         * Service Binding Operator is running
-
+    @disconnected
     Scenario: Provide binding info through backing service CRD annotation
         Given The Custom Resource Definition is present
             """


### PR DESCRIPTION
### Motivation

https://issues.redhat.com/browse/APPSVC-674

### Changes

This PR tags basic scenarios that can be used for smoke-testing SBO in a disconnected environment.

### Testing

Deploy SBO into a disconnected cluster and run:

`TEST_ACCEPTANCE_TAGS=@disconnected make test-acceptance`