### PR TITLE
Add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: 'kind/bug'
+assignees: ''
+
+---
+
+### What is the environment (Minikube, Openshift)?
+
+
+### What is the SBO version used?
+
+
+### What are the steps to reproduce this issue?
+  1. 
+  2. 
+  3. 
+  4. 
+
+
+### What is the expected behaviour?
+
+
+### What is the actual behaviour?
+
+
+### Service Binding Operator Logs
+
+
+### Additional Information (Screenshots, etc)
+


### PR DESCRIPTION
### Motivation

This PR adds a bug report template for the service-binding-operator project.

### Changes

This PR creates a file `bug_report.md` under `.github/ISSUE_TEMPLATE` folder.