### PR TITLE
Add check for the presence of conflict into linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ GO ?= CGO_ENABLED=$(CGO_ENABLED) GOCACHE=$(GOCACHE) GOFLAGS="$(GOFLAGS)" GO111MO
 
 .PHONY: lint
 ## Runs linters
-lint: setup-venv lint-go-code lint-yaml lint-python-code lint-feature-files
+lint: setup-venv lint-go-code lint-yaml lint-python-code lint-feature-files lint-conflicts
 
 YAML_FILES := $(shell find . -path ./vendor -prune -o -path ./config -prune -o -type f -regex ".*\.y[a]ml" -print)
 .PHONY: lint-yaml
@@ -98,6 +98,11 @@ lint-python-code: setup-venv
 .PHONY: lint-feature-files
 lint-feature-files:
 	$(Q)./hack/check-feature-files.sh
+
+## Check for the presence of conflict notes in source file
+.PHONY: lint-conflicts
+lint-conflicts:
+	$(Q)./hack/check-conflicts.sh
 
 .PHONY: test
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin

--- a/hack/check-conflicts.sh
+++ b/hack/check-conflicts.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+echo -e "\nChecking for presence of conflict notes in source files..."
+
+check_results(){
+    found=0
+    for f in "$@"; do
+        grep -PiIrnH '<<<<''<<<|>>>''>>>>|===''====' "$f"
+        if [ $? -ne 1 ]; then
+            found=1
+        fi
+    done
+    if [ $found -eq 1 ]; then
+        echo FAIL
+    else
+        echo PASS
+    fi
+    return $found
+}
+
+overall_failed=0
+
+echo -e "\nChecking staged files... "
+check_results $(git diff --cached --name-only | grep -v "vendor/") || overall_failed=1
+
+echo -e "\nChecking tracked files... "
+check_results $(git ls-tree --full-tree -r HEAD --name-only | grep -v "vendor/") || overall_failed=1
+
+if [ $overall_failed -eq 0 ]; then
+    echo -e "\nNone of the tracked or staged files contain strings indicating a git conflict... PASS\n"
+else
+    echo -e "\nThe above listed files contains strings indicating a git conflict... FAIL\n"
+fi
+exit $overall_failed


### PR DESCRIPTION
### Motivation

Currently it is possible to accidently commit conflict notes (such as `<<<<<<< HEAD`) in source files without actually noticing it.

### Changes

This PR:
* Adds a new linter for detecting git conflict notes in tracked and staged files.

### Testing

`make lint-conflicts`

