### PR TITLE
Include missed directories for python linters

### DIFF
--- a/hack/check-python/measure-cyclomatic-complexity.sh
+++ b/hack/check-python/measure-cyclomatic-complexity.sh
@@ -6,6 +6,8 @@
 
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
-pushd "${SCRIPT_DIR}/.."
-$PYTHON_VENV_DIR/bin/radon cc -s -a -i "$PYTHON_VENV_DIR" .
-popd
+for directory in ${SCRIPT_DIR}/.. $directories; do
+    pushd "$directory"
+    $PYTHON_VENV_DIR/bin/radon cc -s -a -i "$PYTHON_VENV_DIR" .
+    popd
+done

--- a/hack/check-python/measure-maintainability-index.sh
+++ b/hack/check-python/measure-maintainability-index.sh
@@ -6,6 +6,8 @@
 
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
-pushd "${SCRIPT_DIR}/.."
-$PYTHON_VENV_DIR/bin/radon mi -s -i "$PYTHON_VENV_DIR" .
-popd
+for directory in ${SCRIPT_DIR}/.. $directories; do
+    pushd "$directory"
+    $PYTHON_VENV_DIR/bin/radon mi -s -i "$PYTHON_VENV_DIR" .
+    popd
+done


### PR DESCRIPTION
### Motivation

Currently, the python linters `measure-cyclomatic-complexity.sh` and `measure-maintainability-index.sh` miss the directories of the acceptance tests where most of the python code is and only test python files under `hack` directory.

### Changes

This PR includes acceptance test directories containing python code to be tested by `measure-cyclomatic-complexity.sh` and `measure-maintainability-index.sh` python related linters.

### Testing

`make lint-python-code`