### PR TITLE
Include operator package in existing subscription detection in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,7 +68,7 @@ else
 fi
 
 #Apply subscription for subscribing to the requested channel of the service binding operator
-SUB_ALREADY_FOUND=$(kubectl get sub -n $OPERATOR_NAMESPACE -o json --ignore-not-found | jq -rc '.items[] | select(.spec.source == "'$CATSRC_NAME'" and .spec.sourceNamespace == "'$CATSRC_NAMESPACE'" and .spec.channel == "'$OPERATOR_CHANNEL'").metadata.name')
+SUB_ALREADY_FOUND=$(kubectl get sub -n $OPERATOR_NAMESPACE -o json --ignore-not-found | jq -rc '.items[] | select(.spec.source == "'$CATSRC_NAME'" and .spec.sourceNamespace == "'$CATSRC_NAMESPACE'" and .spec.channel == "'$OPERATOR_CHANNEL'" and .spec.name == "'$OPERATOR_PACKAGE'").metadata.name')
 if [ -n "$SUB_ALREADY_FOUND" ]; then
   echo "Subscription to the given channel '$OPERATOR_CHANNEL' of the given Catalog Source '$CATSRC_NAMESPACE/$CATSRC_NAME)' already found: '$SUB_ALREADY_FOUND'."
   echo "Skipping creation of the subscription to avoid duplicities."


### PR DESCRIPTION
### Motivation

Currently, there is a mechanism in `install.sh` script that detects existing operator subscriptions in cluster to avoid duplicities while installing SBO.

The detection mechanism misses operator package name (`.spec.name`) and so can have a false positive results when any other operator is installed from the same catalog source. I that happens, the subscription for SBO (and so SBO itself) is not installed and the following part of the script waiting for SBO to be installed fails.

### Changes

This PR:
* Adds check for `.spec.name` in existing subscription detection mechanism.

### Testing

1. Have a catalog source where SBO is available along with other operators (e.g. `quay.io/operatorhubio/catalog:latest`)
2. Install any other operator from the catalog source 
3. Run `install.sh` with appropriate env variables to install SBO from the above catalog source
4. SBO should be installed