### PR TITLE
[docs] Fix cross-reference links/anchors

### DIFF
--- a/docs/userguide/modules/exposing-binding-data/pages/intro-expose-binding.adoc
+++ b/docs/userguide/modules/exposing-binding-data/pages/intro-expose-binding.adoc
@@ -14,16 +14,16 @@ detected by Service Binding Operator.
 Binding data is exposed for the following scenarios:
 
 * *The backing service is considered as a
-https://github.com/k8s-service-bindings/spec#provisioned-service[Provisioned
+xref:provisioned-service.adoc[Provisioned
 Service]* resource: The service you intend to connect to, is compliant
 with the Service Binding specification and the detection of all the
 binding data values is automatic.
 * *The backing service is not a
-https://github.com/k8s-service-bindings/spec#provisioned-service[Provisioned
+xref:provisioned-service.adoc[Provisioned
 Service]* resource: You must expose the binding data from the backing
 service. You can expose the binding data using any of the following
 methods:
-** *https://github.com/k8s-service-bindings/spec#direct-secret-reference[Direct
+** *xref:direct-secret-reference.adoc[Direct
 Secret Reference]*: When all the required binding values are available
 in a `Secret` that you can reference in your Service Binding definition.
 ** *Generate Secret through CRD or CR annotations*: When you can

--- a/docs/userguide/modules/getting-started/pages/installing-service-binding.adoc
+++ b/docs/userguide/modules/getting-started/pages/installing-service-binding.adoc
@@ -8,6 +8,7 @@ version 1.19 or above].
 * link:#installing-the-service-binding-operator-from-the-openshift-container-platform-web-ui[OpenShift
 version 4.6 or above].
 
+[#installing-the-service-binding-operator-on-kubernetes]
 == Installing the Service Binding Operator on Kubernetes
 
 You can install the Service Binding Operator using the following
@@ -29,6 +30,7 @@ Operator using the released resources:
 kubectl apply -f https://github.com/redhat-developer/service-binding-operator/releases/latest/download/release.yaml
 ....
 
+[#installing-the-service-binding-operator-from-the-openshift-container-platform-web-ui]
 == Installing the Service Binding Operator from the OpenShift Container Platform web UI
 
 Prerequisite:

--- a/docs/userguide/modules/getting-started/pages/quick-start.adoc
+++ b/docs/userguide/modules/getting-started/pages/quick-start.adoc
@@ -38,6 +38,7 @@ database instance]
 . link:#connect-the-application-to-the-database[Connect the application
 to the database with Service Binding]
 
+[#prerequisites]
 == Prerequisites
 
 In order to follow the quick start, you’ll need the following tools
@@ -50,6 +51,7 @@ https://kind.sigs.k8s.io/[kind], locally)
 * PostgreSQL client (`psql` CLI tool)
 * xref:installing-service-binding.adoc[]
 
+[#create-a-postgresql-database-instance]
 == Create a PostgreSQL database instance
 
 The application is going to use to a PostgreSQL database backend which
@@ -108,6 +110,7 @@ We have now finished to configured the database for the application. We
 are ready to deploy the sample application and connect it to the
 database.
 
+[#deploy-the-sample-application]
 == Deploy the sample application
 
 In this section, we are going to deploy the application on our
@@ -155,6 +158,7 @@ Connection"}
 Now, we are going to see how you can use Service Binding to easily
 connect the application to the database.
 
+[#connect-the-application-to-the-database]
 == Connect the application to the database
 
 Suppose the Service Binding operator is not present. In that case, the
@@ -335,6 +339,6 @@ application-to-service linkage.
 
 You can continue to learn more about Service Binding by:
 
-* xref:creating-service-bindings:creating-service-binding.adoc[]
-* Using Projected Bindings
-* xref:exposing-binding-data:intro-expose-binding.adoc[]
+* xref:creating-service-bindings:creating-service-binding.adoc[Creating Service Binding]
+* xref:using-projected-bindings:using-projected-bindings.adoc[Using Projected Bindings]
+* xref:exposing-binding-data:intro-expose-binding.adoc[Expose Binding Data]


### PR DESCRIPTION
### Motivation

Currently, couple of cross-reference links do not work because of the mismatch of the links' expected section ID and actual generated section ID.

### Changes

This PR:
* Sets custom section ID for couple of sections in quick start to match the cross-reference links.
* Changes some of the links from remote to inner-docs sections to enhance the docs flow.

### Testing

`make site` and open `out/site/index.html` to read rendered docs.