### PR TITLE
Allow metadata updates on Ready bindings

### DIFF
--- a/apis/binding/v1alpha1/servicebinding_types.go
+++ b/apis/binding/v1alpha1/servicebinding_types.go
@@ -223,6 +223,10 @@ func (sb *ServiceBinding) HasDeletionTimestamp() bool {
 	return !sb.DeletionTimestamp.IsZero()
 }
 
+func (sb *ServiceBinding) GetSpec() interface{} {
+	return &sb.Spec
+}
+
 // Returns GVR of reference if available, otherwise error
 func (ref *Ref) GroupVersionResource() (*schema.GroupVersionResource, error) {
 	if ref.Resource == "" {

--- a/apis/binding/v1alpha1/servicebinding_webhook.go
+++ b/apis/binding/v1alpha1/servicebinding_webhook.go
@@ -14,6 +14,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"errors"
 	"github.com/redhat-developer/service-binding-operator/apis"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -44,7 +45,11 @@ func (r *ServiceBinding) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *ServiceBinding) ValidateUpdate(old runtime.Object) error {
-	err := apis.CanUpdateBinding(r)
+	oldSb, ok := old.(*ServiceBinding)
+	if !ok {
+		return errors.New("Old object is not service binding")
+	}
+	err := apis.CanUpdateBinding(r, oldSb)
 	if err != nil {
 		log.Error(err, "Update failed")
 	}

--- a/apis/spec/v1alpha2/servicebinding_types.go
+++ b/apis/spec/v1alpha2/servicebinding_types.go
@@ -164,3 +164,7 @@ func (sb *ServiceBinding) HasDeletionTimestamp() bool {
 func (r *ServiceBinding) StatusConditions() []metav1.Condition {
 	return r.Status.Conditions
 }
+
+func (sb *ServiceBinding) GetSpec() interface{} {
+	return &sb.Spec
+}

--- a/apis/spec/v1alpha2/servicebinding_webhook.go
+++ b/apis/spec/v1alpha2/servicebinding_webhook.go
@@ -18,6 +18,7 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"errors"
 	"github.com/redhat-developer/service-binding-operator/apis"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -47,8 +48,12 @@ func (r *ServiceBinding) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *ServiceBinding) ValidateUpdate(old runtime.Object) error {
-	err := apis.CanUpdateBinding(r)
+func (sb *ServiceBinding) ValidateUpdate(old runtime.Object) error {
+	oldSb, ok := old.(*ServiceBinding)
+	if !ok {
+		return errors.New("Old object is not service binding")
+	}
+	err := apis.CanUpdateBinding(sb, oldSb)
 	if err != nil {
 		log.Error(err, "Update failed")
 	}

--- a/apis/spec/v1alpha2/servicebinding_webhook_test.go
+++ b/apis/spec/v1alpha2/servicebinding_webhook_test.go
@@ -11,6 +11,7 @@ var _ = Describe("Validation Webhook", func() {
 
 	It("should allow updates on non-ready bindings", func() {
 		sb := &ServiceBinding{
+			Spec: ServiceBindingSpec{},
 			Status: ServiceBindingStatus{
 				Conditions: []v1.Condition{*apis.Conditions().NotBindingReady().Build()},
 			},
@@ -18,12 +19,29 @@ var _ = Describe("Validation Webhook", func() {
 		Expect(sb.ValidateUpdate(sb)).ShouldNot(HaveOccurred())
 	})
 
-	It("should not allow updates on ready bindings", func() {
-		sb := &ServiceBinding{
+	It("should not allow spec updates on ready bindings", func() {
+		old := &ServiceBinding{
+			Spec: ServiceBindingSpec{},
 			Status: ServiceBindingStatus{
 				Conditions: []v1.Condition{*apis.Conditions().BindingReady().Build()},
 			},
 		}
-		Expect(sb.ValidateUpdate(sb)).Should(HaveOccurred())
+		sb := old.DeepCopy()
+		sb.Spec.Name = "foo"
+		Expect(sb.ValidateUpdate(old)).Should(HaveOccurred())
+	})
+
+	It("should allow metadata updates on ready bindings", func() {
+		old := &ServiceBinding{
+			Spec: ServiceBindingSpec{},
+			Status: ServiceBindingStatus{
+				Conditions: []v1.Condition{*apis.Conditions().BindingReady().Build()},
+			},
+		}
+		sb := old.DeepCopy()
+		sb.Annotations = map[string]string{
+			"foo": "bar",
+		}
+		Expect(sb.ValidateUpdate(old)).ShouldNot(HaveOccurred())
 	})
 })

--- a/test/acceptance/features/immutableBindings.feature
+++ b/test/acceptance/features/immutableBindings.feature
@@ -59,6 +59,50 @@ Feature: Successful Service Binding are Immutable
                     name: service-immutable
             """
 
+    Scenario: Can update metadata on a ready Service Binding
+        Given Generic test application "app-immutable-3" is running
+        And Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-immutable-3
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: service-immutable
+                application:
+                    name: app-immutable-3
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        When Service Binding "binding-immutable-3" is ready
+        Then Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: binding-immutable-3
+                annotations:
+                    foo: bar
+                labels:
+                    foo: bar
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: service-immutable
+                application:
+                    name: app-immutable-3
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+
     Scenario: Allow modifying a not-ready Service Binding
         Given Service Binding is applied
             """
@@ -135,6 +179,48 @@ Feature: Successful Service Binding are Immutable
                   name: service-immutable
                 application:
                     name: spec-app-immutable2
+                    apiVersion: apps/v1
+                    kind: Deployment
+            """
+    @spec
+    Scenario: SPEC Can update metadata on a ready Service Binding
+        Given Generic test application "spec-app-immutable-2" is running
+        And Service Binding is applied
+            """
+            apiVersion: service.binding/v1alpha2
+            kind: ServiceBinding
+            metadata:
+                name: spec-binding-immutable-2
+            spec:
+                type: foo
+                service:
+                  apiVersion: stable.example.com/v1
+                  kind: Backend
+                  name: service-immutable
+                application:
+                    name: spec-app-immutable-2
+                    apiVersion: apps/v1
+                    kind: Deployment
+            """
+        When Service Binding "spec-binding-immutable-2" is ready
+        Then Service Binding is applied
+            """
+            apiVersion: service.binding/v1alpha2
+            kind: ServiceBinding
+            metadata:
+                name: spec-binding-immutable-2
+                annotations:
+                    foo: bar
+                labels:
+                    foo: bar
+            spec:
+                type: foo
+                service:
+                  apiVersion: stable.example.com/v1
+                  kind: Backend
+                  name: service-immutable
+                application:
+                    name: spec-app-immutable-2
                     apiVersion: apps/v1
                     kind: Deployment
             """


### PR DESCRIPTION
Webhooks modifed to prevent updates only if `.spec` part of the binding is updated

Fixes #996