### PR TITLE
Support for selection of array element in paths

### DIFF
--- a/pkg/binding/annotationmapper.go
+++ b/pkg/binding/annotationmapper.go
@@ -70,15 +70,13 @@ func (m *annotationBackedDefinitionBuilder) Build() (Definition, error) {
 		return nil, errors.Wrapf(err, "could not create binding model for annotation key %s and value %s", m.name, m.value)
 	}
 
-	if len(outputName) == 0 {
-		outputName = mod.path[len(mod.path)-1]
-	}
-
 	switch {
 	case mod.isStringElementType() && mod.isStringObjectType():
 		return &stringDefinition{
 			outputName: outputName,
-			path:       mod.path,
+			definition: definition{
+				path: mod.path,
+			},
 		}, nil
 
 	case mod.isStringElementType() && mod.hasDataField():
@@ -86,8 +84,10 @@ func (m *annotationBackedDefinitionBuilder) Build() (Definition, error) {
 			secretConfigMapReader: m.secretConfigMapReader,
 			objectType:            mod.objectType,
 			outputName:            outputName,
-			path:                  mod.path,
-			sourceKey:             mod.sourceKey,
+			definition: definition{
+				path: mod.path,
+			},
+			sourceKey: mod.sourceKey,
 		}, nil
 
 	case mod.isMapElementType() && mod.hasDataField():
@@ -95,28 +95,36 @@ func (m *annotationBackedDefinitionBuilder) Build() (Definition, error) {
 			secretConfigMapReader: m.secretConfigMapReader,
 			objectType:            mod.objectType,
 			outputName:            outputName,
-			path:                  mod.path,
-			sourceValue:           mod.sourceValue,
+			definition: definition{
+				path: mod.path,
+			},
+			sourceValue: mod.sourceValue,
 		}, nil
 
 	case mod.isMapElementType() && mod.isStringObjectType():
 		return &stringOfMapDefinition{
 			outputName: outputName,
-			path:       mod.path,
+			definition: definition{
+				path: mod.path,
+			},
 		}, nil
 
 	case mod.isSliceOfMapsElementType():
 		return &sliceOfMapsFromPathDefinition{
-			outputName:  outputName,
-			path:        mod.path,
+			outputName: outputName,
+			definition: definition{
+				path: mod.path,
+			},
 			sourceKey:   mod.sourceKey,
 			sourceValue: mod.sourceValue,
 		}, nil
 
 	case mod.isSliceOfStringsElementType():
 		return &sliceOfStringsFromPathDefinition{
-			outputName:  outputName,
-			path:        mod.path,
+			outputName: outputName,
+			definition: definition{
+				path: mod.path,
+			},
 			sourceValue: mod.sourceValue,
 		}, nil
 	}

--- a/pkg/binding/annotationmapper_test.go
+++ b/pkg/binding/annotationmapper_test.go
@@ -72,7 +72,9 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 			},
 			expectedValue: &stringDefinition{
 				outputName: "username",
-				path:       []string{"status", "dbCredential", "username"},
+				definition: definition{
+					path: "{.status.dbCredential.username}",
+				},
 			},
 		},
 
@@ -84,7 +86,9 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 			},
 			expectedValue: &stringDefinition{
 				outputName: "anotherUsernameField",
-				path:       []string{"status", "dbCredential", "username"},
+				definition: definition{
+					path: "{.status.dbCredential.username}",
+				},
 			},
 		},
 
@@ -95,8 +99,10 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.dbCredential.username}",
 			},
 			expectedValue: &stringDefinition{
-				outputName: "username",
-				path:       []string{"status", "dbCredential", "username"},
+				outputName: "",
+				definition: definition{
+					path: "{.status.dbCredential.username}",
+				},
 			},
 		},
 
@@ -107,9 +113,11 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.dbCredential},objectType=Secret,sourceValue=username",
 			},
 			expectedValue: &mapFromDataFieldDefinition{
-				objectType:  secretObjectType,
-				outputName:  "username",
-				path:        []string{"status", "dbCredential"},
+				objectType: secretObjectType,
+				outputName: "username",
+				definition: definition{
+					path: "{.status.dbCredential}",
+				},
 				sourceValue: "username",
 			},
 		},
