### PR TITLE
Fix support for label selectors

### DIFF
--- a/test/acceptance/features/bindMultipleAppsToSingleService.feature
+++ b/test/acceptance/features/bindMultipleAppsToSingleService.feature
@@ -1,0 +1,59 @@
+Feature: Bind multiple applications to a single service
+
+    As a user of Service Binding Operator
+    I want to bind multiple applications to a single service that depends on
+
+    Background:
+        Given Namespace [TEST_NAMESPACE] is used
+        * Service Binding Operator is running
+
+    Scenario: Successfully bind two applications to a single service
+        Given Test applications "gen-app-a-s-f-1" and "gen-app-a-s-f-2" is running
+        * The common label "app-custom=test" is set for both apps
+        * CustomResourceDefinition backends.stable.example.com is available
+        * The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: backend-secret
+            stringData:
+                username: AzureDiamond
+                password: hunter2
+            """
+        And The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: service-a-s-f
+                annotations:
+                    service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
+            status:
+                data:
+                    dbCredentials: backend-secret
+            """
+        When Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: service-binding-a-s-f
+            spec:
+                bindAsFiles: false
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: service-a-s-f
+                application:
+                    labelSelector:
+                      matchLabels:
+                        app-custom: test
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding "service-binding-a-s-f" is ready
+        And The application env var "BACKEND_USERNAME" has value "AzureDiamond" in both apps
+        And The application env var "BACKEND_PASSWORD" has value "hunter2" in both apps

--- a/test/acceptance/features/steps/openshift.py
+++ b/test/acceptance/features/steps/openshift.py
@@ -478,3 +478,8 @@ spec:
             else:
                 (output, exit_code) = self.cmd.run(cmd)
         assert exit_code == 0, f"Non-zero exit code ({exit_code}) returned when attempting to create a new app using following command line {cmd}\n: {output}"
+
+    def set_label(self, name, label, namespace):
+        cmd = f"{ctx.cli} label deployments {name} '{label}' -n {namespace}"
+        (output, exit_code) = self.cmd.run(cmd)
+        assert exit_code == 0, f"Non-zero exit code ({exit_code}) returned when attempting set label: {cmd}\n: {output}"


### PR DESCRIPTION
- Fix `.spec.application.name` field becoming mandatory
- If more than one application is selected through label selectors, all will be considered for binding

Fixes #965

- [x] acceptance test demonstrating how to bind 2 applications having the same label.
- [x] Remove `InvalidApplicationReference` reason and corresponding code and tests
  - [x] Added issue #974
- [x] Wrong assertion for the test: `should return an error if application list returns error`