### PR TITLE
Add provisioned service support

### DIFF
--- a/pkg/reconcile/pipeline/api.go
+++ b/pkg/reconcile/pipeline/api.go
@@ -6,6 +6,7 @@ import (
 	api "github.com/redhat-developer/service-binding-operator/api/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/binding"
 	"github.com/redhat-developer/service-binding-operator/pkg/client/kubernetes"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -123,6 +124,9 @@ type Context interface {
 	// Add binding item to the context
 	AddBindingItem(item *BindingItem)
 
+	// Add bindings to the context
+	AddBindings(bindings Bindings)
+
 	// List binding items that should be projected into application containers
 	BindingItems() BindingItems
 
@@ -166,6 +170,15 @@ type BindingItem struct {
 	Name   string
 	Value  interface{}
 	Source Service
+}
+
+// a collection of bindings
+type Bindings interface {
+	// available bindgins
+	Items() (BindingItems, error)
+
+	// reference to resource holding the bindings, nil if not persisted in a resource
+	Source() *v1.ObjectReference
 }
 
 // Returns map representation of given list of binding items

--- a/pkg/reconcile/pipeline/builder/pipeline.go
+++ b/pkg/reconcile/pipeline/builder/pipeline.go
@@ -64,6 +64,8 @@ func Builder() *builder {
 
 var defaultFlow = []pipeline.Handler{
 	pipeline.HandlerFunc(project.Unbind),
+	pipeline.HandlerFunc(collect.PreFlight),
+	pipeline.HandlerFunc(collect.ProvisionedService),
 	pipeline.HandlerFunc(collect.BindingDefinitions),
 	pipeline.HandlerFunc(collect.BindingItems),
 	pipeline.HandlerFunc(collect.OwnedResources),

--- a/pkg/reconcile/pipeline/context/service_test.go
+++ b/pkg/reconcile/pipeline/context/service_test.go
@@ -90,11 +90,11 @@ var _ = Describe("Service", func() {
 				})
 			}
 
-			impl := &service{client: client, resource: u, lookForOwnedResources: true, serviceRef: &v1alpha1.Service{ NamespacedRef: v1alpha1.NamespacedRef{Namespace: &ns}}}
+			impl := &service{client: client, resource: u, lookForOwnedResources: true, serviceRef: &v1alpha1.Service{NamespacedRef: v1alpha1.NamespacedRef{Namespace: &ns}}}
 
 			ownedResources, err := impl.OwnedResources()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ownedResources).Should(HaveLen(len(bindableResourceGVRs)-1))
+			Expect(ownedResources).Should(HaveLen(len(bindableResourceGVRs) - 1))
 			Expect(ownedResources).Should(ConsistOf(children...))
 		})
 
@@ -135,14 +135,14 @@ var _ = Describe("Service", func() {
 				})
 			}
 
-			impl := &service{client: client, resource: u, lookForOwnedResources: true, serviceRef: &v1alpha1.Service{ NamespacedRef: v1alpha1.NamespacedRef{Namespace: &ns}}}
+			impl := &service{client: client, resource: u, lookForOwnedResources: true, serviceRef: &v1alpha1.Service{NamespacedRef: v1alpha1.NamespacedRef{Namespace: &ns}}}
 
 			ownedResources, err := impl.OwnedResources()
 			Expect(err).Should(Equal(expectedErr))
 			Expect(ownedResources).Should(BeNil())
 		},
-		Entry("fail listing configmap", "configmaps"),
-		Entry("fail listing services", "services"),
+			Entry("fail listing configmap", "configmaps"),
+			Entry("fail listing services", "services"),
 		)
 	})
 
