### PR TITLE
Remove output redirect in install.sh to file named 1 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,9 +6,8 @@ OPERATOR_PACKAGE=${OPERATOR_PACKAGE:-service-binding-operator}
 DOCKER_CFG=${DOCKER_CFG:-$HOME/.docker/config.json}
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 
-if [ "$(kubectl get crd clusterserviceversions.operators.coreos.com &>1 || echo false)" == "false" ]; then
+kubectl get crd clusterserviceversions.operators.coreos.com || \
   curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v${OLM_VERSION}/install.sh | bash -s v${OLM_VERSION}
-fi
 
 CATSRC_NAMESPACE="${CATSRC_NAMESPACE:-$(kubectl get catalogsources.operators.coreos.com --all-namespaces -o jsonpath='{.items[0].metadata.namespace}' --ignore-not-found=true)}"
 


### PR DESCRIPTION
### Motivation

Currently, `install.sh` script produces unused file named `1` as a result of an output redirect.

### Changes

This PR:
* Removes the redirect in  `install.sh` script to file named `1` to keep the output visible.

### Testing

After running `./install.sh` check the root directory for the presence of a file name `1` it should not be there.