### PR TITLE
Add Ready/Reason print columns

### DIFF
--- a/apis/binding/v1alpha1/servicebinding_types.go
+++ b/apis/binding/v1alpha1/servicebinding_types.go
@@ -174,6 +174,10 @@ type BindingPath struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=servicebindings,shortName=sbr;sbrs
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+
 type ServiceBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/binding.operators.coreos.com_servicebindings.yaml
+++ b/config/crd/bases/binding.operators.coreos.com_servicebindings.yaml
@@ -19,11 +19,19 @@ spec:
     singular: servicebinding
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceBinding expresses intent to bind a service with an application
-          workload.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
The change improves UX When listing service bindings via `kubectl`. Users are now able to see service binding
ready status and reason, for example:

```
$ kubectl get servicebinding -n foo
NAME                                        READY   REASON              AGE
sb1                                         True    ApplicationsBound   2d3h

```