@@ -153,7 +153,7 @@ func resource(gvk schema.GroupVersionKind, name string, namespace string, owner 
 	u.SetGroupVersionKind(gvk)
 	u.SetName(name)
 	u.SetNamespace(namespace)
-	u.SetOwnerReferences([]v1.OwnerReference {
+	u.SetOwnerReferences([]v1.OwnerReference{
 		{
 			UID: owner,
 		},

--- a/pkg/reconcile/pipeline/mocks/mocks_pipeline.go
+++ b/pkg/reconcile/pipeline/mocks/mocks_pipeline.go
@@ -51,6 +51,18 @@ func (mr *MockContextMockRecorder) AddBindingItem(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBindingItem", reflect.TypeOf((*MockContext)(nil).AddBindingItem), arg0)
 }
 
+// AddBindings mocks base method.
+func (m *MockContext) AddBindings(arg0 pipeline.Bindings) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddBindings", arg0)
+}
+
+// AddBindings indicates an expected call of AddBindings.
+func (mr *MockContextMockRecorder) AddBindings(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBindings", reflect.TypeOf((*MockContext)(nil).AddBindings), arg0)
+}
+
 // Applications mocks base method.
 func (m *MockContext) Applications() ([]pipeline.Application, error) {
 	m.ctrl.T.Helper()

--- a/pkg/reconcile/pipeline/secretbackedbindings.go
+++ b/pkg/reconcile/pipeline/secretbackedbindings.go
@@ -1,0 +1,68 @@
+package pipeline
+
+import (
+	"encoding/base64"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ Bindings = &SecretBackedBindings{}
+
+// bindings whose life-cycle is bound to k8s secret
+type SecretBackedBindings struct {
+	// service associated to the bindings
+	Service Service
+
+	// secret containing the bindings
+	// each binding correspond to a (key, value) pair
+	Secret *unstructured.Unstructured
+	items  BindingItems
+}
+
+func (s *SecretBackedBindings) Items() (BindingItems, error) {
+	if s.items != nil {
+		return s.items, nil
+	}
+	data, found, err := unstructured.NestedStringMap(s.Secret.Object, "data")
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		for k, v := range data {
+			val, err := base64.StdEncoding.DecodeString(v)
+			if err != nil {
+				return nil, err
+			}
+			s.items = append(s.items, &BindingItem{
+				Name:   k,
+				Value:  string(val),
+				Source: s.Service,
+			})
+		}
+	} else {
+		s.items = make([]*BindingItem, 0)
+	}
+	return s.items, nil
+}
+
+func (s *SecretBackedBindings) Source() *corev1.ObjectReference {
+	ref := &corev1.ObjectReference{
+		Kind:       s.Secret.GetKind(),
+		APIVersion: s.Secret.GetAPIVersion(),
+		Name:       s.Secret.GetName(),
+		Namespace:  s.Secret.GetNamespace(),
+	}
+	if s.items == nil {
+		return ref
+	}
+	val, found, err := unstructured.NestedStringMap(s.Secret.Object, "data")
+	if err != nil || !found {
+		return nil
+	}
+	for _, item := range s.items {
+		if _, ok := val[item.Name]; !ok {
+			return nil
+		}
+	}
+	return ref
+}

--- a/pkg/reconcile/pipeline/secretbackedbindings_test.go
+++ b/pkg/reconcile/pipeline/secretbackedbindings_test.go
@@ -1,0 +1,107 @@
+package pipeline_test
+
+import (
+	"encoding/base64"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
+	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline/mocks"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("SecretBackedBindings", func() {
+	var (
+		mockCtrl *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+	})
+
+	It("should return items contained in secret", func() {
+		secret := &unstructured.Unstructured{Object: map[string]interface{}{
+			"data": map[string]interface{}{
+				"foo1": base64.StdEncoding.EncodeToString([]byte("val1")),
+				"foo2": base64.StdEncoding.EncodeToString([]byte("val2")),
+			},
+		}}
+		service := mocks.NewMockService(mockCtrl)
+
+		b := &pipeline.SecretBackedBindings{Secret: secret, Service: service}
+
+		items, err := b.Items()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(items).Should(ConsistOf(&pipeline.BindingItem{Name: "foo1", Value: "val1", Source: service}, &pipeline.BindingItem{Name: "foo2", Value: "val2", Source: service}))
+	})
+
+	It("should return no items for secret with no data", func() {
+		secret := &unstructured.Unstructured{Object: map[string]interface{}{
+			"data": map[string]interface{}{},
+		}}
+
+		b := &pipeline.SecretBackedBindings{Secret: secret}
+		items, err := b.Items()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(items).Should(BeEmpty())
+	})
+
+	It("should return reference to secret when Items() was not invoked", func() {
+		secret := &unstructured.Unstructured{}
+		secret.SetName("foo")
+		secret.SetNamespace("ns1")
+		secret.SetAPIVersion("v1")
+		secret.SetKind("Secret")
+
+		b := &pipeline.SecretBackedBindings{Secret: secret}
+
+		ref := b.Source()
+
+		Expect(ref).Should(Equal(&v1.ObjectReference{APIVersion: "v1", Kind: "Secret", Name: secret.GetName(), Namespace: secret.GetNamespace()}))
+	})
+
+	It("should return no ref when an item key is modified", func() {
+		secret := &unstructured.Unstructured{Object: map[string]interface{}{
+			"data": map[string]interface{}{
+				"foo1": base64.StdEncoding.EncodeToString([]byte("val1")),
+				"foo2": base64.StdEncoding.EncodeToString([]byte("val2")),
+			},
+		}}
+		service := mocks.NewMockService(mockCtrl)
+
+		b := &pipeline.SecretBackedBindings{Secret: secret, Service: service}
+
+		items, _ := b.Items()
+		items[0].Name = "bla"
+
+		ref := b.Source()
+
+		Expect(ref).To(BeNil())
+	})
+
+	It("should return ref if no item key is modified", func() {
+		secret := &unstructured.Unstructured{Object: map[string]interface{}{
+			"data": map[string]interface{}{
+				"foo1": base64.StdEncoding.EncodeToString([]byte("val1")),
+				"foo2": base64.StdEncoding.EncodeToString([]byte("val2")),
+			},
+		}}
+		secret.SetName("foo")
+		secret.SetNamespace("ns1")
+		secret.SetAPIVersion("v1")
+		secret.SetKind("Secret")
+		service := mocks.NewMockService(mockCtrl)
+
+		b := &pipeline.SecretBackedBindings{Secret: secret, Service: service}
+
+		items, err := b.Items()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(items).Should(HaveLen(2))
+
+		ref := b.Source()
+
+		Expect(ref).To(Equal(&v1.ObjectReference{APIVersion: "v1", Kind: "Secret", Name: secret.GetName(), Namespace: secret.GetNamespace()}))
+	})
+
+})

--- a/pkg/util/util.go.go
+++ b/pkg/util/util.go.go
@@ -1,0 +1,8 @@
+package util
+
+func MergeMaps(dest map[string]string, src map[string]string) map[string]string {
+	for k, v := range src {
+		dest[k] = v
+	}
+	return dest
+}


### PR DESCRIPTION
Application can be bound to a provisioned service:

https://github.com/k8s-service-bindings/spec#provisioned-service

* collect.ProvisionedService handler detects if referred service contains a reference to secret containing the bindings
* unit and acceptance tests demonstrate the contact and exposed functionality

Fixes #548 