### PR TITLE
Add optional `.spec.name` to ServiceBinding to `binding.operators.coreos.com/v1alpha1 API`

### DIFF
--- a/apis/binding/v1alpha1/servicebinding_types.go
+++ b/apis/binding/v1alpha1/servicebinding_types.go
@@ -30,6 +30,11 @@ var templates = map[string]string{
 
 // ServiceBindingSpec defines the desired state of ServiceBinding.
 type ServiceBindingSpec struct {
+	// Name is the name of the service as projected into the workload container.  Defaults to .metadata.name.
+	// +kubebuilder:validation:Pattern=`^[a-z0-9\-\.]*$`
+	// +kubebuilder:validation:MaxLength=253
+	// +optional
+	Name string `json:"name,omitempty"`
 	// NamingStrategy defines custom string template for preparing binding
 	// names.  It can be set to pre-defined strategies: `none`,
 	// `lowercase`, or `uppercase`.  Otherwise, it is treated as a custom

--- a/config/crd/bases/binding.operators.coreos.com_servicebindings.yaml
+++ b/config/crd/bases/binding.operators.coreos.com_servicebindings.yaml
@@ -161,6 +161,12 @@ spec:
                   - value
                   type: object
                 type: array
+              name:
+                description: Name is the name of the service as projected into the
+                  workload container.  Defaults to .metadata.name.
+                maxLength: 253
+                pattern: ^[a-z0-9\-\.]*$
+                type: string
               namingStrategy:
                 description: 'NamingStrategy defines custom string template for preparing
                   binding names.  It can be set to pre-defined strategies: `none`,

--- a/pkg/reconcile/pipeline/context/impl.go
+++ b/pkg/reconcile/pipeline/context/impl.go
@@ -128,6 +128,9 @@ var Provider = func(client dynamic.Interface, subjectAccessReviewClient clientau
 }
 
 func (i *bindingImpl) BindingName() string {
+	if i.serviceBinding.Spec.Name != "" {
+		return i.serviceBinding.Spec.Name
+	}
 	return i.bindingMeta.GetName()
 }
 

--- a/pkg/reconcile/pipeline/context/impl_test.go
+++ b/pkg/reconcile/pipeline/context/impl_test.go
@@ -5,13 +5,12 @@ import (
 	"encoding/base64"
 	e "errors"
 	"fmt"
-	"github.com/redhat-developer/service-binding-operator/apis"
-	bindingapi "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-developer/service-binding-operator/apis"
+	bindingapi "github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/converter"
 	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
 	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline/context/mocks"
@@ -422,6 +421,31 @@ var _ = Describe("Context", func() {
 
 			_, err = ctx.Services()
 			Expect(err).To(HaveOccurred())
+		})
+	})
+	Describe("Binding Name", func() {
+		var testProvider = Provider(nil, nil, nil)
+		It("should be equal on .spec.name if specified", func() {
+			ctx, _ := testProvider.Get(&bindingapi.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sb1",
+				},
+				Spec: bindingapi.ServiceBindingSpec{
+					Name: "sb2",
+				},
+			})
+
+			Expect(ctx.BindingName()).To(Equal("sb2"))
+		})
+
+		It("should be equal on .name if .spec.name not specified", func() {
+			ctx, _ := testProvider.Get(&bindingapi.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sb1",
+				},
+			})
+
+			Expect(ctx.BindingName()).To(Equal("sb1"))
 		})
 	})
 

--- a/test/acceptance/features/bindAppToProvisionedService.feature
+++ b/test/acceptance/features/bindAppToProvisionedService.feature
@@ -345,6 +345,40 @@ Feature: Bind application to provisioned service
             db
             """
 
+  Scenario: Bind application to provisioned service and inject binding into folder specified by .spec.name
+    Given Generic test application is running
+    When Service Binding is applied
+          """
+          apiVersion: binding.operators.coreos.com/v1alpha1
+          kind: ServiceBinding
+          metadata:
+              name: $scenario_id
+          spec:
+              name: foo
+              services:
+                - group: stable.example.com
+                  version: v1
+                  kind: ProvisionedBackend
+                  name: provisioned-service-2
+              application:
+                name: $scenario_id
+                group: apps
+                version: v1
+                kind: Deployment
+          """
+    Then Service Binding is ready
+    And Content of file "/bindings/foo/username" in application pod is
+            """
+            foo
+            """
+    And Content of file "/bindings/foo/password" in application pod is
+            """
+            bar
+            """
+    And Content of file "/bindings/foo/type" in application pod is
+            """
+            db
+            """
 
 
   @spec


### PR DESCRIPTION
Until now, the binding name was set through `.metadata.name` of `ServiceBinding` resource,
and that name was used in constructing binding mount point, i.e. `<SERVICE_BINDING_ROOT>/<binding name>`

Since `.metadata.name` value must be unique within all `ServiceBinding` resources in a given namespace,
the introduction of `.spec.name` allows us to overwrite `.metadata.name` and have more predictable
mount points inside containers.

This work aligns `binding.operators.coreos.com/v1alpha1 API` even further to the spec API:

https://github.com/servicebinding/spec#resource-type-schema-1