### PR TITLE
Consolidate roles landing into bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GIT_COMMIT_ID ?= $(shell git rev-parse --short=8 HEAD)
 OPERATOR_REGISTRY ?= quay.io
 OPERATOR_REPO_REF ?= $(OPERATOR_REGISTRY)/redhat-developer/servicebinding-operator
 OPERATOR_IMAGE_REF ?= $(OPERATOR_REPO_REF):$(GIT_COMMIT_ID)
+OPERATOR_IMAGE_SHA_REF ?= $(shell $(CONTAINER_RUNTIME) inspect --format='{{index .RepoDigests 0}}' $(OPERATOR_IMAGE_REF))
 OPERATOR_BUNDLE_IMAGE_REF ?= $(OPERATOR_REPO_REF):bundle-$(VERSION)-$(GIT_COMMIT_ID)
 OPERATOR_INDEX_IMAGE_REF ?= $(OPERATOR_REPO_REF):index
 
@@ -154,7 +155,7 @@ vet:
 # Generate bundle manifests and metadata, then validate generated files.
 bundle: manifests kustomize push-image
 #	operator-sdk generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(shell $(CONTAINER_RUNTIME) inspect --format='{{index .RepoDigests 0}}' $(OPERATOR_IMAGE_REF))
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(OPERATOR_IMAGE_SHA_REF)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle --select-optional name=operatorhub
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/redhat-developer/servicebinding-operator
-  newTag: 395e87bc
+  newName: sbo
+  newTag: latest

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -6,8 +6,28 @@ resources:
 patches:
   - target:
       kind: Deployment
-      name: .*
     patch: |-
       - op: replace
         path: /metadata/name
+        value: service-binding-operator
+# use dedicated service-binding-operator service account
+# because the operator is usually installed by OLM
+# in a namespace shared with other operators
+  - target:
+      kind: ClusterRoleBinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: service-binding-operator
+  - target:
+      kind: RoleBinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: service-binding-operator
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/serviceAccountName
         value: service-binding-operator

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -3,10 +3,12 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- servicebinding_editor_role.yaml
+- servicebinding_viewer_role.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml


### PR DESCRIPTION
* Several roles were bound to a wrong service account, fixed to use `service-binding-operator`
* we are not protecting /metric endpoints for now, hence the auth proxy roles are removed from the bundle
* service binding viewer and editor clusterroles added to the bundle so that cluster roles can make use of them
  and enable appropriate users/service-accounts to manage service bindings