### PR TITLE
Add rbac support for spec alignment

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
 - leader_election_role_binding.yaml
 - servicebinding_editor_role.yaml
 - servicebinding_viewer_role.yaml
+- servicebinding_controller_role.yaml
+- servicebinding_controller_rolebinding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/servicebinding_controller_role.yaml
+++ b/config/rbac/servicebinding_controller_role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: controller-role
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      service.binding/controller: "true"
+rules: []

--- a/config/rbac/servicebinding_controller_rolebinding.yaml
+++ b/config/rbac/servicebinding_controller_rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-binding-controller-role
+subjects:
+- kind: ServiceAccount
+  name: service-binding-operator
+  namespace: operators
+- kind: ServiceAccount
+  name: service-binding-operator
+  namespace: openshift-operators

--- a/test/acceptance/features/pluggableRBAC.feature
+++ b/test/acceptance/features/pluggableRBAC.feature
@@ -1,0 +1,6 @@
+Feature: Making Service Biniding Operator RBAC pluggable so that other controllers/admins can add additional rules for the service binding operator.
+    Scenario: Service Binding Operator installation should contain aggregating cluster role and are bound with Namespace.
+        Given Namespace [TEST_NAMESPACE] is used
+        When Service Binding Operator is running
+        Then cluster role "service-binding-controller-role" is available in the cluster
+        And operator service account is bound to "service-binding-controller-role" in "service-binding-controller-rolebinding"

--- a/test/acceptance/features/steps/openshift.py
+++ b/test/acceptance/features/steps/openshift.py
@@ -144,8 +144,12 @@ spec:
             print('Resource list is empty under namespace - {}'.format(namespace))
             return None
 
-    def is_resource_in(self, resource_type):
-        output, exit_code = self.cmd.run(f'{ctx.cli} get {resource_type}')
+    def is_resource_in(self, resource_type, resource_name=None):
+        if resource_name is None:
+            _, exit_code = self.cmd.run(f'{ctx.cli} get {resource_type}')
+        else:
+            _, exit_code = self.cmd.run(f'{ctx.cli} get {resource_type} {resource_name}')
+
         return exit_code == 0
 
     def wait_for_pod(self, pod_name_pattern, namespace, interval=5, timeout=600):
@@ -299,6 +303,14 @@ spec:
         else:
             print(f'Error getting value for {resource_type}/{name} in {namespace} path={json_path}: {output}')
             return None
+
+    def get_json_resource(self, resource_type, name, namespace):
+        error_msg = f"Error in getting resource: '{resource_type}' '{name}' namespace: '{namespace}'"
+        output, exit_code = self.cmd.run(f'{ctx.cli} get {resource_type} {name} -n {namespace} -o json')
+        assert exit_code == 0, error_msg
+        json_output = json.loads(output)
+        assert json_output is not None, "Error in parsing JSON"
+        return json_output
 
     def get_resource_info_by_jq(self, resource_type, name, namespace, jq_expression, wait=False, interval=5, timeout=120):
         output, exit_code = self.cmd.run(f'{ctx.cli} get {resource_type} {name} -n {namespace} -o json | jq  \'{jq_expression}\'')

--- a/test/acceptance/features/steps/servicebindingoperator.py
+++ b/test/acceptance/features/steps/servicebindingoperator.py
@@ -15,8 +15,9 @@ class Servicebindingoperator():
         self.name = name
 
     def check_crd(self):
-        crd_name = "servicebinding"
-        assert self.openshift.is_resource_in(crd_name), f"CRD '{crd_name}' does not exist"
+        crd_type = "crd"
+        crd_name = "servicebindings.service.binding"
+        assert self.openshift.is_resource_in(crd_type, crd_name), f"CRD '{crd_name}' does not exist"
         return True
 
     def check_deployment(self):


### PR DESCRIPTION
### Motivation
https://github.com/redhat-developer/service-binding-operator/issues/900

### Changes
* Added Aggregated cluster role for the operator to get access to the resources
* Added rolebindings for the openshift-operators and operators namespace

### Testing

For testing this we need to 
* re-create the bundle manifests
* Deploy the operator and bundle to the cluster


For further more details refer the CONTRIBUTING.md