### PR TITLE
Fix path to CRD in repo used by test-cleanup

### DIFF
--- a/hack/remove-sbr-finalizers.sh
+++ b/hack/remove-sbr-finalizers.sh
@@ -7,7 +7,7 @@ else
 fi
 
 # Remove SBR finalizers if CRD exists
-CRD_NAME=$(kubectl get -f config/crd/bases/operators.coreos.com*.yaml -o jsonpath="{.metadata.name}" --ignore-not-found)
+CRD_NAME=$(kubectl get -f config/crd/bases/binding.operators.coreos.com*.yaml -o jsonpath="{.metadata.name}" --ignore-not-found)
 [ -z $CRD_NAME ] && exit 0
 
 SBRS=($(kubectl get $CRD_NAME $USE_NS -o jsonpath="{.items[*].metadata.name}"))


### PR DESCRIPTION
### Motivation

Recent merge of the PR https://github.com/redhat-developer/service-binding-operator/pull/865 introduced a change to the api group which was not reflected in the `./hack/remove-sbr-finalizers.sh` script called by the `test-cleanup` target and fails complaining that `error: the path "config/crd/bases/operators.coreos.com*.yaml" does not exist` since than.

### Changes

This PR fixes the path for CRD from above.

### Testing

`make test-cleanup`