### PR TITLE
[acceptance-tests] Fix oc version compare in before_all hook

### DIFF
--- a/test/acceptance/features/environment.py
+++ b/test/acceptance/features/environment.py
@@ -16,17 +16,18 @@ from steps.command import Command
 from steps.environment import ctx
 
 import os
+import semver
 
 cmd = Command()
 
 
 def before_all(_context):
     if ctx.cli == "oc":
-        output, code = cmd.run("oc version | grep Client")
+        output, code = cmd.run("oc version --client | grep Client")
         assert code == 0, f"Checking oc version failed: {output}"
 
         oc_ver = output.split()[2]
-        assert oc_ver >= "4.5", f"oc version is required 4.5+, but is {oc_ver}."
+        assert semver.compare(oc_ver, "4.5.0") > 0, f"oc version is required 4.5+, but is {oc_ver}."
 
         namespace = os.getenv("TEST_NAMESPACE")
         output, code = cmd.run(f"oc project {namespace}")

--- a/test/acceptance/features/requirements.txt
+++ b/test/acceptance/features/requirements.txt
@@ -2,3 +2,4 @@ behave==1.2.6
 requests==2.24.0
 polling2==0.4.6
 PyYAML==5.4
+semver==2.13.0


### PR DESCRIPTION
### Motivation

Currently, in acceptance tests, there is a check to verify that (when used) `oc` CLI has a minimal version of `4.5`. However, the way how this check is implemented treats the versions only as plain strings and compares it only alphanumerically which does not work in all cases.

That comparison fails for example in case the actual version of `oc` CLI is e.g. `4.10.0-0.nightly-2021-10-31-210828`. That failure fails all scenarios with:
```
...
Running acceptance tests
    TEST_ACCEPTANCE_START_SBO=remote \
            TEST_ACCEPTANCE_SBO_STARTED= \
            TEST_NAMESPACE=test-ns-a449 \
            /home/cloud-user/service-binding-operator/out/venv3/bin/behave --junit --junit-directory /home/cloud-user/service-binding-operator/out/acceptance-tests  --no-capture --no-capture-stderr --tags="~@disabled" --tags="~@examples" --tags=~@crdv1beta1 test/acceptance/features
    ,---------,-
    | COMMAND : oc version | grep Client
    '---------'-
    HOOK-ERROR in before_all: AssertionError: oc version is required 4.5+, but is 4.10.0-0.nightly-2021-10-31-210828.
...
```

Depends on:
* https://github.com/openshift/release/pull/23192
* https://github.com/openshift/release/pull/23199


### Changes

This PR:
* Fixes the `before_all` hook in acceptance tests to compare actual version of `oc` CLI to the minimal required version of `4.5.0` using `[semver](https://pypi.org/project/semver/)` package instead of comparing version strings alphanumerically.

### Testing

1. Use `oc` CLI for version `4.10.0-0.nightly*-*` (e.g. [`4.10.0-0.nightly-2021-10-31-210828`](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.10.0-0.nightly-2021-10-31-210828/openshift-client-linux-4.10.0-0.nightly-2021-10-31-210828.tar.gz))
2. Run `make test-acceptance-with-bundle`