### PR TITLE
[acceptance-tests] Use patch instead of apply for IDP setup to avoid braking cluster's IDPs

### DIFF
--- a/test/acceptance/openshift-setup.sh
+++ b/test/acceptance/openshift-setup.sh
@@ -10,22 +10,7 @@ USER_TOKEN=acceptance-tests-dev
 oc get secret $HTPASSWD_SECRET -n openshift-config >/dev/null 2>&1 \
   || oc create secret generic $HTPASSWD_SECRET --from-file=htpasswd=$HTPASSWD_FILE -n openshift-config
 
-oc apply -f - <<EOF
-apiVersion: config.openshift.io/v1
-kind: OAuth
-metadata:
-  name: cluster
-spec:
-  identityProviders:
-  - name: acceptance-tests
-    challenge: true
-    login: true
-    mappingMethod: claim
-    type: HTPasswd
-    htpasswd:
-      fileData:
-        name: $HTPASSWD_SECRET
-EOF
+oc patch oauth cluster --type merge -p '{"spec":{"identityProviders":[{"htpasswd":{"fileData":{"name":"'$HTPASSWD_SECRET'"}},"mappingMethod":"claim","name":"acceptance-tests","challenge":"true","login":true,"type":"HTPasswd"}]}}'
 
 CURRENT_CTX=$(oc config current-context)
 


### PR DESCRIPTION
### Motivation

Currently the non-admin user account  for acceptance tests is setup via `oc apply` command, which potentially ovewrites OAuth setup of the openshift cluster.

Running the `openshift-setup.sh` script multiple times might cause the `oc login` with the `acceptance-tests-dev` user to fail with:
```
Error from server (InternalError): Internal error occurred: unexpected response: 500
```

### Changes

This PR:
* Changes the way the new IDP is configured in `OAuth` from using `oc apply` command to `oc patch` to avoid breaking cluster's other IDPs 

### Testing

Run `test/acceptance-tests/openshift-setup.sh` multiple times. No login error should occur.