### PR TITLE
Treat invalid "elementType" and "objectType" annotations as errors, not panics

### DIFF
--- a/pkg/binding/annotationmapper.go
+++ b/pkg/binding/annotationmapper.go
@@ -2,8 +2,9 @@ package binding
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/pkg/errors"
 )
@@ -26,12 +27,13 @@ var _ DefinitionBuilder = (*annotationBackedDefinitionBuilder)(nil)
 type modelKey string
 
 const (
-	pathModelKey        modelKey = "path"
-	objectTypeModelKey  modelKey = "objectType"
-	sourceKeyModelKey   modelKey = "sourceKey"
-	sourceValueModelKey modelKey = "sourceValue"
-	elementTypeModelKey modelKey = "elementType"
-	AnnotationPrefix             = "service.binding"
+	pathModelKey                    modelKey = "path"
+	objectTypeModelKey              modelKey = "objectType"
+	sourceKeyModelKey               modelKey = "sourceKey"
+	sourceValueModelKey             modelKey = "sourceValue"
+	elementTypeModelKey             modelKey = "elementType"
+	AnnotationPrefix                         = "service.binding"
+	ProvisionedServiceAnnotationKey          = "servicebinding.io/provisioned-service"
 )
 
 func NewDefinitionBuilder(annotationName string, annotationValue string, configMapReader UnstructuredResourceReader, secretReader UnstructuredResourceReader) *annotationBackedDefinitionBuilder {
@@ -45,25 +47,43 @@ func NewDefinitionBuilder(annotationName string, annotationValue string, configM
 	}
 }
 
