### PR TITLE
Add v1alpha2 CRD meta-data into CSV

### DIFF
--- a/config/manifests/bases/service-binding-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/service-binding-operator.clusterserviceversion.yaml
@@ -20,6 +20,11 @@ spec:
       kind: ServiceBinding
       name: servicebindings.binding.operators.coreos.com
       version: v1alpha1
+    - description: Service Binding for Kubernetes. Describes the connection between a Provisioned Service and an Application Projection. Implements Service Binding Specifcation for Kubernetes (https://github.com/k8s-service-bindings/spec).
+      displayName: Service Binding
+      kind: ServiceBinding
+      name: servicebindings.service.binding
+      version: v1alpha2
   description: " The Service Binding Operator enables application developers to more
                    easily bind applications together with operator managed backing services such
                    as databases, without having to perform manual configuration of secrets, configmaps,


### PR DESCRIPTION
### Motivation

Currently the generated CSV in bundle manifests misses the `displayName` and `description` in owned CRDs sections of `.spec.customresourcedefinitions` for `v1alpha2` version:
```yaml
spec:
  apiservicedefinitions: {}
  customresourcedefinitions:
    owned:
    - description: ServiceBinding expresses intent to bind an operator-backed service with an application workload.
      displayName: Service Binding
      kind: ServiceBinding
      name: servicebindings.binding.operators.coreos.com
      version: v1alpha1
    - kind: ServiceBinding
      name: servicebindings.service.binding
      version: v1alpha2
```
That leads to the following display of "Name Not Available" and "No description available" in [OperatorHub.io's page](https://operatorhub.io/operator/service-binding-operator):
![image](https://user-images.githubusercontent.com/3263627/127167028-69d8da7e-5ade-42d8-9112-e0916ec8cbc5.png)


### Changes

This PR adds the meta-data for `v1alpha2` CRDs into `config/manifests/bases/service-binding-operator.clusterserviceversion.yaml` to fix that.

After this patch the generated `.spec.customresourcedefinitions` in the CSV is:
```yaml
spec:
  apiservicedefinitions: {}
  customresourcedefinitions:
    owned:
    - description: ServiceBinding expresses intent to bind an operator-backed service with an application workload.
      displayName: Service Binding
      kind: ServiceBinding
      name: servicebindings.binding.operators.coreos.com
      version: v1alpha1
    - description: ServiceBinding expresses intent to bind an operator-backed service with an application workload.
      displayName: Service Binding
      kind: ServiceBinding
      name: servicebindings.service.binding
      version: v1alpha2
```

### Testing

Run `make bundle` and check generated `bundle/manifests/service-binding-operator.clusterserviceversion.yaml` file