### PR TITLE
Include cluster-wide resources to be collected by GH Actions.

### DIFF
--- a/.github/actions/collect-kube-resources/action.yaml
+++ b/.github/actions/collect-kube-resources/action.yaml
@@ -23,12 +23,13 @@ runs:
   steps:
     - id: collect-kube-resources
       run: |
-        kubectl api-resources --verbs=list --namespaced -o name > resources.list
+        kubectl api-resources --verbs=list --namespaced -o name > resources.namespaced.list
+        kubectl api-resources --verbs=list --namespaced=false -o name > resources.cluster-wide.list
 
         for ns in ${{inputs.operator-namespace}} ${{inputs.olm-namespace}}; do
           OUTPUT=${{inputs.output-path}}/${ns}
           mkdir -p ${OUTPUT}
-          for res in $(cat resources.list | grep -v secrets); do
+          for res in $(cat resources.namespaced.list | grep -v secrets); do
             kubectl get ${res} --ignore-not-found -n ${ns} -o yaml > ${OUTPUT}/${res}.yaml;
           done
           find ${OUTPUT} -size 0 -delete
@@ -38,11 +39,16 @@ runs:
           ns=$(cat ${{ inputs.test-namespace-file }})
           OUTPUT=${{inputs.output-path}}/${ns}
           mkdir -p ${OUTPUT}
-          for res in $(cat resources.list); do
+          for res in $(cat resources.namespaced.list); do
             kubectl get ${res} --ignore-not-found -n ${ns} -o yaml > ${OUTPUT}/${res}.yaml;
           done
           find ${OUTPUT} -size 0 -delete
         fi
+
+        OUTPUT=${{inputs.output-path}}
+        for res in $(cat resources.cluster-wide.list); do
+          kubectl get ${res} --ignore-not-found -o yaml > ${OUTPUT}/${res}.yaml;
+        done
       shell: bash
 
     - id: collect-operator-logs


### PR DESCRIPTION
## Motivation

Currently the GH actions for acceptance tests collect minikube resources for later debugging after the tests ared one. However it only collect resources from the related namespaces and misses the cluster-wide ones (such as `ClusterRole` or `ClusterRoleBinding`)

### Changes

This PR updates the `collect-kube-resoures` GH action to include collection of cluster-wide resources.

### Testing

After PR checks for running acceptance tests with Kubernetes are finished (passed or failed) the archived artifacts should contain cluster-wide resources as well as the namespaced ones.