### PR TITLE
Add support for CrunchyData Postgres operator

### DIFF
--- a/config/rbac/crunchy_postgres_clusterrole.yaml
+++ b/config/rbac/crunchy_postgres_clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crunchy-postgres-viewer-role
+  labels:
+    servicebinding.io/controller: "true"
+rules:
+  - apiGroups:
+      - postgres-operator.crunchydata.com
+    resources:
+      - postgresclusters
+    verbs:
+      - get
+      - list

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - servicebinding_controller_rolebinding.yaml
 # operators supproted out of the box
 - opstree_redis_clusterrole.yaml
+- crunchy_postgres_clusterrole.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/controllers/crd/crd_controller.go
+++ b/controllers/crd/crd_controller.go
@@ -42,6 +42,12 @@ var bindingAnnotations = map[schema.GroupVersionKind]map[string]string{
 		"service.binding/host":     "path={.metadata.name}",
 		"service.binding/password": "path={.spec.kubernetesConfig.redisSecret.name},objectType=Secret,sourceKey=password",
 	},
+	schema.GroupVersionKind{Group: "postgres-operator.crunchydata.com", Version: "v1beta1", Kind: "PostgresCluster"}: {
+		"service.binding/type":     "postgresql",
+		"service.binding":          "path={.metadata.name}-pguser-{.metadata.name},objectType=Secret",
+		"service.binding/database": "path={.metadata.name}-pguser-{.metadata.name},objectType=Secret,sourceKey=dbname",
+		"service.binding/username": "path={.metadata.name}-pguser-{.metadata.name},objectType=Secret,sourceKey=user",
+	},
 }
 
 // CrdReconciler reconciles a CustomResourceDefinition resources

