### PR TITLE
Document RBAC requirements

### DIFF
--- a/docs/userguide/modules/ROOT/examples/percona_mongodb_clusterrole.yaml
+++ b/docs/userguide/modules/ROOT/examples/percona_mongodb_clusterrole.yaml
@@ -1,0 +1,1 @@
+../../../../../config/rbac/percona_mongodb_clusterrole.yaml

--- a/docs/userguide/modules/creating-service-bindings/pages/creating-service-binding.adoc
+++ b/docs/userguide/modules/creating-service-bindings/pages/creating-service-binding.adoc
@@ -45,6 +45,12 @@ auto-detecting binding resources
 vars
 |===
 
+[IMPORTANT]
+Service Binding Operator performs requests against Kubernetes API using a dedicated service account. By default the account has permissions to bind services to applications, both represented by standard Kubernetes Deployments, DaemonSets, ReplicaSets, StatefulSets and https://docs.openshift.com/container-platform/latest/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are[OpenShift DeploymentConfigs]. Binding services/application defined by {crd} requires adding appropriate rights to the service account, either by cluster admins or operator vendors. Please check xref:exposing-binding-data:rbac-requirements.adoc[] Section for further details.
++
+Equally important is to note that the Service Binding Operator prevent users to bind services to application if
+the user does not have permissions to read binding data or modify application resource. This check is added to prevent privilege escalation, i.e. get access to unauthorized services/applications.
+
 .Example servicebinding in `binding.operators.coreos.com/v1alpha1` API:
 [source,yaml]
 ....

--- a/docs/userguide/modules/exposing-binding-data/nav.adoc
+++ b/docs/userguide/modules/exposing-binding-data/nav.adoc
@@ -5,3 +5,4 @@
 ** xref:adding-annotation.adoc[]
 ** xref:olm-descriptors.adoc[]
 ** xref:detect-bindings.adoc[]
+** xref:rbac-requirements.adoc[]

--- a/docs/userguide/modules/exposing-binding-data/pages/rbac-requirements.adoc
+++ b/docs/userguide/modules/exposing-binding-data/pages/rbac-requirements.adoc
@@ -1,0 +1,17 @@
+= RBAC Requirements
+
+
+Service Binding Operator performs requests against Kubernetes API using a dedicated service account. By default the account has permissions to bind services to applications, both represented by standard Kubernetes Deployments, DaemonSets, ReplicaSets, StatefulSets and https://docs.openshift.com/container-platform/latest/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are[OpenShift DeploymentConfigs]
+
+Based on https://github.com/servicebinding/spec#considerations-for-role-based-access-control-rbac[the spec recommendation], the operator service account is bound to 
+https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles[an aggregated cluster role], allowing operator vendors and/or cluster admins to enable binding custom service resources. The needed permissions need be encapsulated within a `ClusterRole` labelled with `servicebinding.io/controller: "true"`.
+
+
+.Example: Enable binding to MongoDB instances provisioned by https://operatorhub.io/operator/percona-server-mongodb-operator[Percona MongoDB operator]:
+[source,yaml]
+....
+include::ROOT:example$percona_mongodb_clusterrole.yaml[]
+....
+
+This cluster role can be deployed during the installation of the backing service
+operator.  You can add it as part of the manifests.


### PR DESCRIPTION
### Motivation

RBAC is necessary for the working of the operator.

### Changes

Add a chapter on RBAC.

### Testing

`make site` and open `out/site/index.html` to read rendered docs.
