### PR TITLE
Fix doc Edit Page urls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,4 +329,4 @@ clean:
 .PHONY: site
 ## render site
 site:
-	$(CONTAINER_RUNTIME) run -u $(shell id -u) -e HOME=/antora -v ${PWD}:/antora:Z --rm -t antora/antora:2.3.4 antora-playbook.yaml
+	$(CONTAINER_RUNTIME) run -u $(shell id -u) -e CI=true -e HOME=/antora -v ${PWD}:/antora:Z --rm -t antora/antora:2.3.4 antora-playbook.yaml

--- a/antora-playbook.yaml
+++ b/antora-playbook.yaml
@@ -3,7 +3,6 @@ site:
   url: https://redhat-developer.github.io/service-binding-operator
   start_page: userguide::intro.adoc
 content:
-  edit_url: ~
   sources:
     - url: .
       branches: HEAD


### PR DESCRIPTION
Pass CI env var to Antora, so that public file url is used instead of local one