### PR TITLE
Check if unready binding can be removed

### DIFF
--- a/pkg/reconcile/pipeline/handler/project/impl.go
+++ b/pkg/reconcile/pipeline/handler/project/impl.go
@@ -6,7 +6,6 @@ import (
 	"github.com/redhat-developer/service-binding-operator/api/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"path"
@@ -224,15 +223,7 @@ func Unbind(ctx pipeline.Context) {
 		return
 	}
 	applications, err := ctx.Applications()
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			ctx.StopProcessing()
-			return
-		}
-		ctx.RetryProcessing(err)
-		return
-	}
-	if len(applications) == 0 {
+	if err != nil || len(applications) == 0 {
 		ctx.StopProcessing()
 		return
 	}

--- a/pkg/reconcile/pipeline/handler/project/impl_test.go
+++ b/pkg/reconcile/pipeline/handler/project/impl_test.go
@@ -507,13 +507,20 @@ var _ = Describe("Unbind handler", func() {
 		ctx = mocks.NewMockContext(mockCtrl)
 		ctx.EXPECT().UnbindRequested().Return(true)
 		ctx.EXPECT().StopProcessing()
-
 	})
 
 	AfterEach(func() {
 		mockCtrl.Finish()
 	})
 
+	It("should stop processing when there is error getting applications", func() {
+		ctx.EXPECT().Applications().Return(nil, errors.New("foo"))
+		project.Unbind(ctx)
+	})
+	It("should stop processing when there are no applications", func() {
+		ctx.EXPECT().Applications().Return([]pipeline.Application{}, nil)
+		project.Unbind(ctx)
+	})
 	Context("successful processing", func() {
 		var (
 			deploymentsUnstructured    []*unstructured.Unstructured

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -501,8 +501,8 @@ def validate_error(context, err_msg=None):
 @then(u'Service Binding "{sb_name}" is not persistent in the cluster')
 def validate_absent_sb(context, sb_name):
     openshift = Openshift()
-    output = openshift.search_resource_in_namespace("servicebindings", sb_name, context.namespace.name)
-    assert output is None, f"Service Binding {sb_name} is present in namespace '{context.namespace.name}'"
+    polling2.poll(lambda: openshift.search_resource_in_namespace("servicebindings", sb_name, context.namespace.name),
+                  step=5, timeout=400, check_success=lambda v: v is None)
 
 
 @then(u'Service Binding "{sb_name}" is not updated')


### PR DESCRIPTION
* added missing acceptance tests
* in the reconcile loop, add finalizer only if deletion timestamp is unset
* unbind handler: stop processing and do not retry in case of any error when reading the application resource