### PR TITLE
[acceptance-tests] Collect kube resources as well as SBO logs in GH workflows

### DIFF
--- a/.github/actions/collect-kube-resources/action.yaml
+++ b/.github/actions/collect-kube-resources/action.yaml
@@ -1,0 +1,53 @@
+# action.yml
+name: 'Collect Kube resources from Kubernetes cluster'
+description: 'Collects resources for later debugging from OLM operator testing.'
+inputs:
+  operator-namespace:
+    description: "Operator namespace"
+    required: false
+    default: ''
+  olm-namespace:
+    description: "OLM namespace"
+    required: false
+    default: ''
+  test-namespace-file:
+    description: "File with test namespace"
+    required: false
+    default: 'out/test-namespace'
+  output-path:
+    description: "A path to directory under which to store output files"
+    required: false
+    default: '.'
+runs:
+  using: "composite"
+  steps:
+    - id: collect-kube-resources
+      run: |
+        kubectl api-resources --verbs=list --namespaced -o name > resources.list
+
+        for ns in ${{inputs.operator-namespace}} ${{inputs.olm-namespace}}; do
+          OUTPUT=${{inputs.output-path}}/${ns}
+          mkdir -p ${OUTPUT}
+          for res in $(cat resources.list | grep -v secrets); do
+            kubectl get ${res} --ignore-not-found -n ${ns} -o yaml > ${OUTPUT}/${res}.yaml;
+          done
+          find ${OUTPUT} -size 0 -delete
+        done
+
+        if [ -f ${{ inputs.test-namespace-file }} ]; then
+          ns=$(cat ${{ inputs.test-namespace-file }})
+          OUTPUT=${{inputs.output-path}}/${ns}
+          mkdir -p ${OUTPUT}
+          for res in $(cat resources.list); do
+            kubectl get ${res} --ignore-not-found -n ${ns} -o yaml > ${OUTPUT}/${res}.yaml;
+          done
+          find ${OUTPUT} -size 0 -delete
+        fi
+      shell: bash
+
+    - id: collect-operator-logs
+      run: |
+        mkdir -p ${{inputs.output-path}}
+        operator_pod=$(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n ${{inputs.operator-namespace}} | tail -1)
+        kubectl logs ${operator_pod} -n ${{inputs.operator-namespace}} > ${{inputs.output-path}}/${operator_pod}.log
+      shell: bash

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -107,11 +107,14 @@ jobs:
 
           make SKIP_REGISTRY_LOGIN=true -o registry-login test-acceptance-with-bundle
 
-      - name: Collect logs
+      - name: Collect Kube resources
         continue-on-error: true
-        run: |
-          mkdir -p ${TEST_RESULTS}
-          kubectl logs $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n operators | tail -1) -n operators > ${TEST_RESULTS}/sbo.log
+        uses: ./.github/actions/collect-kube-resources
+        with:
+          operator-namespace: operators
+          olm-namespace: olm
+          test-namespace-file: out/test-namespace
+          output-path: ${{env.TEST_RESULTS}}
         if: always()
 
       - name: Setup Testspace
@@ -184,11 +187,13 @@ jobs:
           kubectl apply -f out/release.yaml
           make TEST_ACCEPTANCE_START_SBO=remote test-acceptance
 
-      - name: Collect logs
+      - name: Collect Kube resources
         continue-on-error: true
-        run: |
-          mkdir -p ${TEST_RESULTS}
-          kubectl logs $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n operators | tail -1) -n operators > ${TEST_RESULTS}/sbo.log
+        uses: ./.github/actions/collect-kube-resources
+        with:
+          operator-namespace: service-binding-operator
+          test-namespace-file: out/test-namespace
+          output-path: ${{env.TEST_RESULTS}}
         if: always()
 
       - name: Setup Testspace


### PR DESCRIPTION
### Motivation

Currently, only SBO logs are collected for debugging.

### Changes

This PR:
* Adds steps to acceptance testing PR checks to collect additional resources such as Subscription, CatalogSource, Pods and Deployments related to SBO for debugging purposes

### Testing

PR checks will do.