### PR TITLE
Add support for Opstree Redis operator-backed services

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
 - bindablekinds_viewer_rolebinding.yaml
 - servicebinding_controller_role.yaml
 - servicebinding_controller_rolebinding.yaml
+# operators supproted out of the box
+- opstree_redis_clusterrole.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/opstree_redis_clusterrole.yaml
+++ b/config/rbac/opstree_redis_clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opstree-redis-viewer-role
+  labels:
+    servicebinding.io/controller: "true"
+rules:
+  - apiGroups:
+      - redis.redis.opstreelabs.in
+    resources:
+      - redis
+    verbs:
+      - get
+      - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,6 +38,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - apps

--- a/hack/get-test-namespace
+++ b/hack/get-test-namespace
@@ -33,6 +33,6 @@ uuid()
 
 mkdir -p "$OUTPUT_DIR"
 
-[ -f "$NS_FILE" ] || echo "test-namespace-$(uuid | cut -d '-' -f 5)" > "$NS_FILE"
+[ -f "$NS_FILE" ] || echo "test-ns-$(uuid | cut -d '-' -f 5 | cut -c -4)" > "$NS_FILE"
 
 cat "$NS_FILE"

--- a/pkg/binding/annotationmapper.go
+++ b/pkg/binding/annotationmapper.go
@@ -34,6 +34,7 @@ const (
 	elementTypeModelKey             modelKey = "elementType"
 	AnnotationPrefix                         = "service.binding"
 	ProvisionedServiceAnnotationKey          = "servicebinding.io/provisioned-service"
+	TypeKey                                  = AnnotationPrefix + "/type"
 )
 
 func NewDefinitionBuilder(annotationName string, annotationValue string, configMapReader UnstructuredResourceReader, secretReader UnstructuredResourceReader) *annotationBackedDefinitionBuilder {
@@ -95,9 +96,10 @@ func (m *annotationBackedDefinitionBuilder) Build() (Definition, error) {
 	}
 
 	switch {
-	case mod.isStringElementType() && mod.isStringObjectType():
+	case (mod.isStringElementType() && mod.isStringObjectType()) || mod.value != "":
 		return &stringDefinition{
 			outputName: outputName,
+			value:      mod.value,
 			definition: definition{
 				path: mod.path,
 			},

--- a/pkg/binding/annotationmapper_test.go
+++ b/pkg/binding/annotationmapper_test.go
@@ -86,6 +86,17 @@ func TestAnnotationBackedBuilderValidAnnotations(t *testing.T) {
 			},
 		},
 		{
+			description: "value definition",
+			builder: &annotationBackedDefinitionBuilder{
+				name:  "service.binding/type",
+				value: "foo",
+			},
+			expectedValue: &stringDefinition{
+				outputName: "type",
+				value:      "foo",
+			},
+		},
+		{
 			description: "Ignore non-service binding annotations",
 			builder: &annotationBackedDefinitionBuilder{
 				name:  "foo",

--- a/pkg/binding/definition.go
+++ b/pkg/binding/definition.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -56,6 +55,7 @@ func (d *definition) GetPath() string {
 
 type stringDefinition struct {
 	outputName string
+	value      string
 	definition
 }
 
@@ -64,6 +64,13 @@ var _ Definition = (*stringDefinition)(nil)
 func (d *stringDefinition) Apply(u *unstructured.Unstructured) (Value, error) {
 	if d.outputName == "" {
 		return nil, fmt.Errorf("cannot use generic service.binding annotation for string elements, need to specify binding key like service.binding/foo")
+	}
+	if d.value != "" {
+		return &value{
+			v: map[string]interface{}{
+				d.outputName: d.value,
+			},
+		}, nil
 	}
 	val, err := getValuesByJSONPath(u.Object, d.path)
 	if err != nil {

--- a/pkg/binding/definition_test.go
+++ b/pkg/binding/definition_test.go
@@ -13,6 +13,7 @@ func TestStringDefinition(t *testing.T) {
 		description   string
 		outputName    string
 		path          string
+		value         string
 		expectedValue interface{}
 	}
 
@@ -31,6 +32,14 @@ func TestStringDefinition(t *testing.T) {
 			path:        "{.status.dbCredentials.username}",
 			expectedValue: map[string]interface{}{
 				"anotherName": "AzureDiamond",
+			},
+		},
+		{
+			description: "raw value",
+			outputName:  "foo",
+			value:       "bar",
+			expectedValue: map[string]interface{}{
+				"foo": "bar",
 			},
 		},
 	}
@@ -52,6 +61,7 @@ func TestStringDefinition(t *testing.T) {
 				definition: definition{
 					path: tc.path,
 				},
+				value: tc.value,
 			}
 			val, err := d.Apply(u)
 			require.NoError(t, err)

--- a/pkg/binding/model.go
+++ b/pkg/binding/model.go
@@ -12,7 +12,7 @@ type model struct {
 	objectType  objectType
 	sourceKey   string
 	sourceValue string
-	bindAs      BindingType
+	value       string
 }
 
 func (m *model) isStringElementType() bool {
@@ -58,6 +58,11 @@ func newModel(annotationValue string) (*model, error) {
 	// assert PathModelKey is present
 	path, found := raw[pathModelKey]
 	if !found {
+		if len(raw) == 0 {
+			return &model{
+				value: annotationValue,
+			}, nil
+		}
 		return nil, fmt.Errorf("path not found: %q", annotationValue)
 	}
 	if !strings.HasPrefix(path, "{") || !strings.HasSuffix(path, "}") {
@@ -120,6 +125,5 @@ func newModel(annotationValue string) (*model, error) {
 		objectType:  objType,
 		sourceValue: sourceValue,
 		sourceKey:   sourceKey,
-		bindAs:      TypeEnvVar,
 	}, nil
 }

--- a/test/acceptance/features/steps/olm.py
+++ b/test/acceptance/features/steps/olm.py
@@ -29,10 +29,11 @@ class Operator(object):
             return False
 
     def install_catalog_source(self):
-        install_src_output = self.openshift.create_catalog_source(self.operator_catalog_source_name, self.operator_catalog_image)
-        if re.search(r'.*catalogsource.operators.coreos.com/%s\s(unchanged|created)' % self.operator_catalog_source_name, install_src_output) is None:
-            print("Failed to create {} catalog source".format(self.operator_catalog_source_name))
-            return False
+        if self.operator_catalog_image != "":
+            install_src_output = self.openshift.create_catalog_source(self.operator_catalog_source_name, self.operator_catalog_image)
+            if re.search(r'.*catalogsource.operators.coreos.com/%s\s(unchanged|created)' % self.operator_catalog_source_name, install_src_output) is None:
+                print("Failed to create {} catalog source".format(self.operator_catalog_source_name))
+                return False
         return self.openshift.wait_for_package_manifest(self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel)
 
     def install_operator_subscription(self):

--- a/test/acceptance/features/steps/redisoperator.py
+++ b/test/acceptance/features/steps/redisoperator.py
@@ -1,0 +1,24 @@
+from olm import Operator
+from environment import ctx
+from behave import given
+
+
+class RedisOperator(Operator):
+
+    def __init__(self, name="redis-operator"):
+        self.name = name
+        if ctx.cli == "oc":
+            self.operator_catalog_source_name = "community-operators"
+        else:
+            self.operator_catalog_source_name = "operatorhubio-catalog"
+        self.operator_catalog_channel = "stable"
+        self.package_name = name
+
+
+@given(u'Opstree Redis operator is running')
+def install_redis_operator(_context):
+    operator = RedisOperator()
+    if not operator.is_running():
+        operator.install_operator_subscription()
+        operator.is_running(wait=True)
+    print("Opstree Redis operator is running")

--- a/test/acceptance/features/supportExistingOperatorBackedServices.feature
+++ b/test/acceptance/features/supportExistingOperatorBackedServices.feature
@@ -1,0 +1,89 @@
+@olm
+Feature: Support a number of existing operator-backed services out of the box
+
+  As a user of Service Binding operator
+  I would like to be able to bind my application to a number of existing operator-backed services
+  without a need to tweak their k8s resources
+
+  Background:
+    Given Namespace [TEST_NAMESPACE] is used
+    * Service Binding Operator is running
+
+  Scenario: Bind test application to Redis instance provisioned by Opstree Redis operator
+    Given Opstree Redis operator is running
+    * Generic test application is running
+    * The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: redis-secret
+            stringData:
+                password: redisSecret!
+            """
+
+    * The Custom Resource is present
+          """
+          apiVersion: redis.redis.opstreelabs.in/v1beta1
+          kind: Redis
+          metadata:
+            name: redis-standalone
+          spec:
+            kubernetesConfig:
+              image: quay.io/opstree/redis:v6.2.5
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 101m
+                  memory: 128Mi
+                limits:
+                  cpu: 101m
+                  memory: 128Mi
+              serviceType: ClusterIP
+              redisSecret:
+                name: redis-secret
+                key: password
+            storage:
+              volumeClaimTemplate:
+                spec:
+                  # storageClassName: standard
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: 1Gi
+            redisExporter:
+              enabled: false
+              image: quay.io/opstree/redis-exporter:1.0
+          """
+    When Service Binding is applied
+          """
+          apiVersion: binding.operators.coreos.com/v1alpha1
+          kind: ServiceBinding
+          metadata:
+              name: $scenario_id
+          spec:
+              services:
+              - group: redis.redis.opstreelabs.in
+                version: v1beta1
+                kind: Redis
+                name: redis-standalone
+              application:
+                name: $scenario_id
+                group: apps
+                version: v1
+                resource: deployments
+          """
+    Then Service Binding is ready
+    And Kind Redis with apiVersion redis.redis.opstreelabs.in/v1beta1 is listed in bindable kinds
+    And Content of file "/bindings/$scenario_id/type" in application pod is
+           """
+           redis
+           """
+    And Content of file "/bindings/$scenario_id/host" in application pod is
+           """
+           redis-standalone
+           """
+    And Content of file "/bindings/$scenario_id/password" in application pod is
+           """
+           redisSecret!
+           """


### PR DESCRIPTION
Provisioned `redis.redis.opstreelabs.in/v1beta1`/`Redis` instances are bindable out of the box, exposing following binding data:
* type (always set to 'redis')
* host
* password

In order to expose `type`, support for binding constant has been added. Namely, if a service binding annotation value does not specify `path`,
then the annotation value is used as the binding value. With that it is possible to state something like this:

```
service.binding/type: redis
```

Unit and acceptance tests have been added to verify the introduced behavior.



Solves indirectly #843