@@ -121,9 +129,11 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.dbCredential},objectType=Secret,sourceValue=username",
 			},
 			expectedValue: &mapFromDataFieldDefinition{
-				objectType:  secretObjectType,
-				outputName:  "anotherUsernameField",
-				path:        []string{"status", "dbCredential"},
+				objectType: secretObjectType,
+				outputName: "anotherUsernameField",
+				definition: definition{
+					path: "{.status.dbCredential}",
+				},
 				sourceValue: "username",
 			},
 		},
@@ -136,8 +146,10 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 			},
 			expectedValue: &mapFromDataFieldDefinition{
 				objectType: secretObjectType,
-				outputName: "dbCredential",
-				path:       []string{"status", "dbCredential"},
+				outputName: "",
+				definition: definition{
+					path: "{.status.dbCredential}",
+				},
 			},
 		},
 
@@ -148,9 +160,11 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.dbCredential},objectType=ConfigMap,sourceValue=username",
 			},
 			expectedValue: &mapFromDataFieldDefinition{
-				objectType:  configMapObjectType,
-				outputName:  "username",
-				path:        []string{"status", "dbCredential"},
+				objectType: configMapObjectType,
+				outputName: "username",
+				definition: definition{
+					path: "{.status.dbCredential}",
+				},
 				sourceValue: "username",
 			},
 		},
@@ -162,9 +176,11 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.dbCredential},objectType=ConfigMap,sourceValue=username",
 			},
 			expectedValue: &mapFromDataFieldDefinition{
-				objectType:  configMapObjectType,
-				outputName:  "anotherUsernameField",
-				path:        []string{"status", "dbCredential"},
+				objectType: configMapObjectType,
+				outputName: "anotherUsernameField",
+				definition: definition{
+					path: "{.status.dbCredential}",
+				},
 				sourceValue: "username",
 			},
 		},
@@ -176,9 +192,10 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.dbCredential},objectType=ConfigMap,sourceValue=username",
 			},
 			expectedValue: &mapFromDataFieldDefinition{
-				objectType:  configMapObjectType,
-				outputName:  "dbCredential",
-				path:        []string{"status", "dbCredential"},
+				objectType: configMapObjectType,
+				definition: definition{
+					path: "{.status.dbCredential}",
+				},
 				sourceValue: "username",
 			},
 		},
@@ -191,7 +208,9 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 			},
 			expectedValue: &stringOfMapDefinition{
 				outputName: "database",
-				path:       []string{"status", "database"},
+				definition: definition{
+					path: "{.status.database}",
+				},
 			},
 		},
 
@@ -203,7 +222,9 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 			},
 			expectedValue: &stringOfMapDefinition{
 				outputName: "anotherDatabaseField",
-				path:       []string{"status", "database"},
+				definition: definition{
+					path: "{.status.database}",
+				},
 			},
 		},
 
@@ -214,8 +235,9 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.database},elementType=map",
 			},
 			expectedValue: &stringOfMapDefinition{
-				outputName: "database",
-				path:       []string{"status", "database"},
+				definition: definition{
+					path: "{.status.database}",
+				},
 			},
 		},
 
@@ -226,8 +248,9 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.bootstrap},elementType=sliceOfMaps,sourceKey=type,sourceValue=url",
 			},
 			expectedValue: &sliceOfMapsFromPathDefinition{
-				outputName:  "bootstrap",
-				path:        []string{"status", "bootstrap"},
+				definition: definition{
+					path: "{.status.bootstrap}",
+				},
 				sourceKey:   "type",
 				sourceValue: "url",
 			},
