### PR TITLE
Apply CSV best practices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,12 @@ vet:
 
 .PHONY: bundle
 # Generate bundle manifests and metadata, then validate generated files.
-bundle: manifests kustomize push-image
+bundle: manifests kustomize yq push-image
 #	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(OPERATOR_REPO_REF)@$(OPERATOR_IMAGE_SHA_REF)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(YQ) e -i '.metadata.annotations.containerImage="$(OPERATOR_REPO_REF)@$(OPERATOR_IMAGE_SHA_REF)"' bundle/manifests/service-binding-operator.clusterserviceversion.yaml
+	rm bundle/manifests/service-binding-operator_v1_serviceaccount.yaml
 	operator-sdk bundle validate ./bundle --select-optional name=operatorhub
 
 .PHONY: setup-venv

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: service-binding-controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,16 +11,16 @@ metadata:
   name: operator
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: service-binding-controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: service-binding-controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: service-binding-controller-manager
     spec:
       serviceAccountName: operator
       containers:

--- a/config/manifests/bases/service-binding-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/service-binding-operator.clusterserviceversion.yaml
@@ -9,6 +9,8 @@ metadata:
       and operator backed services
     repository: https://github.com/redhat-developer/service-binding-operator
     support: Service Binding Operator Community
+    containerImage: ""
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: service-binding-operator.v0.0.0
   namespace: placeholder
 spec:
@@ -63,7 +65,8 @@ spec:
   maintainers:
     - email: service-binding-support@redhat.com
       name: Openshift Application Services
-  maturity: alpha
+  maturity: candidate
+  minKubeVersion: 1.16.0
   provider:
     name: Red Hat
     url: redhat.com

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: service-binding-controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -13,4 +13,4 @@ spec:
       port: https
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: service-binding-controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: service-binding-controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: service-binding-controller-manager

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -9,4 +9,4 @@ spec:
     - port: 443
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    control-plane: service-binding-controller-manager


### PR DESCRIPTION
* added annotation that indicates that the operator can be deployed in disconnected environments
* specified minimal supported kube version
* added containerImage annotation
* maturity set to 'candidate'
* explicit service account dropped from bundle
* common label renamed to service-binding-controller-manager