### PR TITLE
Remove BindableKinds CR from samples

### DIFF
--- a/config/samples/binding_v1alpha1_bindablekinds.yaml
+++ b/config/samples/binding_v1alpha1_bindablekinds.yaml
@@ -1,4 +1,0 @@
-apiVersion: binding.operators.coreos.com/v1alpha1
-kind: BindableKinds
-metadata:
-  name: bindablekinds-sample

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,5 +2,4 @@
 resources:
 - operators_v1alpha1_servicebinding.yaml
 - servicebinding.io_v1alpha3_servicebinding.yaml
-- binding_v1alpha1_bindablekinds.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
### Motivation

Currently, sample `BindableKinds` CR included in CSV does not contain `.spec` bloc, because its API does not have Spec in.

That fails [`basic-check-spec-test` of OperatorSDK's scorecard tests](https://sdk.operatorframework.io/docs/testing-operators/scorecard/#basic-test-suite).

`BindableKinds` is supposed to be a singleton instance in a cluster and is only used by the operator to publish set of bindable kinds. The CRs are not supposed to be created by users and therefore having an example for users does not make much sense.

### Changes

This PR:
* Removes example CR of `BindableKinds` 

### Testing