@@ -240,8 +263,10 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.bootstrap},elementType=sliceOfMaps,sourceKey=type,sourceValue=url",
 			},
 			expectedValue: &sliceOfMapsFromPathDefinition{
-				outputName:  "anotherBootstrapField",
-				path:        []string{"status", "bootstrap"},
+				outputName: "anotherBootstrapField",
+				definition: definition{
+					path: "{.status.bootstrap}",
+				},
 				sourceKey:   "type",
 				sourceValue: "url",
 			},
@@ -254,8 +279,9 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				value: "path={.status.bootstrap},elementType=sliceOfStrings,sourceValue=url",
 			},
 			expectedValue: &sliceOfStringsFromPathDefinition{
-				outputName:  "bootstrap",
-				path:        []string{"status", "bootstrap"},
+				definition: definition{
+					path: "{.status.bootstrap}",
+				},
 				sourceValue: "url",
 			},
 		},

--- a/pkg/binding/jsonpath.go
+++ b/pkg/binding/jsonpath.go
@@ -1,0 +1,29 @@
+package binding
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// getValuesByJSONPath returns values from the given map matching the provided JSONPath
+// 'path' argument takes JSONPath expressions enclosed by curly braces {}
+// see https://kubernetes.io/docs/reference/kubectl/jsonpath/ for more details
+// It returns zero or more filtered values back,
+// or error if the jsonpath is invalid or it cannot be applied on the given map
+func getValuesByJSONPath(obj map[string]interface{}, path string) ([]reflect.Value, error) {
+	j := jsonpath.New("")
+	err := j.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+	result, err := j.FindResults(obj)
+	if err != nil {
+		return nil, err
+	}
+	if len(result) > 1 {
+		return nil, fmt.Errorf("more than one item found in the result: %v", result)
+	}
+	return result[0], nil
+}

--- a/pkg/binding/jsonpath_test.go
+++ b/pkg/binding/jsonpath_test.go
@@ -1,0 +1,106 @@
+package binding
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGetValueByJSONPath(t *testing.T) {
+	json := []byte(`{
+		"apiVersion": "apps/v1",
+		"kind": "StatefulSet",
+		"metadata": {
+			"name": "db1",
+			"namespace": "prj1"
+		},
+		"spec": {
+			"selector": {
+				"matchLabels": {
+					"app": "db1"
+				}
+			},
+			"serviceName": "db1-svc",
+			"template": {
+				"metadata": {
+					"labels": {
+						"app": "db1"
+					}
+				},
+				"spec": {
+					"containers": [
+						{
+							"env": [
+								{
+									"name": "POSTGRESQL_USER",
+									"value": "user1"
+								},
+								{
+									"name": "POSTGRESQL_PASSWORD",
+									"value": "k33p5ecret"
+								},
+								{
+									"name": "POSTGRESQL_DATABASE",
+									"value": "mydb"
+								}
+							],
+							"image": "centos/postgresql-96-centos7",
+							"name": "db1"
+						}
+					]
+				}
+			}
+		}
+	}`)
+	tests := []struct {
+		Path    string
+		Want    interface{}
+		WantErr bool
+	}{
+		{
+			Path: ".spec.serviceName",
+			Want: "db1-svc",
+		},
+		{
+			Path: ".spec.template.spec.containers[0].name",
+			Want: "db1",
+		},
+		{
+			Path: ".spec.template.spec.containers[0].env[2].value",
+			Want: "mydb",
+		},
+		{
+			Path: ".spec.template.spec.containers[?(@.name==\"db1\")].env[?(@.name==\"POSTGRESQL_USER\")].value",
+			Want: "user1",
+		},
+		{
+			Path: ".spec.template.metadata.labels",
+			Want: map[string]interface{}{
+				"app": "db1",
+			},
+		},
+		{
+			Path:    ".foo",
+			WantErr: true,
+		},
+	}
+
+	var u unstructured.Unstructured
+	err := u.UnmarshalJSON(json)
+	if err != nil {
+		t.Errorf("Error unmarshaling json input\n")
+	}
+
+	for _, test := range tests {
+		t.Run(test.Path, func(t *testing.T) {
+			result, err := getValuesByJSONPath(u.Object, "{"+test.Path+"}")
+			if (err != nil) != test.WantErr {
+				t.Errorf("Expecting err %v, got %v\n", test.WantErr, err)
+			}
+			if !test.WantErr && fmt.Sprintf("%v", result[0].Interface()) != fmt.Sprintf("%v", test.Want) {
+				t.Errorf("Expecting %v, got %v\n", test.Want, result[0].Interface())
+			}
+		})
+	}
+}

