### PR TITLE
Fix CSV manifests to reflect v1alpha3 version of spec API and recent addition of BindableKinds CRD

### DIFF
--- a/apis/binding/v1alpha1/servicebinding_types.go
+++ b/apis/binding/v1alpha1/servicebinding_types.go
@@ -172,7 +172,6 @@ type BindingPath struct {
 // ServiceBinding expresses intent to bind a service with an application
 // workload.
 // +kubebuilder:subresource:status
-// +operator-sdk:gen-csv:customresourcedefinitions.displayName="Service Binding"
 // +kubebuilder:resource:path=servicebindings,shortName=sbr;sbrs
 // +kubebuilder:object:root=true
 type ServiceBinding struct {

--- a/apis/spec/v1alpha3/servicebinding_types.go
+++ b/apis/spec/v1alpha3/servicebinding_types.go
@@ -96,7 +96,6 @@ type ServiceBindingStatus struct {
 	Binding *ServiceBindingSecretReference `json:"binding,omitempty"`
 }
 
-// +operator-sdk:gen-csv:customresourcedefinitions.displayName="Service Binding (spec API)"
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status

--- a/config/manifests/bases/service-binding-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/service-binding-operator.clusterserviceversion.yaml
@@ -17,6 +17,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: BindableKinds contains a list of bindable type (group, version, kind) found in the cluster. It is cluster-scoped and there is only single instance named 'bindable-kinds'.
+      displayName: Bindable Kinds
+      kind: BindableKinds
+      name: bindablekinds.binding.operators.coreos.com
+      version: v1alpha1
     - description: Service Binding expresses intent to bind a backing service with an application workload. 
       displayName: Service Binding
       kind: ServiceBinding
@@ -26,7 +31,7 @@ spec:
       displayName: Service Binding (Spec API Tech Preview)
       kind: ServiceBinding
       name: servicebindings.servicebinding.io
-      version: v1alpha2
+      version: v1alpha3
   description: " The Service Binding Operator enables application developers to more
                    easily bind applications together with operator managed backing services such
                    as databases, without having to perform manual configuration of secrets, configmaps,


### PR DESCRIPTION
### Motivation

Currently the `config/manifests/bases/service-binding-operator.clusterserviceversion.yaml` file is not updated for latest version of spec `ServiceBinding` and `BindableKinds` CRDs and so it is generated without `displayName` and `description`.

This is how it is shown in operatorhub.io

![image](https://user-images.githubusercontent.com/3263627/135436553-2dfeaeac-478d-436d-8f02-ce3b6d48e9a3.png)

and this is how it looks like in OpenShift's OperatorHub

![image](https://user-images.githubusercontent.com/3263627/135438471-dc2590f7-7063-4db8-8628-92d527871349.png)

![image](https://user-images.githubusercontent.com/3263627/135438931-09685f54-5faa-4cc1-a75d-74cd583aeef3.png)

See that the `ServiceBinding` from spec API does not have the proper name displayed (should be `Service Binding (Spec API Tech Preview)`)

### Changes

This PR:
* Adds `BindableKinds` CRD into base CSV
* Updates version of `servicebindings.servicebinding.io` to `v1alpha3` in base CSV
* Removes deprecated and unused `+operator-sdk:gen-csv:...` annotations from `servicebinding_types.go` in both `binding` and `spec` apis.

With this PR this is how it looks in OpenShift - correct display name and descriptions for all CRDs

![image](https://user-images.githubusercontent.com/3263627/135439151-bc4a1324-2533-4bd2-9227-1ac28ac00b28.png)

![image](https://user-images.githubusercontent.com/3263627/135439340-1d2e12f9-10ed-4df3-8fdb-64c9c6a6066c.png)

### Testing