-func (m *annotationBackedDefinitionBuilder) outputName() (string, error) {
-	// bail out in the case the annotation name doesn't start with "service.binding"
-	if m.name != AnnotationPrefix && !strings.HasPrefix(m.name, AnnotationPrefix+"/") {
-		return "", fmt.Errorf("can't process annotation with name %q", m.name)
+func (m *annotationBackedDefinitionBuilder) isServiceBindingAnnotation() (bool, error) {
+	if m.name == ProvisionedServiceAnnotationKey {
+		return false, nil
 	}
 
-	if p := strings.SplitN(m.name, "/", 2); len(p) > 1 && len(p[1]) > 0 {
-		return p[1], nil
+	if m.name == AnnotationPrefix {
+		return true, nil
+	} else if strings.HasPrefix(m.name, AnnotationPrefix) {
+		if strings.HasPrefix(m.name, AnnotationPrefix+"/") {
+			return true, nil
+		}
+
+		// it starts with AnnotationPrefix, but has extra text at the end not
+		// separated by a /, so treat it as an error
+		return false, fmt.Errorf("can't process annotation with name %q", m.name)
 	}
 
-	return "", nil
+	// bail out when the annotation name doesn't start with "service.binding"
+	return false, nil
+}
+
+func (m *annotationBackedDefinitionBuilder) outputName() string {
+
+	if p := strings.SplitN(m.name, "/", 2); len(p) == 2 && len(p[1]) > 0 {
+		return p[1]
+	}
+
+	return ""
 }
 
 func (m *annotationBackedDefinitionBuilder) Build() (Definition, error) {
 
-	outputName, err := m.outputName()
-	if err != nil {
+	if valid, err := m.isServiceBindingAnnotation(); !valid || err != nil {
 		return nil, err
 	}
+
+	outputName := m.outputName()
 
 	mod, err := newModel(m.value)
 	if err != nil {
@@ -128,6 +148,5 @@ func (m *annotationBackedDefinitionBuilder) Build() (Definition, error) {
 			sourceValue: mod.sourceValue,
 		}, nil
 	}
-
-	panic(fmt.Sprintf("Annotation %s=%s not implemented!", m.name, m.value))
+	return nil, fmt.Errorf("Annotation %s: %s not implemented!", m.name, m.value)
 }

--- a/pkg/binding/annotationmapper_test.go
+++ b/pkg/binding/annotationmapper_test.go
@@ -41,9 +41,17 @@ func TestAnnotationBackedBuilderInvalidAnnotation(t *testing.T) {
 			},
 		},
 		{
-			description: "other prefix supplied",
+			description: "invalid element type",
 			builder: &annotationBackedDefinitionBuilder{
-				name: "other.prefix",
+				name:  "service.binding/databaseField",
+				value: "path={.status.dbCredential},elementType=asdf",
+			},
+		},
+		{
+			description: "invalid object type",
+			builder: &annotationBackedDefinitionBuilder{
+				name:  "service.binding/username",
+				value: "path={.status.dbCredential},objectType=asdf,valueKey=username",
 			},
 		},
 	}
@@ -77,7 +85,22 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			description: "Ignore non-service binding annotations",
+			builder: &annotationBackedDefinitionBuilder{
+				name:  "foo",
+				value: "bar",
+			},
+			expectedValue: nil,
+		},
+		{
+			description: "Ignore provisioned service binding annotations",
+			builder: &annotationBackedDefinitionBuilder{
+				name:  ProvisionedServiceAnnotationKey,
+				value: "true",
+			},
+			expectedValue: nil,
+		},
 		{
 			description: "string definition",
 			builder: &annotationBackedDefinitionBuilder{

--- a/test/acceptance/features/bindAppToServiceAnnotations.feature
+++ b/test/acceptance/features/bindAppToServiceAnnotations.feature
@@ -584,3 +584,126 @@ Feature: Bind an application to a service using annotations
         And Service Binding CollectionReady.reason is "ValueNotFound"
         And Service Binding CollectionReady.message is "Value for key webarrows_primary not found"
 
+    Scenario: Application cannot be bound to service containing invalid elementType annotation
+        Given Generic test application is running
+        And CustomResourceDefinition backends.stable.example.com is available
+        And The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: $scenario_id
+                annotations:
+                    service.binding/credentials: path={.spec.connections.dbCredentials},elementType=asdf
+            spec:
+                connections:
+                  - type: primary
+                    url: primary.example.com
+            status:
+                somestatus: good
+            """
+        When Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                bindAsFiles: false
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: $scenario_id
+                application:
+                    name: $scenario_id
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding CollectionReady.status is "False"
+        And Service Binding CollectionReady.reason is "InvalidAnnotation"
+        And Service Binding Ready.message is "Annotation service.binding/credentials: path={.spec.connections.dbCredentials},elementType=asdf not implemented!"
+
+    Scenario: Application cannot be bound to service containing invalid objectType annotation
+        Given Generic test application is running
+        And CustomResourceDefinition backends.stable.example.com is available
+        And The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: $scenario_id
+                annotations:
+                    service.binding/credentials: path={.spec.connections.dbCredentials},objectType=asdf,sourceKey=username
+            spec:
+                connections:
+                  - type: primary
+                    url: primary.example.com
+            status:
+                somestatus: good
+            """
+        When Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                bindAsFiles: false
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: $scenario_id
+                application:
+                    name: $scenario_id
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding CollectionReady.status is "False"
+        And Service Binding CollectionReady.reason is "InvalidAnnotation"
+        And Service Binding Ready.message is "Annotation service.binding/credentials: path={.spec.connections.dbCredentials},objectType=asdf,sourceKey=username not implemented!"
+
+    Scenario: Application cannot be bound to service containing invalid path annotation
+        Given Generic test application is running
+        And CustomResourceDefinition backends.stable.example.com is available
+        And The Custom Resource is present
+            """
+            apiVersion: stable.example.com/v1
+            kind: Backend
+            metadata:
+                name: $scenario_id
+                annotations:
+                    service.binding/credentials: path=asdf
+            spec:
+                connections:
+                  - type: primary
+                    url: primary.example.com
+            status:
+                somestatus: good
+            """
+        When Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                bindAsFiles: false
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: Backend
+                    name: $scenario_id
+                application:
+                    name: $scenario_id
+                    group: apps
+                    version: v1
+                    resource: deployments
+            """
+        Then Service Binding CollectionReady.status is "False"
+        And Service Binding CollectionReady.reason is "InvalidAnnotation"
+        And Service Binding CollectionReady.message is "Failed to create binding definition from "service.binding/credentials: path=asdf": could not create binding model for annotation key service.binding/credentials and value path=asdf: path has invalid syntax: "asdf""
+        And Service Binding Ready.message is "could not create binding model for annotation key service.binding/credentials and value path=asdf: path has invalid syntax: "asdf""


### PR DESCRIPTION
### Motivation

If a service has an invalid service binding annotation set, we shouldn't attempt to bind the service.  However, current behavior catches most cases (such as an invalid path), but errors currently are ignored, and when either `elementType` or `objectType` isn't valid, we panic.  This could cause issues for users.

### Changes

Rather than panicking, we should fail the binding request and report any errors that are thrown.

### Testing

Attempting to bind against a service with an garbage annotation should now fail and report errors in the binding status.  For example, ```service.binding/credentials: path={.status.dbCredentials},elementType=asdf``` should fail.  This currently implements unit and acceptance tests for both `elementType` and `objectType` errors.  It also adds an acceptance test for invalid paths for the sake of regression testing.