### PR TITLE
Fix stop-local hack dir path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,8 @@ deploy-crds: install
 .PHONY: stop-local
 ## Stop Local: Stop locally running operator
 stop-local:
-	$(Q)-./remove-sbr-finalizers.sh
-	$(Q)-./hack/stop-sbo-local.sh
+	$(Q)-$(HACK_DIR)/remove-sbr-finalizers.sh
+	$(Q)-$(HACK_DIR)/stop-sbo-local.sh
 
 .PHONY: test-acceptance-setup
 # Setup the environment for the acceptance tests


### PR DESCRIPTION
### Motivation

Currently, the `stop-local` target contains invalid references to the hack scripts that make the target fail.

### Changes

This PR fixes paths to hack scripts for `stop-local` target.

### Testing

`make stop-local`