### PR TITLE
Fix crash when service annotation with sliceOfMaps elements has invalid sourceValue

### DIFF
--- a/test/acceptance/resources/backend_crd.yaml
+++ b/test/acceptance/resources/backend_crd.yaml
@@ -44,6 +44,15 @@ spec:
                       type: string
                     environment:
                       type: string
+                connections:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      url:
+                        type: string
             status:
               type: object
               properties:


### PR DESCRIPTION
### Motivation

When using the `sliceOfMaps` elementType in a service binding annotation, the operator panics when the specified sourceValue does not exist in the underlying maps, although the expected behavior would be to inform the user the binding has an error through conditions.

### Changes

This PR changes the current behavior by verifying that the extracted value is present, and reports an error in the service binding in the case that the sourceValue key isn't present.

Replaces #993 and fixes #967.

### Testing

See #967 for reproducibility details.