### PR TITLE
Attach acceptance tests report in GH Actions

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -15,6 +15,7 @@ env:
   MINIKUBE_VERSION: "1.15.1"
   TEST_ACCEPTANCE_CLI: "kubectl"
   CONTAINER_RUNTIME: "docker"
+  TEST_RESULTS: "out/acceptance-tests/TEST*.xml"
 
 jobs:
   lint:
@@ -69,6 +70,7 @@ jobs:
 
     env:
       EXTRA_BEHAVE_ARGS: "--tags=~@knative --tags=~@openshift --tags=~@examples"
+      TEST_RUN: Acceptance_tests_Kubernetes_with_OLM
 
     steps:
       - name: Checkout Git Repository
@@ -94,6 +96,22 @@ jobs:
           eval $(minikube docker-env)
           make OPERATOR_REPO_REF=$(minikube ip):5000/sbo SKIP_REGISTRY_LOGIN=true release-operator -o registry-login test-acceptance-with-bundle
 
+      - name: Setup Testspace
+        uses: testspace-com/setup-testspace@v1
+        with:
+          domain: ${{ github.repository_owner }}
+        if: always()
+
+      - name: Publish tests results to Testspace
+        run: |
+          testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}
+        if: always()
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: kubernetes-with-olm-test-results
+          path: ${{ env.TEST_RESULTS }}
+        if: always()
 
   acceptance_without_olm:
     name: Acceptance tests running on Kubernetes without using OLM
@@ -101,6 +119,7 @@ jobs:
 
     env:
       EXTRA_BEHAVE_ARGS: "--tags=~@knative --tags=~@openshift --tags=~@olm"
+      TEST_RUN: Acceptance_tests_Kubernetes_without_OLM
       UMOCI_VERSION: "0.4.5"
 
     steps:
@@ -134,3 +153,20 @@ jobs:
           make OPERATOR_REPO_REF=$(minikube ip):5000/sbo SKIP_REGISTRY_LOGIN=true release-operator -o registry-login release-manifests
           kubectl apply -f out/release.yaml
           make TEST_ACCEPTANCE_START_SBO=remote test-acceptance
+
+      - name: Setup Testspace
+        uses: testspace-com/setup-testspace@v1
+        with:
+          domain: ${{ github.repository_owner }}
+        if: always()
+
+      - name: Publish tests results to Testspace
+        run: |
+          testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}
+        if: always()
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: kubernetes-without-olm-test-results
+          path: ${{ env.TEST_RESULTS }}
+        if: always()


### PR DESCRIPTION
### Motivation

Currently the acceptance tests results in GitHub Actions are not being published or tracked - only overall PASS or FAIL. That makes it very tedious to investigate what went wrong if the tests fail.

### Changes

This PR:
* Adds steps to acceptance testing GHA jobs to collect and publish the results into Testspace where it can be easily looked and browsed.

### Testing

Check `testspace/analytics` PR check