--- a/pkg/binding/definition.go
+++ b/pkg/binding/definition.go
@@ -166,7 +166,7 @@ func (d *mapFromDataFieldDefinition) Apply(u *unstructured.Unstructured) (Value,
 	if len(res) != 1 {
 		return nil, fmt.Errorf("only one value should be returned for %v but we got %v", d.path, res)
 	}
-	resourceName := res[0].Elem().String()
+	resourceName := fmt.Sprintf("%v", res[0].Interface())
 
 	var otherObj *unstructured.Unstructured
 	if d.objectType == secretObjectType {

--- a/pkg/binding/jsonpath.go
+++ b/pkg/binding/jsonpath.go
@@ -1,10 +1,9 @@
 package binding
 
 import (
-	"fmt"
-	"reflect"
-
 	"k8s.io/client-go/util/jsonpath"
+	"reflect"
+	"strings"
 )
 
 // getValuesByJSONPath returns values from the given map matching the provided JSONPath
@@ -23,7 +22,13 @@ func getValuesByJSONPath(obj map[string]interface{}, path string) ([]reflect.Val
 		return nil, err
 	}
 	if len(result) > 1 {
-		return nil, fmt.Errorf("more than one item found in the result: %v", result)
+		w := strings.Builder{}
+		for i := range result {
+			if err := j.PrintResults(&w, result[i]); err != nil {
+				return nil, err
+			}
+		}
+		return []reflect.Value{reflect.ValueOf(w.String())}, nil
 	}
 	return result[0], nil
 }

--- a/pkg/binding/jsonpath_test.go
+++ b/pkg/binding/jsonpath_test.go
@@ -59,30 +59,34 @@ func TestGetValueByJSONPath(t *testing.T) {
 		WantErr bool
 	}{
 		{
-			Path: ".spec.serviceName",
+			Path: "{.spec.serviceName}",
 			Want: "db1-svc",
 		},
 		{
-			Path: ".spec.template.spec.containers[0].name",
+			Path: "{.spec.template.spec.containers[0].name}",
 			Want: "db1",
 		},
 		{
-			Path: ".spec.template.spec.containers[0].env[2].value",
+			Path: "{.spec.template.spec.containers[0].env[2].value}",
 			Want: "mydb",
 		},
 		{
-			Path: ".spec.template.spec.containers[?(@.name==\"db1\")].env[?(@.name==\"POSTGRESQL_USER\")].value",
+			Path: "{.spec.template.spec.containers[?(@.name==\"db1\")].env[?(@.name==\"POSTGRESQL_USER\")].value}",
 			Want: "user1",
 		},
 		{
-			Path: ".spec.template.metadata.labels",
+			Path: "{.spec.template.metadata.labels}",
 			Want: map[string]interface{}{
 				"app": "db1",
 			},
 		},
 		{
-			Path:    ".foo",
+			Path:    "{.foo}",
 			WantErr: true,
+		},
+		{
+			Path: "foo-{.spec.serviceName}",
+			Want: "foo-db1-svc",
 		},
 	}
 
@@ -94,7 +98,7 @@ func TestGetValueByJSONPath(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Path, func(t *testing.T) {
-			result, err := getValuesByJSONPath(u.Object, "{"+test.Path+"}")
+			result, err := getValuesByJSONPath(u.Object, test.Path)
 			if (err != nil) != test.WantErr {
 				t.Errorf("Expecting err %v, got %v\n", test.WantErr, err)
 			}

--- a/pkg/binding/model.go
+++ b/pkg/binding/model.go
@@ -65,7 +65,7 @@ func newModel(annotationValue string) (*model, error) {
 		}
 		return nil, fmt.Errorf("path not found: %q", annotationValue)
 	}
-	if !strings.HasPrefix(path, "{") || !strings.HasSuffix(path, "}") {
+	if n := strings.Count(path, "{"); n == 0 || n != strings.Count(path, "}") {
 		return nil, fmt.Errorf("path has invalid syntax: %q", path)
 	}
 

--- a/test/acceptance/features/steps/crunchypostgresoperator.py
+++ b/test/acceptance/features/steps/crunchypostgresoperator.py
@@ -1,0 +1,24 @@
+from olm import Operator
+from environment import ctx
+from behave import given
+
+
+class CrunchyPostgresOperator(Operator):
+
+    def __init__(self, name="pgo"):
+        self.name = name
+        if ctx.cli == "oc":
+            self.operator_catalog_source_name = "community-operators"
+        else:
+            self.operator_catalog_source_name = "operatorhubio-catalog"
+        self.operator_catalog_channel = "v5"
+        self.package_name = "postgresql"
+
+
+@given(u'Crunchy Data Postgres operator is running')
+def install(_context):
+    operator = CrunchyPostgresOperator()
+    if not operator.is_running():
+        operator.install_operator_subscription()
+        operator.is_running(wait=True)
+    print("Crunchy Data Postgres operator is running")

--- a/test/acceptance/features/steps/generic_testapp.py
+++ b/test/acceptance/features/steps/generic_testapp.py
@@ -79,9 +79,15 @@ def check_env_var_existence(context, name):
 
 @step(u'Content of file "{file_path}" in application pod is')
 def check_file_value(context, file_path):
-    value = context.text.strip()
+    value = Template(context.text.strip()).substitute(NAMESPACE=context.namespace.name)
     resource = Template(file_path).substitute(scenario_id=scenario_id(context))
     polling2.poll(lambda: context.application.get_file_value(resource) == value, step=5, timeout=400)
+
+
+@step(u'File "{file_path}" exists in application pod')
+def check_file_exists(context, file_path):
+    resource = Template(file_path).substitute(scenario_id=scenario_id(context))
+    polling2.poll(lambda: context.application.get_file_value(resource) != "", step=5, timeout=400)
 
 
 @step(u'File "{file_path}" is unavailable in application pod')

--- a/test/acceptance/features/supportExistingOperatorBackedServices.feature
+++ b/test/acceptance/features/supportExistingOperatorBackedServices.feature
@@ -87,3 +87,74 @@ Feature: Support a number of existing operator-backed services out of the box
            """
            redisSecret!
            """
+
+  Scenario: Bind test application to Postgres provisioned by Crunchy Data Postgres operator
+    Given Crunchy Data Postgres operator is running
+    * Generic test application is running
+    * The Custom Resource is present
+          """
+          apiVersion: postgres-operator.crunchydata.com/v1beta1
+          kind: PostgresCluster
+          metadata:
+            name: hippo
+          spec:
+            image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
+            postgresVersion: 13
+            instances:
+              - name: instance1
+                dataVolumeClaimSpec:
+                  accessModes:
+                  - "ReadWriteOnce"
+                  resources:
+                    requests:
+                      storage: 1Gi
+            backups:
+              pgbackrest:
+                image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+                repos:
+                - name: repo1
+                  volume:
+                    volumeClaimSpec:
+                      accessModes:
+                      - "ReadWriteOnce"
+                      resources:
+                        requests:
+                          storage: 1Gi
+          """
+    When Service Binding is applied
+          """
+          apiVersion: binding.operators.coreos.com/v1alpha1
+          kind: ServiceBinding
+          metadata:
+              name: $scenario_id
+          spec:
+              services:
+              - group: postgres-operator.crunchydata.com
+                version: v1beta1
+                kind: PostgresCluster
+                name: hippo
+              application:
+                name: $scenario_id
+                group: apps
+                version: v1
+                resource: deployments
+          """
+    Then Service Binding is ready
+    And Kind PostgresCluster with apiVersion postgres-operator.crunchydata.com/v1beta1 is listed in bindable kinds
+    And Content of file "/bindings/$scenario_id/type" in application pod is
+           """
+           postgresql
+           """
+    And Content of file "/bindings/$scenario_id/host" in application pod is
+           """
+           hippo-primary.$NAMESPACE.svc
+           """
+    And Content of file "/bindings/$scenario_id/database" in application pod is
+           """
+           hippo
+           """
+    And Content of file "/bindings/$scenario_id/username" in application pod is
+           """
+           hippo
+           """
+    And File "/bindings/$scenario_id/password" exists in application pod


### PR DESCRIPTION
In order to read binding data from the right secret, the value of `path` key of a service binding annotation
is treated as a template:
* multiple json paths can specified and the results of their evaluation are rendered in the final binding value
* the template can contain arbitrary additional strings that are rendered 'as-is' in the final binding value

Hence, it is possible to generate proper secret reference and read binding data from it. In the case of
CrunchyData Postgres Operator, this is the right annotations:

```
"service.binding": "path={.metadata.name}-pguser-{.metadata.name},objectType=Secret",
```

On top of that, `user` is exposed as `username` as well, and `dbname` and `database`, so that
more applications can find all the binding data they need.