### PR TITLE
registry: add support for percona mongodb clusters

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - percona_mysql_clusterrole.yaml
 - cloud_native_postgres_clusterrole.yaml
 - rabbitmq_operator_clusterrole.yaml
+- percona_mongodb_clusterrole.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/percona_mongodb_clusterrole.yaml
+++ b/config/rbac/percona_mongodb_clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: percona-mongodb-view
+  labels:
+    servicebinding.io/controller: "true"
+rules:
+  - apiGroups:
+      - psmdb.percona.com
+    resources:
+      - perconaservermongodbs
+      - perconaservermongodbs/status
+    verbs:
+      - get
+      - list

--- a/controllers/crd/crd_controller.go
+++ b/controllers/crd/crd_controller.go
@@ -63,6 +63,22 @@ var bindingAnnotations = map[schema.GroupVersionKind]map[string]string{
 		"service.binding/username": "root",
 		"service.binding/password": "path={.spec.secretsName},objectType=Secret,sourceKey=root",
 	},
+	schema.GroupVersionKind{Group: "psmdb.percona.com", Version: "v1-9-0", Kind: "PerconaServerMongoDB"}: {
+		"service.binding/type":     "mongodb",
+		"service.binding/provider": "percona",
+		"service.binding":          "path={.spec.secrets.users},objectType=Secret",
+		"service.binding/username": "path={.spec.secrets.users},objectType=Secret,sourceKey=MONGODB_USER_ADMIN_USER",
+		"service.binding/password": "path={.spec.secrets.users},objectType=Secret,sourceKey=MONGODB_USER_ADMIN_PASSWORD",
+		"service.binding/host":     "path={.status.host}",
+	},
+	schema.GroupVersionKind{Group: "psmdb.percona.com", Version: "v1-10-0", Kind: "PerconaServerMongoDB"}: {
+		"service.binding/type":     "mongodb",
+		"service.binding/provider": "percona",
+		"service.binding":          "path={.spec.secrets.users},objectType=Secret",
+		"service.binding/username": "path={.spec.secrets.users},objectType=Secret,sourceKey=MONGODB_USER_ADMIN_USER",
+		"service.binding/password": "path={.spec.secrets.users},objectType=Secret,sourceKey=MONGODB_USER_ADMIN_PASSWORD",
+		"service.binding/host":     "path={.status.host}",
+	},
 	schema.GroupVersionKind{Group: "postgresql.k8s.enterprisedb.io", Version: "v1", Kind: "Cluster"}: {
 		"service.binding/type":     "postgresql",
 		"service.binding/host":     "path={.metadata.name}",

--- a/test/acceptance/features/steps/perconamongodboperator.py
+++ b/test/acceptance/features/steps/perconamongodboperator.py
@@ -1,0 +1,49 @@
+from olm import Operator
+from environment import ctx
+from behave import given
+
+
+class PerconaMongoDBOperator(Operator):
+
+    def __init__(self, name="percona-server-mongodb-operator"):
+        self.name = name
+        if ctx.cli == "oc":
+            self.operator_catalog_source_name = "community-operators"
+        else:
+            self.operator_catalog_source_name = "operatorhubio-catalog"
+        self.operator_catalog_channel = "stable"
+        self.package_name = name
+
+
+@given(u'Percona MongoDB operator is running')
+def install_percona_mongodb_operator(context):
+    operator = PerconaMongoDBOperator()
+    operator.openshift.operators_namespace = context.namespace.name
+    if not operator.is_running():
+        subscription = f'''
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: operatorgroup
+  namespace: {operator.openshift.operators_namespace}
+spec:
+  targetNamespaces:
+  - {operator.openshift.operators_namespace}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: '{operator.name}'
+  namespace: {operator.openshift.operators_namespace}
+spec:
+  channel: '{operator.operator_catalog_channel}'
+  installPlanApproval: Automatic
+  name: '{operator.package_name}'
+  source: '{operator.operator_catalog_source_name}'
+  sourceNamespace: {operator.openshift.olm_namespace}
+        '''
+        print(subscription)
+        operator.openshift.apply(subscription)
+        operator.is_running(wait=True)
+    print("Percona MongoDB operator is running")


### PR DESCRIPTION
Percona is one of the better-used database providers in k8s.  Supporting them as best as we can in SBO will be to our benefit.

### Motivation

Since Percona doesn't require invasive changes into the operator to support at least some amount of binding, we should try to support it.

### Changes

This adds RBAC rules and an acceptance test as a part of this work.