### PR TITLE
Fix SBO base image conflict with local registry in GH Actions

### DIFF
--- a/.github/actions/setup-podman/registries_template.conf
+++ b/.github/actions/setup-podman/registries_template.conf
@@ -4,3 +4,6 @@ unqualified-search-registries = ['docker.io']
 prefix = "REGISTRY_PREFIX"
 insecure = true
 location = "localhost:5000"
+
+[[registry.mirror]]
+location = "REGISTRY_PREFIX"

--- a/.github/workflows/merge-to-master.yaml
+++ b/.github/workflows/merge-to-master.yaml
@@ -37,19 +37,12 @@ jobs:
           python-version: "3.7"
           architecture: "x64"
 
-      - name: Set up CLI
-        run: |
-          curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${SDK_VERSION}/operator-sdk_linux_amd64
-          chmod +x operator-sdk
-          mv -v operator-sdk $GITHUB_WORKSPACE/bin/
-
-          curl -Lo opm https://github.com/operator-framework/operator-registry/releases/download/v${OPM_VERSION}/linux-amd64-opm
-          chmod +x opm
-          mv -v opm $GITHUB_WORKSPACE/bin/
-
-          curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl
-          chmod +x kubectl
-          mv -v kubectl $GITHUB_WORKSPACE/bin/
+      - name: Setup CLI
+        uses: ./.github/actions/setup-cli
+        with:
+          operator-sdk: true
+          opm: true
+          kubectl: true
 
       - name: Release operator on Quay.io
         env:


### PR DESCRIPTION
### Motivation

Recently merged https://github.com/redhat-developer/service-binding-operator/pull/972 introduced a conflict in the local registry set up for building the PR images and the base image used to build SBO operator image.

### Changes

This PR
* Fixes the conflict by setting a registry mirror
* Re-uses the setup-cli action introduced in the above mentioned merged PR in merge-to-master jobs

### Testing

PR checks will do.