### PR TITLE
Fix test-cleanup to use the generated CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ create-test-namespace:
 test-setup: test-cleanup create-test-namespace deploy-test-3rd-party-crds
 
 .PHONY: test-cleanup
-test-cleanup:
+test-cleanup: manifests
 	$(Q)-TEST_NAMESPACE=$(TEST_NAMESPACE) $(HACK_DIR)/test-cleanup.sh
 
 .PHONY: deploy-rbac

--- a/hack/remove-sbr-finalizers.sh
+++ b/hack/remove-sbr-finalizers.sh
@@ -7,7 +7,7 @@ else
 fi
 
 # Remove SBR finalizers if CRD exists
-CRD_NAME=$(kubectl get -f deploy/crds/*crd.yaml -o jsonpath="{.metadata.name}" --ignore-not-found)
+CRD_NAME=$(kubectl get -f config/crd/bases/operators.coreos.com*.yaml -o jsonpath="{.metadata.name}" --ignore-not-found)
 [ -z $CRD_NAME ] && exit 0
 
 SBRS=($(kubectl get $CRD_NAME $USE_NS -o jsonpath="{.items[*].metadata.name}"))


### PR DESCRIPTION
### Motivation

Recent [update to a new version of `operator-sdk`](https://github.com/redhat-developer/service-binding-operator/pull/848]) changed the way how the manifests (e.g. CRD) are generated and removed the `deploy/crd/*crd.yaml` file that was used in the `test-cleanup` script so now the script fails complaining that it could not find the file.

### Changes

This PR:
* Changes the location from which the SBO's CRD is taken for the `test-cleanup`  script to the one that is generated by the `manifests` target. 

### Testing

`make test-cleanup`