### PR TITLE
Fix non-OLM acceptance tests use SBO installed in Kubernetes, not local instance

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -102,7 +102,6 @@ jobs:
     env:
       EXTRA_BEHAVE_ARGS: "--tags=~@knative --tags=~@openshift --tags=~@olm"
       UMOCI_VERSION: "0.4.5"
-      OPERATOR_VERSION: "0.4.0"
 
     steps:
       - name: Checkout Git Repository
@@ -134,4 +133,4 @@ jobs:
           eval $(minikube docker-env)
           make OPERATOR_REPO_REF=$(minikube ip):5000/sbo SKIP_REGISTRY_LOGIN=true release-operator -o registry-login release-manifests
           kubectl apply -f out/release.yaml
-          make test-acceptance
+          make TEST_ACCEPTANCE_START_SBO=remote test-acceptance


### PR DESCRIPTION
### Motivation

Currently the `Acceptance tests running on Kubernetes without using OLM` GHA job runs the acceptance tests in a local mode (The default mode determined by the `TEST_ACCEPTANCE_START_SBO` variable (with the locally started instance of SBO) while it builds operator's images and than installs SBO into the Kubernetes, at the same time. The acceptnace tests should be run in a remote mode to use that instance, that is being installed into Kubernetes.

### Changes

This PR:
* Switches the non-OLM acceptance testing GitHub Action to remote mode by setting `TEST_ACCEPTANCE_START_SBO` variable to `remote`.
* Removes useless `OPERATOR_VERSION` variable

### Testing

This PR's GitHub Action check: `Acceptance tests running on Kubernetes without using OLM`