--- a/pkg/binding/mocks/mocks.go
+++ b/pkg/binding/mocks/mocks.go
@@ -51,10 +51,10 @@ func (mr *MockDefinitionMockRecorder) Apply(arg0 interface{}) *gomock.Call {
 }
 
 // GetPath mocks base method.
-func (m *MockDefinition) GetPath() []string {
+func (m *MockDefinition) GetPath() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPath")
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].(string)
 	return ret0
 }
 

--- a/pkg/binding/spec.go
+++ b/pkg/binding/spec.go
@@ -4,12 +4,8 @@ import (
 	"context"
 	"fmt"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"strings"
-
-	"github.com/mitchellh/copystructure"
-	"github.com/redhat-developer/service-binding-operator/pkg/nested"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -85,8 +81,6 @@ func (s *SpecHandler) Handle() (result, error) {
 
 	v := val.Get()
 
-	path := strings.Join(d.GetPath(), ".")
-
 	out := make(map[string]interface{})
 
 	switch t := v.(type) {
@@ -98,18 +92,14 @@ func (s *SpecHandler) Handle() (result, error) {
 		for k, v := range t {
 			out[k] = v
 		}
+	case map[interface{}]interface{}:
+		for k, v := range t {
+			out[fmt.Sprintf("%v", k)] = v
+		}
 	}
-
-	cpy, err := copystructure.Copy(out)
-	if err != nil {
-		return result{}, err
-	}
-
-	rawData := nested.ComposeValue(cpy, nested.NewPath(path))
 
 	return result{
-		Data:    out,
-		RawData: rawData,
+		Data: out,
 	}, nil
 }
 

--- a/pkg/binding/spec_test.go
+++ b/pkg/binding/spec_test.go
@@ -40,7 +40,6 @@ func TestSpecHandler(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			require.Equal(t, args.expectedData, got.Data, "Data does not match expected")
-			require.Equal(t, args.expectedRawData, got.RawData, "RawData does not match expected")
 		}
 	}
 
@@ -245,7 +244,7 @@ func TestSpecHandler(t *testing.T) {
 	}))
 
 	t.Run("should a map with type as key and url as value", assertHandler(args{
-		name:  "service.binding",
+		name:  "service.binding/bootstrap",
 		value: "path={.status.bootstrap},elementType=sliceOfMaps,sourceKey=type,sourceValue=url",
 		service: map[string]interface{}{
 			"metadata": map[string]interface{}{
@@ -335,7 +334,7 @@ func TestSpecHandler(t *testing.T) {
 	}))
 
 	t.Run("should return a slice of strings with all urls", assertHandler(args{
-		name:  "service.binding",
+		name:  "service.binding/bootstrap",
 		value: "path={.status.bootstrap},elementType=sliceOfStrings,sourceKey=url",
 		service: map[string]interface{}{
 			"metadata": map[string]interface{}{

--- a/pkg/reconcile/pipeline/builder/pipeline_integration_test.go
+++ b/pkg/reconcile/pipeline/builder/pipeline_integration_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Default Pipeline", func() {
 		service := &unstructured.Unstructured{Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
-					"service.binding":      "path={.status.foo}",
+					"service.binding/bar":  "path={.status.foo}",
 					"service.binding/bar2": "path={.status.foo2}",
 				},
 			},
@@ -144,7 +144,7 @@ var _ = Describe("Default Pipeline", func() {
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, secret)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(secret.StringData).To(Equal(map[string]string{
-			"DATABASE_FOO":  "val1",
+			"DATABASE_BAR":  "val1",
 			"DATABASE_BAR2": "val2",
 		}))
 

--- a/pkg/reconcile/pipeline/handler/collect/impl_test.go
+++ b/pkg/reconcile/pipeline/handler/collect/impl_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	"strings"
+
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/api/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/binding"
@@ -807,7 +809,7 @@ var _ = Describe("Integration Collect definitions + items", func() {
 			serviceContent: map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"annotations": map[string]interface{}{
-						"service.binding":      "path={.status.foo}",
+						"service.binding/bar":  "path={.status.foo}",
 						"service.binding/bar2": "path={.status.foo2}",
 					},
 				},
@@ -819,7 +821,7 @@ var _ = Describe("Integration Collect definitions + items", func() {
 			},
 			expectedItems: []*pipeline.BindingItem{
 				{
-					Name:  "foo",
+					Name:  "bar",
 					Value: "val1",
 				},
 				{
@@ -935,7 +937,7 @@ type bindingDefMatcher struct {
 func (m bindingDefMatcher) Matches(x interface{}) bool {
 	bd, ok := x.(binding.Definition)
 	if ok {
-		return reflect.DeepEqual(bd.GetPath(), m.path)
+		return reflect.DeepEqual(bd.GetPath(), fmt.Sprintf("{.%v}", strings.Join(m.path, ".")))
 	}
 	return false
 }

--- a/test/acceptance/features/bindAppToService.feature
+++ b/test/acceptance/features/bindAppToService.feature
@@ -790,7 +790,7 @@ Feature: Bind an application to a service
                     resource: deployments
             """
         Then Service Binding "binding-request-configmap" is ready
-        And The application env var "CONFIGMAP_DATA_WORD" has value "hello"
+        And The application env var "CONFIGMAP_WORD" has value "hello"
 
 
     Scenario: Inject all secret keys into application
@@ -826,4 +826,4 @@ Feature: Bind an application to a service
                     resource: deployments
             """
         Then Service Binding "binding-request-secret" is ready
-        And The application env var "SECRET_DATA_WORD" has value "aGVsbG8="
+        And The application env var "SECRET_WORD" has value "aGVsbG8="

--- a/test/acceptance/features/bindAppToServiceUsingSecret.feature
+++ b/test/acceptance/features/bindAppToServiceUsingSecret.feature
@@ -485,9 +485,7 @@ Feature: Bind values from a secret referred in backing service resource
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
-    # Remove this disable tag once this issue is closed: https://github.com/redhat-developer/service-binding-operator/issues/808
-    @disabled
-    Scenario: Inject data from secret referred at .spec.containers.envFrom.secretRef.name
+    Scenario: Inject data from secret referred in field belonging to list
         Given The Secret is present
             """
             apiVersion: v1
@@ -552,7 +550,7 @@ Feature: Bind values from a secret referred in backing service resource
                 version: v1
                 resource: deployments
           """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "sb-inject-secret-data" should be changed to "True"
+        Then Service Binding "sb-inject-secret-data" is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
@@ -722,7 +720,7 @@ Feature: Bind values from a secret referred in backing service resource
             metadata:
                 name: provisioned-service-3
                 annotations:
-                    "service.binding": "path={.spec.foo}"
+                    "service.binding/foo": "path={.spec.foo}"
             spec:
                 foo: bla
             status:


### PR DESCRIPTION
### Changes

Calls to `unstructured.NestedFieldCopy` replaced by usage of [JSONPath) parser from client-go library](https://github.com/kubernetes/client-go/tree/master/util/jsonpath).

Refactored `model` and builders to keep jsonpath in original form, without spliting into steps
    
 * This simplified the annotation parsing logic
 * Since we now support full JSON path, we cannot now detect selected field name in all possible cases.
    Hence using "service.binding" annotation key alone is allowed only when `objectType` is set to `Secret` or `ConfigMap`
    In all other cases, "service.binding/xxx" convention must be used. A number of unit tests adjusted accordingly
 * reenabled the acceptance tests that requires `path` to be a regular JSONPath expression
      (the provided expression uses subscript operator to locate the field containing the secret name)

Fixes #963. #808  

