### PR TITLE
Use $scenario_id in acceptance tests when possible

### DIFF
--- a/test/acceptance/features/allowBindingWhenUserHasPermissions.feature
+++ b/test/acceptance/features/allowBindingWhenUserHasPermissions.feature
@@ -12,14 +12,14 @@ Feature: Prevent users to bind services to application
 
 
   Scenario: Service cannot be bound to application if user cannot read service resource from another namespace
-    Given Namespace "backend-ns" exists
+    Given Namespace "$scenario_id-ns" exists
     * The Custom Resource is present
             """
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: $scenario_id
-                namespace: backend-ns
+                name: $scenario_id-backend
+                namespace: $scenario_id-ns
             spec:
                 host: example.common
                 tags:
@@ -33,7 +33,7 @@ Feature: Prevent users to bind services to application
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 application:
                     name: $scenario_id
@@ -44,8 +44,8 @@ Feature: Prevent users to bind services to application
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: $scenario_id
-                    namespace: backend-ns
+                    name: $scenario_id-backend
+                    namespace: $scenario_id-ns
                     id: backend
                 mappings:
                    - name: TAGS
@@ -59,7 +59,7 @@ Feature: Prevent users to bind services to application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
             spec:
                 host: example.common
                 tags:
@@ -73,7 +73,7 @@ Feature: Prevent users to bind services to application
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 application:
                     name: $scenario_id
@@ -84,7 +84,7 @@ Feature: Prevent users to bind services to application
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
                     id: backend
                 mappings:
                    - name: TAGS
@@ -98,20 +98,20 @@ Feature: Prevent users to bind services to application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
                 annotations:
                     service.binding/username: path={.status.bindings},objectType=Secret,valueKey=username
             spec:
                 host: example.common
             status:
-                bindings: $scenario_id
+                bindings: $scenario_id-secret
             """
     * The Secret is present
             """
             apiVersion: v1
             kind: Secret
             metadata:
-                name: $scenario_id
+                name: $scenario_id-secret
             stringData:
                 username: acmeuser
 
@@ -124,7 +124,7 @@ Feature: Prevent users to bind services to application
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 application:
                     name: $scenario_id
@@ -135,7 +135,7 @@ Feature: Prevent users to bind services to application
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
                     id: backend
             """
     Then Service Binding CollectionReady.status is "False"
@@ -146,7 +146,7 @@ Feature: Prevent users to bind services to application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
                 annotations:
                     service.binding/username: path={.status.bindings},objectType=ConfigMap,valueKey=username
             spec:
@@ -159,10 +159,9 @@ Feature: Prevent users to bind services to application
             apiVersion: v1
             kind: ConfigMap
             metadata:
-                name: $scenario_id
+                name: $scenario_id-secret
             data:
                 username: acmeuser
-
             """
     * User acceptance-tests-dev has 'service-binding-editor-role' role in test namespace
     * User acceptance-tests-dev has 'backends-view' role in test namespace
@@ -172,7 +171,7 @@ Feature: Prevent users to bind services to application
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 application:
                     name: $scenario_id
@@ -183,7 +182,7 @@ Feature: Prevent users to bind services to application
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
                     id: backend
             """
     Then Service Binding CollectionReady.status is "False"
@@ -194,7 +193,7 @@ Feature: Prevent users to bind services to application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
             spec:
                 host: example.common
                 tags:
@@ -209,7 +208,7 @@ Feature: Prevent users to bind services to application
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 application:
                     name: $scenario_id
@@ -220,7 +219,7 @@ Feature: Prevent users to bind services to application
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
                     id: backend
                 mappings:
                    - name: TAGS
@@ -236,7 +235,7 @@ Feature: Prevent users to bind services to application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
             spec:
                 host: example.common
                 tags:
@@ -250,7 +249,7 @@ Feature: Prevent users to bind services to application
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 type: foo
                 workload:
@@ -260,7 +259,7 @@ Feature: Prevent users to bind services to application
                 service:
                     apiVersion: stable.example.com/v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
             """
     Then Service Binding CollectionReady.status is "False"
 
@@ -271,20 +270,20 @@ Feature: Prevent users to bind services to application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
                 annotations:
                     service.binding/username: path={.status.bindings},objectType=Secret,valueKey=username
             spec:
                 host: example.common
             status:
-                bindings: $scenario_id
+                bindings: $scenario_id-secret
             """
     * The Secret is present
             """
             apiVersion: v1
             kind: Secret
             metadata:
-                name: $scenario_id
+                name: $scenario_id-secret
             stringData:
                 username: acmeuser
 
@@ -297,7 +296,7 @@ Feature: Prevent users to bind services to application
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 type: foo
                 workload:
@@ -307,7 +306,7 @@ Feature: Prevent users to bind services to application
                 service:
                     apiVersion: stable.example.com/v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
             """
     Then Service Binding CollectionReady.status is "False"
 
@@ -318,23 +317,22 @@ Feature: Prevent users to bind services to application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
                 annotations:
                     service.binding/username: path={.status.bindings},objectType=ConfigMap,valueKey=username
             spec:
                 host: example.common
             status:
-                bindings: $scenario_id
+                bindings: $scenario_id-secret
             """
     * The ConfigMap is present
             """
             apiVersion: v1
             kind: ConfigMap
             metadata:
-                name: $scenario_id
+                name: $scenario_id-secret
             data:
                 username: acmeuser
-
             """
     * User acceptance-tests-dev has 'service-binding-editor-role' role in test namespace
     * User acceptance-tests-dev has 'backends-view' role in test namespace
@@ -344,7 +342,7 @@ Feature: Prevent users to bind services to application
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 type: foo
                 workload:
@@ -354,7 +352,7 @@ Feature: Prevent users to bind services to application
                 service:
                     apiVersion: stable.example.com/v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
             """
     Then Service Binding CollectionReady.status is "False"
 
@@ -365,7 +363,7 @@ Feature: Prevent users to bind services to application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
             spec:
                 host: example.common
                 tags:
@@ -380,7 +378,7 @@ Feature: Prevent users to bind services to application
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 type: foo
                 workload:
@@ -390,7 +388,7 @@ Feature: Prevent users to bind services to application
                 service:
                     apiVersion: stable.example.com/v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
             """
     Then Service Binding CollectionReady.status is "True"
     And Service Binding InjectionReady.status is "False"

--- a/test/acceptance/features/bindAppToMultipleServices.feature
+++ b/test/acceptance/features/bindAppToMultipleServices.feature
@@ -9,13 +9,13 @@ Feature: Bind a single application to multiple services
         * CustomResourceDefinition backends.stable.example.com is available
 
     Scenario: Bind two backend services by creating 2 SBRs to a single application
-        Given Generic test application "myapp-2-sbrs" is running
+        Given Generic test application is running
         * The Custom Resource is present
         """
         apiVersion: stable.example.com/v1
         kind: Backend
         metadata:
-            name: myapp-2-sbrs-service-1
+            name: $scenario_id-backend-1
             annotations:
                 service.binding/host: path={.spec.host}
         spec:
@@ -26,7 +26,7 @@ Feature: Bind a single application to multiple services
         apiVersion: stable.example.com/v1
         kind: Backend
         metadata:
-            name: myapp-2-sbrs-service-2
+            name: $scenario_id-backend-2
             annotations:
                 service.binding/port: path={.spec.port}
         spec:
@@ -37,11 +37,11 @@ Feature: Bind a single application to multiple services
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding1-myapp-2-sbrs
+                name: $scenario_id-binding-1
             spec:
                 bindAsFiles: false
                 application:
-                    name: myapp-2-sbrs
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -49,9 +49,9 @@ Feature: Bind a single application to multiple services
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: myapp-2-sbrs-service-1
+                    name: $scenario_id-backend-1
             """
-        Then Service Binding "binding1-myapp-2-sbrs" is ready
+        Then Service Binding "$scenario_id-binding-1" is ready
         And The application env var "BACKEND_HOST" has value "foo"
 
         When Service Binding is applied
@@ -59,11 +59,11 @@ Feature: Bind a single application to multiple services
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding2-myapp-2-sbrs
+                name: $scenario_id-binding-2
             spec:
                 bindAsFiles: false
                 application:
-                    name: myapp-2-sbrs
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -71,22 +71,22 @@ Feature: Bind a single application to multiple services
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: myapp-2-sbrs-service-2
+                    name: $scenario_id-backend-2
             """
-        Then Service Binding "binding2-myapp-2-sbrs" is ready
+        Then Service Binding "$scenario_id-binding-2" is ready
         And The application env var "BACKEND_HOST" has value "foo"
         And The application env var "BACKEND_PORT" has value "bar"
         And The application got redeployed 2 times so far
         And The application does not get redeployed again with 5 minutes
 
     Scenario: Bind two backend services by creating 1 SBR to a single application
-        Given Generic test application "myapp-1sbr" is running
+        Given Generic test application is running
         * The Custom Resource is present
             """
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: internal-db-1sbr
+                name: $scenario_id-internal
                 annotations:
                     service.binding/host_internal_db: path={.spec.host_internal_db}
             spec:
@@ -97,7 +97,7 @@ Feature: Bind a single application to multiple services
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: external-db-1sbr
+                name: $scenario_id-external
                 annotations:
                     service.binding/host_external_db: path={.spec.host_external_db}
             spec:
@@ -108,11 +108,11 @@ Feature: Bind a single application to multiple services
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-1sbr
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: myapp-1sbr
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -125,16 +125,16 @@ Feature: Bind a single application to multiple services
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: internal-db-1sbr
+                    name: $scenario_id-internal
                     id: db1
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: external-db-1sbr
+                    name: $scenario_id-external
                     id: db2
             """
-        Then Service Binding "binding-request-1sbr" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_HOST_INTERNAL_DB" has value "internal.db.stable.example.com"
         And The application env var "BACKEND_HOST_EXTERNAL_DB" has value "external.db.stable.example.com"
-        And The application env var "FOO" has value "internal-db-1sbr_external-db-1sbr"
-        And The application env var "FOO2" has value "internal-db-1sbr_Backend"
+        And The application env var "FOO" has value "$scenario_id-internal_$scenario_id-external"
+        And The application env var "FOO2" has value "$scenario_id-internal_Backend"

--- a/test/acceptance/features/bindAppToProvisionedService.feature
+++ b/test/acceptance/features/bindAppToProvisionedService.feature
@@ -53,13 +53,13 @@ Feature: Bind application to provisioned service
             """
 
   Scenario: Bind application to provisioned service
-    Given Generic test application "myaop-provision-srv" is running
+    Given Generic test application is running
     When Service Binding is applied
           """
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: bind-provisioned-service-1
+              name: $scenario_id-binding
           spec:
               services:
               - group: stable.example.com
@@ -67,18 +67,18 @@ Feature: Bind application to provisioned service
                 kind: ProvisionedBackend
                 name: provisioned-service-1
               application:
-                name: myaop-provision-srv
+                name: $scenario_id
                 group: apps
                 version: v1
                 resource: deployments
           """
-    Then Service Binding "bind-provisioned-service-1" is ready
-    And jq ".status.secret" of Service Binding "bind-provisioned-service-1" should be changed to "provisioned-secret-1"
-    And Content of file "/bindings/bind-provisioned-service-1/username" in application pod is
+    Then Service Binding is ready
+    And jq ".status.secret" of Service Binding should be changed to "provisioned-secret-1"
+    And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-    And Content of file "/bindings/bind-provisioned-service-1/password" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
@@ -91,7 +91,7 @@ Feature: Bind application to provisioned service
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: $scenario_id
+              name: $scenario_id-binding
           spec:
               services:
               - group: stable.example.com
@@ -105,12 +105,12 @@ Feature: Bind application to provisioned service
                 resource: deploymentconfigs
           """
     Then Service Binding is ready
-    And jq ".status.secret" of Service Binding should be changed to "provisioned-secret-1"
-    And Content of file "/bindings/$scenario_id/username" in application pod is
+    And jq ".status.secret" of Service Binding "$scenario_id-binding" should be changed to "provisioned-secret-1"
+    And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-    And Content of file "/bindings/$scenario_id/password" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
@@ -160,32 +160,32 @@ Feature: Bind application to provisioned service
             apiVersion: stable.example.com/v1
             kind: ProvisionedBackend
             metadata:
-                name: provisioned-service-2
+                name: $scenario_id-provisioned-backend
             spec:
                 foo: bar
             """
-    * Generic test application "myaop-provision-srv2" is running
+    * Generic test application is running
     When Service Binding is applied
           """
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: bind-provisioned-service-2
+              name: $scenario_id-binding
           spec:
               services:
               - group: stable.example.com
                 version: v1
                 kind: ProvisionedBackend
-                name: provisioned-service-2
+                name: $scenario_id-provisioned-backend
               application:
-                name: myaop-provision-srv2
+                name: $scenario_id
                 group: apps
                 version: v1
                 resource: deployments
           """
-    Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "bind-provisioned-service-2" should be changed to "False"
-    And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "bind-provisioned-service-2" should be changed to "False"
-    And jq ".status.conditions[] | select(.type=="CollectionReady").reason" of Service Binding "bind-provisioned-service-2" should be changed to "ErrorReadingBinding"
+    Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding should be changed to "False"
+    And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding should be changed to "False"
+    And jq ".status.conditions[] | select(.type=="CollectionReady").reason" of Service Binding should be changed to "ErrorReadingBinding"
 
   Scenario: Bind application to provisioned service that has binding annotations as well
     Given OLM Operator "provisioned_backend_with_annotations" is running
@@ -194,7 +194,7 @@ Feature: Bind application to provisioned service
             apiVersion: stable.example.com/v1
             kind: ProvisionedBackend
             metadata:
-                name: provisioned-service-3
+                name: $scenario_id-provisioned-backend
                 annotations:
                     "service.binding/foo": "path={.spec.foo}"
             spec:
@@ -203,35 +203,35 @@ Feature: Bind application to provisioned service
                 binding:
                     name: provisioned-secret-1
             """
-    * Generic test application "myaop-provision-srv3" is running
+    * Generic test application is running
     When Service Binding is applied
           """
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: bind-provisioned-service-3
+              name: $scenario_id-binding
           spec:
               services:
               - group: stable.example.com
                 version: v1
                 kind: ProvisionedBackend
-                name: provisioned-service-3
+                name: $scenario_id-provisioned-backend
               application:
-                name: myaop-provision-srv3
+                name: $scenario_id
                 group: apps
                 version: v1
                 resource: deployments
           """
-    Then Service Binding "bind-provisioned-service-3" is ready
-    And Content of file "/bindings/bind-provisioned-service-3/username" in application pod is
+    Then Service Binding is ready
+    And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-    And Content of file "/bindings/bind-provisioned-service-3/password" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
-    And Content of file "/bindings/bind-provisioned-service-3/foo" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/foo" in application pod is
             """
             bla
             """
@@ -239,47 +239,47 @@ Feature: Bind application to provisioned service
   @spec
   @smoke
   Scenario: SPEC Bind application to provisioned service
-    Given Generic test application "spec-myapp-provision-srv" is running
+    Given Generic test application is running
     When Service Binding is applied
           """
           apiVersion: servicebinding.io/v1alpha3
           kind: ServiceBinding
           metadata:
-              name: spec-bind-provisioned-service-1
+              name: $scenario_id-binding
           spec:
               service:
                 apiVersion: stable.example.com/v1
                 kind: ProvisionedBackend
                 name: provisioned-service-2
               workload:
-                name: spec-myapp-provision-srv
+                name: $scenario_id
                 apiVersion: apps/v1
                 kind: Deployment
           """
-    Then Service Binding "spec-bind-provisioned-service-1" is ready
-    And jq ".status.binding.name" of Service Binding "spec-bind-provisioned-service-1" should be changed to "provisioned-secret-2"
-    And Content of file "/bindings/spec-bind-provisioned-service-1/username" in application pod is
+    Then Service Binding is ready
+    And jq ".status.binding.name" of Service Binding "$scenario_id-binding" should be changed to "provisioned-secret-2"
+    And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-    And Content of file "/bindings/spec-bind-provisioned-service-1/password" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
-    And Content of file "/bindings/spec-bind-provisioned-service-1/type" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/type" in application pod is
             """
             db
             """
 
   @spec
   Scenario: SPEC Bind application to provisioned service and inject type/provider from values set on service binding
-    Given Generic test application "spec-myapp-provision-srv4" is running
+    Given Generic test application is running
     When Service Binding is applied
           """
           apiVersion: servicebinding.io/v1alpha3
           kind: ServiceBinding
           metadata:
-              name: spec-bind-provisioned-service-4
+              name: $scenario_id-binding
           spec:
               type: mysql
               provider: foovendor
@@ -288,37 +288,37 @@ Feature: Bind application to provisioned service
                 kind: ProvisionedBackend
                 name: provisioned-service-1
               workload:
-                name: spec-myapp-provision-srv4
+                name: $scenario_id
                 apiVersion: apps/v1
                 kind: Deployment
           """
-    Then Service Binding "spec-bind-provisioned-service-4" is ready
-    And Content of file "/bindings/spec-bind-provisioned-service-4/username" in application pod is
+    Then Service Binding is ready
+    And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-    And Content of file "/bindings/spec-bind-provisioned-service-4/password" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
-    And Content of file "/bindings/spec-bind-provisioned-service-4/type" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/type" in application pod is
             """
             mysql
             """
-    And Content of file "/bindings/spec-bind-provisioned-service-4/provider" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/provider" in application pod is
             """
             foovendor
             """
 
   @spec
   Scenario: SPEC Bind application to provisioned service and inject binding into folder specified by .spec.name
-    Given Generic test application "spec-myapp-provision-srv3" is running
+    Given Generic test application is running
     When Service Binding is applied
           """
           apiVersion: servicebinding.io/v1alpha3
           kind: ServiceBinding
           metadata:
-              name: spec-bind-provisioned-service-3
+              name: $scenario_id-binding
           spec:
               name: foo-bindings
               service:
@@ -326,12 +326,12 @@ Feature: Bind application to provisioned service
                 kind: ProvisionedBackend
                 name: provisioned-service-2
               workload:
-                name: spec-myapp-provision-srv3
+                name: $scenario_id
                 apiVersion: apps/v1
                 kind: Deployment
           """
-    Then Service Binding "spec-bind-provisioned-service-3" is ready
-    And jq ".status.binding.name" of Service Binding "spec-bind-provisioned-service-3" should be changed to "provisioned-secret-2"
+    Then Service Binding is ready
+    And jq ".status.binding.name" of Service Binding "$scenario_id-binding" should be changed to "provisioned-secret-2"
     And Content of file "/bindings/foo-bindings/username" in application pod is
             """
             foo
@@ -352,7 +352,7 @@ Feature: Bind application to provisioned service
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: $scenario_id
+              name: $scenario_id-binding
           spec:
               name: foo
               services:
@@ -383,13 +383,13 @@ Feature: Bind application to provisioned service
 
   @spec
   Scenario: SPEC Inject specified bindings as env vars
-    Given Generic test application "spec-myapp-provision-srv8" is running
+    Given Generic test application is running
     When Service Binding is applied
           """
           apiVersion: servicebinding.io/v1alpha3
           kind: ServiceBinding
           metadata:
-              name: spec-bind-provisioned-service-8
+              name: $scenario_id-binding
           spec:
               env:
                 - name: "FOO"
@@ -401,21 +401,21 @@ Feature: Bind application to provisioned service
                 kind: ProvisionedBackend
                 name: provisioned-service-2
               workload:
-                name: spec-myapp-provision-srv8
+                name: $scenario_id
                 apiVersion: apps/v1
                 kind: Deployment
           """
-    Then Service Binding "spec-bind-provisioned-service-8" is ready
-    And jq ".status.binding.name" of Service Binding "spec-bind-provisioned-service-8" should be changed to "provisioned-secret-2"
-    And Content of file "/bindings/spec-bind-provisioned-service-8/username" in application pod is
+    Then Service Binding is ready
+    And jq ".status.binding.name" of Service Binding "$scenario_id-binding" should be changed to "provisioned-secret-2"
+    And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-    And Content of file "/bindings/spec-bind-provisioned-service-8/password" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
-    And Content of file "/bindings/spec-bind-provisioned-service-8/type" in application pod is
+    And Content of file "/bindings/$scenario_id-binding/type" in application pod is
             """
             db
             """

--- a/test/acceptance/features/bindAppToService.feature
+++ b/test/acceptance/features/bindAppToService.feature
@@ -9,14 +9,14 @@ Feature: Bind an application to a service
 
     @smoke
     Scenario: Bind an application to backend service in the following order: Application, Service and Binding
-        Given Generic test application "gen-app-a-s-b" is running
+        Given Generic test application is running
         * CustomResourceDefinition backends.stable.example.com is available
         * The Secret is present
             """
             apiVersion: v1
             kind: Secret
             metadata:
-                name: backend-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -26,53 +26,53 @@ Feature: Bind an application to a service
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: service-a-s-b
+                name: $scenario_id-backend
                 annotations:
                     service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
             status:
                 data:
-                    dbCredentials: backend-secret
+                    dbCredentials: $scenario_id-secret
             """
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: service-binding-a-s-b
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: service-a-s-b
+                    name: $scenario_id-backend
                 application:
-                    name: gen-app-a-s-b
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "service-binding-a-s-b" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
     Scenario:  Bind an application to backend service in the following order: Application, Binding and Service
-        Given Generic test application "gen-app-a-b-s" is running
+        Given Generic test application is running
         And Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: service-binding-a-b-s
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: service-a-b-s
+                    name: $scenario_id-backend
                 application:
-                    name: gen-app-a-b-s
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -83,7 +83,7 @@ Feature: Bind an application to a service
             apiVersion: v1
             kind: Secret
             metadata:
-                name: backend-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -93,14 +93,14 @@ Feature: Bind an application to a service
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: service-a-b-s
+                name: $scenario_id-backend
                 annotations:
                     service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
             status:
                 data:
-                    dbCredentials: backend-secret
+                    dbCredentials: $scenario_id-secret
             """
-        Then Service Binding "service-binding-a-b-s" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
@@ -111,7 +111,7 @@ Feature: Bind an application to a service
             apiVersion: v1
             kind: Secret
             metadata:
-                name: backend-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -121,34 +121,34 @@ Feature: Bind an application to a service
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: service-s-b-a
+                name: $scenario_id-backend
                 annotations:
                     service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
             status:
                 data:
-                    dbCredentials: backend-secret
+                    dbCredentials: $scenario_id-secret
             """
         And Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: service-binding-s-b-a
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: service-s-b-a
+                    name: $scenario_id-backend
                 application:
-                    name: gen-app-s-b-a
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        When Generic test application "gen-app-s-b-a" is running
-        Then Service Binding "service-binding-s-b-a" is ready
+        When Generic test application is running
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
@@ -158,28 +158,28 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: service-binding-b-a-s
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: service-b-a-s
+                    name: $scenario_id-backend
                 application:
-                    name: gen-app-b-a-s
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        * Generic test application "gen-app-b-a-s" is running
+        * Generic test application is running
         * CustomResourceDefinition backends.stable.example.com is available
         * The Secret is present
             """
             apiVersion: v1
             kind: Secret
             metadata:
-                name: backend-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -189,14 +189,14 @@ Feature: Bind an application to a service
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: service-b-a-s
+                name: $scenario_id-backend
                 annotations:
                     service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
             status:
                 data:
-                    dbCredentials: backend-secret
+                    dbCredentials: $scenario_id-secret
             """
-        Then Service Binding "service-binding-b-a-s" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
@@ -206,16 +206,16 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: service-binding-b-s-a
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: service-b-s-a
+                    name: $scenario_id-backend
                 application:
-                    name: gen-app-b-s-a
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -226,7 +226,7 @@ Feature: Bind an application to a service
             apiVersion: v1
             kind: Secret
             metadata:
-                name: backend-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -236,15 +236,15 @@ Feature: Bind an application to a service
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: service-b-s-a
+                name: $scenario_id-backend
                 annotations:
                     service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
             status:
                 data:
-                    dbCredentials: backend-secret
+                    dbCredentials: $scenario_id-secret
             """
-        When Generic test application "gen-app-b-s-a" is running
-        Then Service Binding "service-binding-b-s-a" is ready
+        When Generic test application is running
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
@@ -256,7 +256,7 @@ Feature: Bind an application to a service
             apiVersion: v1
             kind: Secret
             metadata:
-                name: backend-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -266,23 +266,23 @@ Feature: Bind an application to a service
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: service-missing-app
+                name: $scenario_id-backend
                 annotations:
                     service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
             status:
                 data:
-                    dbCredentials: backend-secret
+                    dbCredentials: $scenario_id-secret
             """
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: service-binding-missing-app
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: gen-missing-app
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -290,12 +290,12 @@ Feature: Bind an application to a service
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: service-missing-app
+                    name: $scenario_id-backend
             """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "service-binding-missing-app" should be changed to "True"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding "service-binding-missing-app" should be changed to "False"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").reason" of Service Binding "service-binding-missing-app" should be changed to "ApplicationNotFound"
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "service-binding-missing-app" should be changed to "False"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding should be changed to "True"
+        And jq ".status.conditions[] | select(.type=="InjectionReady").status" of Service Binding should be changed to "False"
+        And jq ".status.conditions[] | select(.type=="InjectionReady").reason" of Service Binding should be changed to "ApplicationNotFound"
+        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding should be changed to "False"
 
 
     @negative
@@ -306,7 +306,7 @@ Feature: Bind an application to a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-demo-empty-app
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host: path={.spec.host}
                     service.binding/username: path={.spec.username}
@@ -319,17 +319,17 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-empty-app
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-demo-empty-app
+                    name: $scenario_id-backend
             """
         Then Error message is thrown
-        And Service Binding "binding-request-empty-app" is not persistent in the cluster
+        And Service Binding "$scenario_id-binding" is not persistent in the cluster
 
     @negative
     Scenario: Cannot create Service Binding with name and label selector
@@ -339,7 +339,7 @@ Feature: Bind an application to a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-demo-empty-app
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host: path={.spec.host}
                     service.binding/username: path={.spec.username}
@@ -352,11 +352,11 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-with-name-label-selector
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: gen-missing-app
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -367,7 +367,7 @@ Feature: Bind an application to a service
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-demo-empty-app
+                    name: $scenario_id-backend
             """
         Then Error message "name and selector MUST NOT be defined in the application reference" is thrown
 
@@ -379,7 +379,7 @@ Feature: Bind an application to a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-demo-empty-app
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host: path={.spec.host}
                     service.binding/username: path={.spec.username}
@@ -392,10 +392,10 @@ Feature: Bind an application to a service
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: binding-request-with-name-label-selector-spec
+                name: $scenario_id-binding
             spec:
                 workload:
-                  name: gen-missing-app
+                  name: $scenario_id
                   apiVersion: apps/v1
                   kind: Deployment
                   selector:
@@ -404,7 +404,7 @@ Feature: Bind an application to a service
                 service:
                   apiVersion: stable.example.com/v1
                   kind: Backend
-                  name: backend-demo-empty-app
+                  name: $scenario_id-backend
             """
         Then Error message "name and selector MUST NOT be defined in the application reference" is thrown
 
@@ -416,7 +416,7 @@ Feature: Bind an application to a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-demo-empty-app
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host: path={.spec.host}
                     service.binding/username: path={.spec.username}
@@ -429,7 +429,7 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-with-name-label-selector2
+                name: $scenario_id-valid
             spec:
                 bindAsFiles: false
                 application:
@@ -443,18 +443,18 @@ Feature: Bind an application to a service
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-demo-empty-app
+                    name: $scenario_id-backend
             """
         When Invalid Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-with-name-label-selector2
+                name: $scenario_id-invalid
             spec:
                 bindAsFiles: false
                 application:
-                    name: gen-missing-app
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -465,7 +465,7 @@ Feature: Bind an application to a service
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-demo-empty-app
+                    name: $scenario_id-backend
             """
         Then Error message "name and selector MUST NOT be defined in the application reference" is thrown
 
@@ -477,7 +477,7 @@ Feature: Bind an application to a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-demo-empty-app
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host: path={.spec.host}
                     service.binding/username: path={.spec.username}
@@ -490,7 +490,7 @@ Feature: Bind an application to a service
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: binding-request-with-name-label-selector-spec2
+                name: $scenario_id-valid
             spec:
                 workload:
                   apiVersion: apps/v1
@@ -501,7 +501,7 @@ Feature: Bind an application to a service
                 service:
                   apiVersion: stable.example.com/v1
                   kind: Backend
-                  name: backend-demo-empty-app
+                  name: $scenario_id
             """
         When Invalid Service Binding is applied
             """
@@ -511,7 +511,7 @@ Feature: Bind an application to a service
                 name: binding-request-with-name-label-selector-spec2
             spec:
                 workload:
-                  name: gen-missing-app
+                  name: $scenario_id-invalid
                   apiVersion: apps/v1
                   kind: Deployment
                   selector:
@@ -520,20 +520,20 @@ Feature: Bind an application to a service
                 service:
                   apiVersion: stable.example.com/v1
                   kind: Backend
-                  name: backend-demo-empty-app
+                  name: $scenario_id-backend
             """
         Then Error message "name and selector MUST NOT be defined in the application reference" is thrown
 
     @olm
     Scenario: Bind service to application using binding definition available in x-descriptors
         Given OLM Operator "backend-new-spec" is running
-        * Generic test application "gen-app-a-s-c" is running
+        * Generic test application is running
         * The Custom Resource is present
             """
             apiVersion: "beta.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-demo
+                name: $scenario_id-backend
             spec:
                 host: example.common
                 ports:
@@ -547,34 +547,34 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-backend-new-spec
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                 -   group: beta.example.com
                     version: v1
                     kind: Backend
-                    name: backend-demo
+                    name: $scenario_id-backend
                 application:
-                    name: gen-app-a-s-c
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "binding-request-backend-new-spec" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_HOST" has value "example.common"
         And The application env var "BACKEND_PORTS_FTP" has value "22"
         And The application env var "BACKEND_PORTS_TCP" has value "8080"
 
     Scenario: Custom environment variable is injected into the application under the declared name ignoring global and service env prefix
-        Given Generic test application "gen-app-c-e" is running
+        Given Generic test application is running
         * CustomResourceDefinition backends.stable.example.com is available
         * The Custom Resource is present
             """
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: service-c-e
+                name: $scenario_id-backend
                 annotations:
                     service.binding/port: path={.data.port}
                     service.binding/host: path={.data.host}
@@ -587,11 +587,11 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: service-binding-c-e
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: gen-app-c-e
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -599,13 +599,13 @@ Feature: Bind an application to a service
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: service-c-e
+                    name: $scenario_id-backend
                     id: backendSVC
                 mappings:
                     - name: HOST_ADDR
                       value: '{{ .backendSVC.data.host }}:{{ .backendSVC.data.port }}'
             """
-        Then Service Binding "service-binding-c-e" is ready
+        Then Service Binding is ready
         And The application env var "HOST_ADDR" has value "127.0.0.1:8080"
 
     @negative
@@ -615,12 +615,12 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-empty-services
+                name: $scenario_id-binding
             spec:
                 services:
             """
         Then Error message is thrown
-        And Service Binding "binding-request-empty-services" is not persistent in the cluster
+        And Service Binding "$scenario_id-binding" is not persistent in the cluster
 
     @negative
     Scenario: Service Binding without gvk of services is not allowed in the cluster
@@ -629,10 +629,10 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-without-gvk
+                name: $scenario_id-binding
             spec:
                 services:
-                -   name: backend-demo
+                -   name: $scenario_id
             """
         Then Error message is thrown
 
@@ -643,47 +643,47 @@ Feature: Bind an application to a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: demo-backserv-cr-3
+                name: $scenario_id-backend
                 annotations:
                     service.binding/name: path={.metadata.name}
             """
-        * Generic test application "gen-app-a-s-e" is running
+        * Generic test application is running
         * Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-remove-service
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: demo-backserv-cr-3
+                    name: $scenario_id-backend
                 application:
-                    name: gen-app-a-s-e
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        * Service Binding "binding-request-remove-service" is ready
+        * Service Binding is ready
         When Invalid Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-remove-service
+                name: $scenario_id-binding
             spec:
                 services:
                 application:
-                    name: gen-app-a-s-e
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
         Then Error message is thrown
-        And Service Binding "binding-request-remove-service" is not updated
+        And Service Binding "$scenario_id-binding" is not updated
 
     @negative
     Scenario: Service Binding without spec is not allowed in the cluster
@@ -692,10 +692,10 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-without-spec
+                name: $scenario_id-binding
             """
         Then Error message is thrown
-        And Service Binding "binding-request-without-spec" is not persistent in the cluster
+        And Service Binding "$scenario_id-binding" is not persistent in the cluster
 
     @negative
     Scenario: Service Binding with empty spec is not allowed in the cluster
@@ -704,11 +704,11 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-empty-spec
+                name: $scenario_id-binding
             spec:
             """
         Then Error message is thrown
-        And Service Binding "binding-request-empty-spec" is not persistent in the cluster
+        And Service Binding "$scenario_id-binding" is not persistent in the cluster
 
     @negative
     # Adding olm tag due to flakiness of this test on non-olm ci
@@ -721,46 +721,46 @@ Feature: Bind an application to a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: demo-backserv-cr-5
+                name: $scenario_id-backend
                 annotations:
                     service.binding/name: path={.metadata.name}
             """
-        * Generic test application "gen-app-a-s-g" is running
+        * Generic test application is running
         * Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-emptying-spec
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: demo-backserv-cr-5
+                    name: $scenario_id-backend
                 application:
-                    name: gen-app-a-s-g
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        * Service Binding "binding-request-emptying-spec" is ready
+        * Service Binding is ready
         When Invalid Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-emptying-spec
+                name: $scenario_id-binding
             spec:
                 application:
-                    name: gen-app-a-s-g
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
         Then Error message is thrown
-        And Service Binding "binding-request-emptying-spec" is not updated
+        And Service Binding "$scenario_id-binding" is not updated
 
     @negative
     # Adding olm tag due to flakiness of this test on non-olm ci
@@ -773,40 +773,40 @@ Feature: Bind an application to a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: demo-backserv-cr-4
+                name: $scenario_id-backend
                 annotations:
                     service.binding/name: path={.metadata.name}
             """
-        * Generic test application "gen-app-a-s-h" is running
+        * Generic test application is running
         * Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-remove-spec
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: demo-backserv-cr-4
+                    name: $scenario_id-backend
                 application:
-                    name: gen-app-a-s-h
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        * Service Binding "binding-request-remove-spec" is ready
+        * Service Binding is ready
         When Invalid Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-remove-spec
+                name: $scenario_id-binding
             """
         Then Error message is thrown
-        And Service Binding "binding-request-remove-spec" is not updated
+        And Service Binding "$scenario_id-binding" is not updated
 
     Scenario: Bind an application to a service present in a different namespace
         Given Namespace is present
@@ -814,31 +814,31 @@ Feature: Bind an application to a service
             apiVersion: v1
             kind: Namespace
             metadata:
-                name: backend-services
+                name: $scenario_id-ns
             """
         * The Custom Resource is present
             """
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: backend-cross-ns-service
-                namespace: backend-services
+                name: $scenario_id-backend
+                namespace: $scenario_id-ns
                 annotations:
                     service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
             spec:
                 host_cross_ns_service: cross.ns.service.stable.example.com
             """
-        * Generic test application "myapp-in-sbr-ns" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-cross-ns-service
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: myapp-in-sbr-ns
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -846,10 +846,10 @@ Feature: Bind an application to a service
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-cross-ns-service
-                    namespace: backend-services
+                    name: $scenario_id-backend
+                    namespace: $scenario_id-ns
             """
-        Then Service Binding "binding-request-cross-ns-service" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_HOST_CROSS_NS_SERVICE" has value "cross.ns.service.stable.example.com"
 
     Scenario: Inject all configmap keys into application
@@ -858,33 +858,33 @@ Feature: Bind an application to a service
             apiVersion: v1
             kind: ConfigMap
             metadata:
-                name: example
+                name: $scenario_id-configmap
                 annotations:
                     service.binding: path={.data},elementType=map
             data:
                 word: "hello"
             """
-        * Generic test application "myapp-cm" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-configmap
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                 -   group: ""
                     version: v1
                     kind: ConfigMap
-                    name: example
+                    name: $scenario_id-configmap
                 application:
-                    name: myapp-cm
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "binding-request-configmap" is ready
+        Then Service Binding is ready
         And The application env var "CONFIGMAP_WORD" has value "hello"
 
 
@@ -894,33 +894,33 @@ Feature: Bind an application to a service
             apiVersion: v1
             kind: Secret
             metadata:
-                name: example
+                name: $scenario_id-secret
                 annotations:
                     service.binding: path={.data},elementType=map
             data:
                 word: "aGVsbG8="
             """
-        * Generic test application "myapp-secret" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-secret
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                 -   group: ""
                     version: v1
                     kind: Secret
-                    name: example
+                    name: $scenario_id-secret
                 application:
-                    name: myapp-secret
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "binding-request-secret" is ready
+        Then Service Binding is ready
         And The application env var "SECRET_WORD" has value "aGVsbG8="
 
     @negative
@@ -944,7 +944,7 @@ Feature: Bind an application to a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 detectBindingResources: true

--- a/test/acceptance/features/bindAppToServiceAnnotations.feature
+++ b/test/acceptance/features/bindAppToServiceAnnotations.feature
@@ -10,7 +10,7 @@ Feature: Bind an application to a service using annotations
         * Service Binding Operator is running
 
     Scenario: Provide binding info through backing service CRD annotation and ensure app env vars reflect it
-        Given Generic test application "rsa-2-service" is running
+        Given Generic test application is running
         Given The Custom Resource Definition is present
             """
             apiVersion: apiextensions.k8s.io/v1
@@ -71,7 +71,7 @@ Feature: Bind an application to a service using annotations
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-demo
+                name: $scenario_id-backend
             spec:
                 host: example.common
                 userLabels:
@@ -86,30 +86,30 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-backend-a
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-demo
+                    name: $scenario_id-backend
                     id: SBR
                 application:
-                    name: rsa-2-service
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
 
-        Then Service Binding "binding-request-backend-a" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_READY" has value "true"
         And The application env var "BACKEND_HOST" has value "example.common"
         And The application env var "BACKEND_ENVIRONMENT" has value "staging"
         And The application env var "BACKEND_DATATYPE" has value "base64"
 
     Scenario: Each value in referred map from service resource gets injected into app as separate env variable
-        Given Generic test application "rsa-2-service" is running
+        Given Generic test application is running
         And The Custom Resource Definition is present
             """
             apiVersion: apiextensions.k8s.io/v1
@@ -179,7 +179,7 @@ Feature: Bind an application to a service using annotations
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: rsa-2-service
+                name: $scenario_id-backend
             spec:
                 image: docker.io/postgres
                 imageName: postgres
@@ -202,27 +202,27 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: rsa-2
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: rsa-2-service
+                    name: $scenario_id-backend
                 application:
-                    name: rsa-2-service
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "rsa-2" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_SPEC_IMAGE" has value "docker.io/postgres"
         And The application env var "BACKEND_SPEC_IMAGENAME" has value "postgres"
         And The application env var "BACKEND_SPEC_DBNAME" has value "db-demo"
 
     Scenario: Each value in referred slice of strings from service resource gets injected into app as separate env variable
-        Given Generic test application "slos-app" is running
+        Given Generic test application is running
         And The Custom Resource Definition is present
             """
             apiVersion: apiextensions.k8s.io/v1
@@ -272,7 +272,7 @@ Feature: Bind an application to a service using annotations
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: slos-service
+                name: $scenario_id-backend
             spec:
                 tags:
                   - knowledge
@@ -286,27 +286,27 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: slos-binding
+                name: $scenario_id
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: slos-service
+                    name: $scenario_id-backend
                 application:
-                    name: slos-app
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "slos-binding" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_TAGS_0" has value "knowledge"
         And The application env var "BACKEND_TAGS_1" has value "is"
         And The application env var "BACKEND_TAGS_2" has value "power"
 
     Scenario: Values extracted from each map by a given key in referred slice of maps from service resource gets injected into app as separate env variable
-        Given Generic test application "slom-to-slos-app" is running
+        Given Generic test application is running
         And The Custom Resource Definition is present
             """
             apiVersion: apiextensions.k8s.io/v1
@@ -361,7 +361,7 @@ Feature: Bind an application to a service using annotations
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: slom-to-slos-service
+                name: $scenario_id-backend
             spec:
                 connections:
                   - type: primary
@@ -378,27 +378,27 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: slom-to-slos-binding
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: slom-to-slos-service
+                    name: $scenario_id-backend
                 application:
-                    name: slom-to-slos-app
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "slom-to-slos-binding" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_URL_0" has value "primary.example.com"
         And The application env var "BACKEND_URL_1" has value "secondary.example.com"
         And The application env var "BACKEND_URL_2" has value "black-hole.example.com"
 
     Scenario: Each value in referred slice of maps from service resource gets injected into app as separate env variable
-        Given Generic test application "slom-app" is running
+        Given Generic test application is running
         And The Custom Resource Definition is present
             """
             apiVersion: apiextensions.k8s.io/v1
@@ -453,7 +453,7 @@ Feature: Bind an application to a service using annotations
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: slom-service
+                name: $scenario_id-backend
             spec:
                 connections:
                   - type: primary
@@ -470,34 +470,34 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: slom-binding
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: slom-service
+                    name: $scenario_id-backend
                 application:
-                    name: slom-app
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "slom-binding" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_WEBARROWS_PRIMARY" has value "primary.example.com"
         And The application env var "BACKEND_WEBARROWS_SECONDARY" has value "secondary.example.com"
         And The application env var "BACKEND_WEBARROWS_404" has value "black-hole.example.com"
 
     Scenario: Bind referring service using group version resource
-        Given Generic test application "binding-service-via-gvr" is running
+        Given Generic test application is running
         * CustomResourceDefinition backends.stable.example.com is available
         * The Custom Resource is present
             """
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: binding-service-via-gvr-service
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host_internal_db: path={.spec.host_internal_db}
             spec:
@@ -508,11 +508,11 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-service-via-gvr
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: binding-service-via-gvr
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -520,20 +520,20 @@ Feature: Bind an application to a service using annotations
                 -   group: stable.example.com
                     version: v1
                     resource: backends
-                    name: binding-service-via-gvr-service
+                    name: $scenario_id-backend
             """
-        Then Service Binding "binding-service-via-gvr" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_HOST_INTERNAL_DB" has value "internal.db.stable.example.com"
 
     Scenario: Bind referring application using group version kind
-        Given Generic test application "binding-app-via-gvk" is running
+        Given Generic test application is running
         * CustomResourceDefinition backends.stable.example.com is available
         * The Custom Resource is present
             """
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: binding-app-via-gvk-service
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host_internal_db: path={.spec.host_internal_db}
             spec:
@@ -544,11 +544,11 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-app-via-gvk
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: binding-app-via-gvk
+                    name: $scenario_id
                     group: apps
                     version: v1
                     kind: Deployment
@@ -556,9 +556,9 @@ Feature: Bind an application to a service using annotations
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: binding-app-via-gvk-service
+                    name: $scenario_id-backend
             """
-        Then Service Binding "binding-app-via-gvk" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_HOST_INTERNAL_DB" has value "internal.db.stable.example.com"
 
     Scenario: Application cannot be bound to service containing annotation with an invalid sourceValue value
@@ -569,7 +569,7 @@ Feature: Bind an application to a service using annotations
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
                 annotations:
                     service.binding/webarrows: path={.spec.connections},elementType=sliceOfMaps,sourceKey=type,sourceValue=asdf
             spec:
@@ -584,14 +584,14 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
                 application:
                     name: $scenario_id
                     group: apps
@@ -610,7 +610,7 @@ Feature: Bind an application to a service using annotations
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
                 annotations:
                     service.binding/credentials: path={.spec.connections.dbCredentials},elementType=asdf
             spec:
@@ -625,14 +625,14 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
                 application:
                     name: $scenario_id
                     group: apps
@@ -651,7 +651,7 @@ Feature: Bind an application to a service using annotations
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
                 annotations:
                     service.binding/credentials: path={.spec.connections.dbCredentials},objectType=asdf,sourceKey=username
             spec:
@@ -666,14 +666,14 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
                 application:
                     name: $scenario_id
                     group: apps
@@ -692,7 +692,7 @@ Feature: Bind an application to a service using annotations
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: $scenario_id
+                name: $scenario_id-backend
                 annotations:
                     service.binding/credentials: path=asdf
             spec:
@@ -707,14 +707,14 @@ Feature: Bind an application to a service using annotations
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: $scenario_id
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: $scenario_id
+                    name: $scenario_id-backend
                 application:
                     name: $scenario_id
                     group: apps

--- a/test/acceptance/features/bindAppToServiceUsingConfigMap.feature
+++ b/test/acceptance/features/bindAppToServiceUsingConfigMap.feature
@@ -8,7 +8,7 @@ Feature: Bind values from a config map referred in backing service resource
         * Service Binding Operator is running
 
     Scenario: Inject into app a key from a config map referred within service resource
-        Given Generic test application "cmsa-1" is running
+        Given Generic test application is running
         And The Custom Resource Definition is present
             """
             apiVersion: apiextensions.k8s.io/v1
@@ -63,7 +63,7 @@ Feature: Bind values from a config map referred in backing service resource
             apiVersion: v1
             kind: ConfigMap
             metadata:
-                name: cmsa-1-configmap
+                name: $scenario_id-configmap
             data:
                 certificate: "certificate value"
             """
@@ -72,39 +72,39 @@ Feature: Bind values from a config map referred in backing service resource
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: cmsa-1-service
+                name: $scenario_id-service
             spec:
                 image: docker.io/postgres
                 imageName: postgres
                 dbName: db-demo
             status:
                 data:
-                    dbConfiguration: cmsa-1-configmap
+                    dbConfiguration: $scenario_id-configmap
             """
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: cmsa-1
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: cmsa-1-service
+                    name: $scenario_id-service
                 application:
-                    name: cmsa-1
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "cmsa-1" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_CERTIFICATE" has value "certificate value"
 
     Scenario: Inject into app all keys from a config map referred within service resource
-        Given Generic test application "cmsa-2" is running
+        Given Generic test application is running
         And The Custom Resource Definition is present
             """
             apiVersion: apiextensions.k8s.io/v1
@@ -159,7 +159,7 @@ Feature: Bind values from a config map referred in backing service resource
             apiVersion: v1
             kind: ConfigMap
             metadata:
-                name: cmsa-2-configmap
+                name: $scenario_id-configmap
             data:
                 timeout: "30"
                 certificate: certificate value
@@ -169,33 +169,33 @@ Feature: Bind values from a config map referred in backing service resource
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: cmsa-2-service
+                name: $scenario_id-backend
             spec:
                 image: docker.io/postgres
                 imageName: postgres
                 dbName: db-demo
             status:
                 data:
-                    dbConfiguration: cmsa-2-configmap    # ConfigMap
+                    dbConfiguration: $scenario_id-configmap    # ConfigMap
             """
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: cmsa-2
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: cmsa-2-service
+                    name: $scenario_id-backend
                 application:
-                    name: cmsa-2
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "cmsa-2" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_CERTIFICATE" has value "certificate value"

--- a/test/acceptance/features/bindAppToServiceUsingSecret.feature
+++ b/test/acceptance/features/bindAppToServiceUsingSecret.feature
@@ -9,7 +9,7 @@ Feature: Bind values from a secret referred in backing service resource
 
     Scenario: Inject into app a key from a secret referred within service resource
         Binding definition is declared on service CRD.
-        Given Generic test application "ssa-1" is running
+        Given Generic test application is running
         And The Custom Resource Definition is present
             """
             apiVersion: apiextensions.k8s.io/v1
@@ -64,7 +64,7 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: ssa-1-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
             """
@@ -73,39 +73,39 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: ssa-1-service
+                name: $scenario_id-backend
             spec:
                 image: docker.io/postgres
                 imageName: postgres
                 dbName: db-demo
             status:
                 data:
-                    dbCredentials: ssa-1-secret
+                    dbCredentials: $scenario_id-secret
             """
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: ssa-1
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: ssa-1-service
+                    name: $scenario_id-backend
                 application:
-                    name: ssa-1
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "ssa-1" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
 
     Scenario: Inject into app all keys from a secret referred within service resource
-        Given Generic test application "ssa-2" is running
+        Given Generic test application is running
         And The Custom Resource Definition is present
             """
             apiVersion: apiextensions.k8s.io/v1
@@ -160,7 +160,7 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: ssa-2-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -170,42 +170,42 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: ssa-2-service
+                name: $scenario_id-backend
             spec:
                 image: docker.io/postgres
                 imageName: postgres
                 dbName: db-demo
             status:
                 data:
-                    dbCredentials: ssa-2-secret
+                    dbCredentials: $scenario_id-secret
             """
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: ssa-2
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: ssa-2-service
+                    name: $scenario_id-backend
                 application:
-                    name: ssa-2
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "ssa-2" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
     @olm
     Scenario: Inject into app a key from a secret referred within service resource Binding definition is declared via OLM descriptor.
 
-        Given Generic test application "ssd-1" is running
+        Given Generic test application is running
         * OLM Operator "backends_foo" is running
         * The Custom Resource Definition is present
             """
@@ -319,7 +319,7 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: ssd-1-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
             """
@@ -328,40 +328,40 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: foo.example.com/v1
             kind: Backend
             metadata:
-                name: ssd-1-service
+                name: $scenario_id-backend
             spec:
                 host: example.com
             status:
                 data:
-                    dbCredentials: ssd-1-secret
+                    dbCredentials: $scenario_id-secret
             """
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: ssd-1
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: foo.example.com
                     version: v1
                     kind: Backend
-                    name: ssd-1-service
+                    name: $scenario_id-backend
                 application:
-                    name: ssd-1
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "ssd-1" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_HOST" has value "example.com"
 
     @olm
     Scenario: Inject into app all keys from a secret referred within service resource Binding definition is declared via OLM descriptor.
 
-        Given Generic test application "ssd-2" is running
+        Given Generic test application is running
         * OLM Operator "backends_bar" is running
         * The Custom Resource Definition is present
             """
@@ -473,7 +473,7 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: ssd-2-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -483,35 +483,35 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: bar.example.com/v1
             kind: Backend
             metadata:
-                name: ssd-2-service
+                name: $scenario_id-backend
             spec:
                 image: docker.io/postgres
                 imageName: postgres
                 dbName: db-demo
             status:
                 data:
-                    dbCredentials: ssd-2-secret
+                    dbCredentials: $scenario_id-secret
             """
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: ssd-2
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: bar.example.com
                     version: v1
                     kind: Backend
-                    name: ssd-2-service
+                    name: $scenario_id-backend
                 application:
-                    name: ssd-2
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "ssd-2" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
@@ -558,15 +558,15 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Namespace
             metadata:
-                name: backend-services
+                name: $scenario_id-ns
             """
         * The Secret is present
             """
             apiVersion: v1
             kind: Secret
             metadata:
-                name: ssa-3-secret
-                namespace: backend-services
+                name: $scenario_id-secret
+                namespace: $scenario_id-ns
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -576,33 +576,33 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: ssa-3-service
-                namespace: backend-services
+                name: $scenario_id-backend
+                namespace: $scenario_id-ns
             status:
-                credentials: ssa-3-secret
+                credentials: $scenario_id-secret
             """
-        * Generic test application "ssa-3" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: ssa-3
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: ssa-3-service
-                    namespace: backend-services
+                    name: $scenario_id-backend
+                    namespace: $scenario_id-ns
                 application:
-                    name: ssa-3
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "ssa-3" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
@@ -612,7 +612,7 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: db-secret-x
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -672,34 +672,34 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: backend-service-x
+                name: $scenario_id-backend
             spec:
                 containers:
                 - envFrom:
                   - secretRef:
-                        name: db-secret-x
+                        name: $scenario_id-secret
             """
-        * Generic test application "myapp-x" is running
+        * Generic test application is running
         When Service Binding is applied
           """
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: sb-inject-secret-data
+              name: $scenario_id-binding
           spec:
               bindAsFiles: false
               services:
               - group: stable.example.com
                 version: v1
                 kind: Backend
-                name: backend-service-x
+                name: $scenario_id-backend
               application:
-                name: myapp-x
+                name: $scenario_id
                 group: apps
                 version: v1
                 resource: deployments
           """
-        Then Service Binding "sb-inject-secret-data" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
@@ -710,37 +710,37 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: provisioned-secret-1
+                name: $scenario_id-secret
             stringData:
                 username: foo
                 password: bar
             """
-        * Generic test application "myapp-provision-srv2" is running
+        * Generic test application is running
         When Service Binding is applied
           """
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: bind-direct-secret-1
+              name: $scenario_id-binding
           spec:
               services:
               - group: ""
                 version: v1
                 kind: Secret
-                name: provisioned-secret-1
+                name: $scenario_id-secret
               application:
-                name: myapp-provision-srv2
+                name: $scenario_id
                 group: apps
                 version: v1
                 resource: deployments
           """
-        Then Service Binding "bind-direct-secret-1" is ready
-        And jq ".status.secret" of Service Binding "bind-direct-secret-1" should be changed to "provisioned-secret-1"
-        And Content of file "/bindings/bind-direct-secret-1/username" in application pod is
+        Then Service Binding is ready
+        And jq ".status.secret" of Service Binding should be changed to "$scenario_id-secret"
+        And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-        And Content of file "/bindings/bind-direct-secret-1/password" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
@@ -751,28 +751,28 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: provisioned-secret-1
+                name: $scenario_id-secret
             stringData:
                 username: foo
                 password: bar
             """
-        * Generic test application "myapp-provision-srv3" is running
+        * Generic test application is running
         When Service Binding is applied
           """
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: bind-direct-secret-mapping
+              name: $scenario_id-binding
           spec:
               bindAsFiles: true
               services:
               - group: ""
                 version: v1
                 kind: Secret
-                name: provisioned-secret-1
+                name: $scenario_id-secret
                 id: sec
               application:
-                name: myapp-provision-srv3
+                name: $scenario_id
                 group: apps
                 version: v1
                 resource: deployments
@@ -780,71 +780,71 @@ Feature: Bind values from a secret referred in backing service resource
                 - name: username_with_password
                   value: '{{ .username }}:{{ .password }}'
           """
-        Then Service Binding "bind-direct-secret-mapping" is ready
-        And Service Binding "bind-direct-secret-mapping" has the binding secret name set in the status
-        And Content of file "/bindings/bind-direct-secret-mapping/username" in application pod is
+        Then Service Binding is ready
+        And Service Binding "$scenario_id-binding" has the binding secret name set in the status
+        And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-        And Content of file "/bindings/bind-direct-secret-mapping/password" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
-        And Content of file "/bindings/bind-direct-secret-mapping/username_with_password" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/username_with_password" in application pod is
             """
             foo:bar
             """
 
     Scenario: Inject binding to an application from a Secret resource created later referred as service 
-        Given Generic test application "myapp-provision-srv4" is running
+        Given Generic test application is running
         When Service Binding is applied
           """
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: bind-provisioned-service-4
+              name: $scenario_id-binding
           spec:
               services:
               - group: ""
                 version: v1
                 kind: Secret
-                name: provisioned-secret-4
+                name: $scenario_id-secret
               application:
-                name: myapp-provision-srv4
+                name: $scenario_id
                 group: apps
                 version: v1
                 resource: deployments
           """
-        * jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "bind-provisioned-service-4" should be changed to "False"
+        * jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding should be changed to "False"
         * The Secret is present
             """
             apiVersion: v1
             kind: Secret
             metadata:
-                name: provisioned-secret-4
+                name: $scenario_id-secret
             stringData:
                 username: foo
                 password: bar
             """
 
-        Then Service Binding "bind-provisioned-service-4" is ready
-        And Content of file "/bindings/bind-provisioned-service-4/username" in application pod is
+        Then Service Binding is ready
+        And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-        And Content of file "/bindings/bind-provisioned-service-4/password" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
 
     Scenario: Inject binding to an application from two Secret resources referred as services
-        Given Generic test application "myapp-provision-srv5" is running
+        Given Generic test application is running
         * The Secret is present
             """
             apiVersion: v1
             kind: Secret
             metadata:
-                name: provisioned-secret-5
+                name: $scenario_id-secret-1
             stringData:
                 username: foo
                 password: bar
@@ -854,7 +854,7 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: provisioned-secret-6
+                name: $scenario_id-secret-2
             stringData:
                 username2: foo2
                 password2: bar2
@@ -864,37 +864,37 @@ Feature: Bind values from a secret referred in backing service resource
           apiVersion: binding.operators.coreos.com/v1alpha1
           kind: ServiceBinding
           metadata:
-              name: bind-direct-secret-2
+              name: $scenario_id-binding
           spec:
               services:
               - group: ""
                 version: v1
                 kind: Secret
-                name: provisioned-secret-5
+                name: $scenario_id-secret-1
               - group: ""
                 version: v1
                 kind: Secret
-                name: provisioned-secret-6
+                name: $scenario_id-secret-2
               application:
-                name: myapp-provision-srv5
+                name: $scenario_id
                 group: apps
                 version: v1
                 resource: deployments
           """
-        Then Service Binding "bind-direct-secret-2" is ready
-        And Content of file "/bindings/bind-direct-secret-2/username" in application pod is
+        Then Service Binding is ready
+        And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-        And Content of file "/bindings/bind-direct-secret-2/password" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
-        And Content of file "/bindings/bind-direct-secret-2/username2" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/username2" in application pod is
             """
             foo2
             """
-        And Content of file "/bindings/bind-direct-secret-2/password2" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/password2" in application pod is
             """
             bar2
 
@@ -906,40 +906,40 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: provisioned-secret-1
+                name: $scenario_id-secret
             stringData:
                 username: foo
                 password: bar
                 type: db
             """
-        * Generic test application "spec-myapp-provision-srv2" is running
+        * Generic test application is running
         When Service Binding is applied
           """
           apiVersion: servicebinding.io/v1alpha3
           kind: ServiceBinding
           metadata:
-              name: spec-direct-secret-1
+              name: $scenario_id-binding
           spec:
               service:
                 apiVersion: v1
                 kind: Secret
-                name: provisioned-secret-1
+                name: $scenario_id-secret
               workload:
-                name: spec-myapp-provision-srv2
+                name: $scenario_id
                 apiVersion: apps/v1
                 kind: Deployment
           """
-        Then Service Binding "spec-direct-secret-1" is ready
-        And jq ".status.binding.name" of Service Binding "spec-direct-secret-1" should be changed to "provisioned-secret-1"
-        And Content of file "/bindings/spec-direct-secret-1/username" in application pod is
+        Then Service Binding is ready
+        And jq ".status.binding.name" of Service Binding should be changed to "$scenario_id-secret"
+        And Content of file "/bindings/$scenario_id-binding/username" in application pod is
             """
             foo
             """
-        And Content of file "/bindings/spec-direct-secret-1/password" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/password" in application pod is
             """
             bar
             """
-        And Content of file "/bindings/spec-direct-secret-1/type" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/type" in application pod is
             """
             db
             """
@@ -952,30 +952,30 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: provisioned-secret-6
+                name: $scenario_id-secret
             stringData:
                 username: foo
                 password: bar
             """
-        * Generic test application "spec-myapp-provision-srv6" is running
+        * Generic test application is running
         When Service Binding is applied
           """
           apiVersion: servicebinding.io/v1alpha3
           kind: ServiceBinding
           metadata:
-              name: spec-bind-provisioned-service-6
+              name: $scenario_id-binding
           spec:
               service:
                 apiVersion: v1
                 kind: Secret
-                name: provisioned-secret-6
+                name: $scenario_id-secret
               workload:
-                name: spec-myapp-provision-srv6
+                name: $scenario_id
                 apiVersion: apps/v1
                 kind: Deployment
           """
-        Then jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "spec-bind-provisioned-service-6" should be changed to "False"
-        And jq ".status.conditions[] | select(.type=="InjectionReady").reason" of Service Binding "spec-bind-provisioned-service-6" should be changed to "RequiredBindingNotFound"
+        Then jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding should be changed to "False"
+        And jq ".status.conditions[] | select(.type=="InjectionReady").reason" of Service Binding should be changed to "RequiredBindingNotFound"
 
     @spec
     Scenario: SPEC Inject binding to only specified containers inside application pod
@@ -984,7 +984,7 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: v1
             kind: Secret
             metadata:
-                name: provisioned-secret-1
+                name: $scenario_id-secret
             stringData:
                 username: foo
                 password: bar
@@ -996,7 +996,7 @@ Feature: Bind values from a secret referred in backing service resource
             apiVersion: "stable.example.com/v1"
             kind: AppConfig
             metadata:
-                name: multi-container-app
+                name: $scenario_id-appconfig
             spec:
                 template:
                     spec:
@@ -1018,14 +1018,14 @@ Feature: Bind values from a secret referred in backing service resource
           apiVersion: servicebinding.io/v1alpha3
           kind: ServiceBinding
           metadata:
-              name: multi-container-binding
+              name: $scenario_id-binding
           spec:
               service:
                 apiVersion: v1
                 kind: Secret
-                name: provisioned-secret-1
+                name: $scenario_id-secret
               workload:
-                name: multi-container-app
+                name: $scenario_id-appconfig
                 apiVersion: stable.example.com/v1
                 kind: AppConfig
                 containers:
@@ -1033,10 +1033,10 @@ Feature: Bind values from a secret referred in backing service resource
                     - bar
                     - bla
           """
-        Then Service Binding "multi-container-binding" is ready
-        * jq ".status.binding.name" of Service Binding "multi-container-binding" should be changed to "provisioned-secret-1"
-        * jsonpath "{.spec.template.spec.containers[0].volumeMounts}" on "appconfigs/multi-container-app" should return no value
-        * jsonpath "{.spec.template.spec.containers[1].volumeMounts}" on "appconfigs/multi-container-app" should return "[{"mountPath":"/bindings/multi-container-binding","name":"multi-container-binding"}]"
-        * jsonpath "{.spec.template.spec.containers[2].volumeMounts}" on "appconfigs/multi-container-app" should return "[{"mountPath":"/bindings/multi-container-binding","name":"multi-container-binding"}]"
-        * jsonpath "{.spec.template.spec.containers[3].volumeMounts}" on "appconfigs/multi-container-app" should return no value
-        * jsonpath "{.spec.template.spec.initContainers[0].volumeMounts}" on "appconfigs/multi-container-app" should return "[{"mountPath":"/bindings/multi-container-binding","name":"multi-container-binding"}]"
+        Then Service Binding is ready
+        * jq ".status.binding.name" of Service Binding should be changed to "$scenario_id-secret"
+        * jsonpath "{.spec.template.spec.containers[0].volumeMounts}" on "appconfigs/$scenario_id-appconfig" should return no value
+        * jsonpath "{.spec.template.spec.containers[1].volumeMounts}" on "appconfigs/$scenario_id-appconfig" should return "[{"mountPath":"/bindings/$scenario_id-binding","name":"$scenario_id-binding"}]"
+        * jsonpath "{.spec.template.spec.containers[2].volumeMounts}" on "appconfigs/$scenario_id-appconfig" should return "[{"mountPath":"/bindings/$scenario_id-binding","name":"$scenario_id-binding"}]"
+        * jsonpath "{.spec.template.spec.containers[3].volumeMounts}" on "appconfigs/$scenario_id-appconfig" should return no value
+        * jsonpath "{.spec.template.spec.initContainers[0].volumeMounts}" on "appconfigs/$scenario_id-appconfig" should return "[{"mountPath":"/bindings/$scenario_id-binding","name":"$scenario_id-binding"}]"

--- a/test/acceptance/features/bindMultipleAppsToSingleService.feature
+++ b/test/acceptance/features/bindMultipleAppsToSingleService.feature
@@ -26,7 +26,7 @@ Feature: Bind multiple applications to a single service
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: service-a-s-f
+                name: $scenario_id-service
                 annotations:
                     service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
             status:
@@ -38,14 +38,14 @@ Feature: Bind multiple applications to a single service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: service-binding-a-s-f
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 services:
                   - group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: service-a-s-f
+                    name: $scenario_id-service
                 application:
                     labelSelector:
                       matchLabels:
@@ -54,6 +54,6 @@ Feature: Bind multiple applications to a single service
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "service-binding-a-s-f" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond" in both apps
         And The application env var "BACKEND_PASSWORD" has value "hunter2" in both apps

--- a/test/acceptance/features/bindWithCustomNamingStrategies.feature
+++ b/test/acceptance/features/bindWithCustomNamingStrategies.feature
@@ -14,23 +14,23 @@ Feature: Bind an application to a service using custom naming strategies
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: backend-no-naming
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
             spec:
                 host_cross_ns_service: cross.ns.service.stable.example.com
             """
-        * Generic test application "myapp-no-naming" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-no-naming
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: myapp-no-naming
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -38,9 +38,9 @@ Feature: Bind an application to a service using custom naming strategies
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-no-naming
+                    name: $scenario_id-backend
             """
-        Then Service Binding "binding-request-no-naming" is ready
+        Then Service Binding is ready
         And The application env var "BACKEND_HOST_CROSS_NS_SERVICE" has value "cross.ns.service.stable.example.com"
 
     Scenario: Bind an application to a service with naming strategy none
@@ -49,13 +49,13 @@ Feature: Bind an application to a service using custom naming strategies
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: backend-naming-none
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
             spec:
                 host_cross_ns_service: cross.ns.service.stable.example.com
             """
-        * Generic test application "myapp-naming-none" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
@@ -66,7 +66,7 @@ Feature: Bind an application to a service using custom naming strategies
                 bindAsFiles: false
                 namingStrategy: none
                 application:
-                    name: myapp-naming-none
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -74,9 +74,9 @@ Feature: Bind an application to a service using custom naming strategies
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-naming-none
+                    name: $scenario_id-backend
             """
-        Then Service Binding "binding-request-naming-none" is ready
+        Then Service Binding is ready
         And The application env var "host_cross_ns_service" has value "cross.ns.service.stable.example.com"
 
     Scenario: Bind an application to a service with custom naming strategy
@@ -85,24 +85,24 @@ Feature: Bind an application to a service using custom naming strategies
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: backend-custom-naming
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
             spec:
                 host_cross_ns_service: cross.ns.service.stable.example.com
             """
-        * Generic test application "myapp-custom-naming" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-custom-naming
+                name: $scenario_id-backend
             spec:
                 bindAsFiles: false
                 namingStrategy: "PREFIX_{{ .service.kind | upper }}_{{ .name | upper }}_SUFFIX"
                 application:
-                    name: myapp-custom-naming
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -110,9 +110,9 @@ Feature: Bind an application to a service using custom naming strategies
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-custom-naming
+                    name: $scenario_id-backend
             """
-        Then Service Binding "binding-request-custom-naming" is ready
+        Then Service Binding is ready
         And The application env var "PREFIX_BACKEND_HOST_CROSS_NS_SERVICE_SUFFIX" has value "cross.ns.service.stable.example.com"
 
     Scenario: Bind an application to a service with bind as file and no naming strategy
@@ -121,23 +121,23 @@ Feature: Bind an application to a service using custom naming strategies
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: backend-bind-files
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
             spec:
                 host_cross_ns_service: cross.ns.service.stable.example.com
             """
-        * Generic test application "myapp-bind-files" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-bind-files
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: true
                 application:
-                    name: myapp-bind-files
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -145,11 +145,11 @@ Feature: Bind an application to a service using custom naming strategies
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-bind-files
+                    name: $scenario_id-backend
             """
-        Then Service Binding "binding-request-bind-files" is ready
+        Then Service Binding is ready
         And The env var "host_cross_ns_service" is not available to the application
-        And Content of file "/bindings/binding-request-bind-files/host_cross_ns_service" in application pod is
+        And Content of file "/bindings/$scenario_id-binding/host_cross_ns_service" in application pod is
             """
             cross.ns.service.stable.example.com
             """
@@ -160,24 +160,24 @@ Feature: Bind an application to a service using custom naming strategies
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: backend-custom-file-naming
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
             spec:
                 host_cross_ns_service: cross.ns.service.stable.example.com
             """
-        * Generic test application "myapp-custom-file-naming" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-custom-file-naming
+                name: $scenario_id-binding
             spec:
                 namingStrategy: "PREFIX_{{ .service.kind | upper }}_{{ .name | upper }}_SUFFIX"
                 bindAsFiles: true
                 application:
-                    name: myapp-custom-file-naming
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -185,10 +185,10 @@ Feature: Bind an application to a service using custom naming strategies
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-custom-file-naming
+                    name: $scenario_id-backend
             """
-        Then Service Binding "binding-request-custom-file-naming" is ready
-        And Content of file "/bindings/binding-request-custom-file-naming/PREFIX_BACKEND_HOST_CROSS_NS_SERVICE_SUFFIX" in application pod is
+        Then Service Binding is ready
+        And Content of file "/bindings/$scenario_id-binding/PREFIX_BACKEND_HOST_CROSS_NS_SERVICE_SUFFIX" in application pod is
             """
             cross.ns.service.stable.example.com
             """
@@ -200,24 +200,24 @@ Feature: Bind an application to a service using custom naming strategies
             apiVersion: stable.example.com/v1
             kind: Backend
             metadata:
-                name: backend-naming-error
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host_cross_ns_service: path={.spec.host_cross_ns_service}
             spec:
                 host_cross_ns_service: cross.ns.service.stable.example.com
             """
-        * Generic test application "myapp-naming-error" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-naming-error
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 namingStrategy: "{{ .service.test.name | lower }}_incorrect"
                 application:
-                    name: myapp-naming-error
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -225,7 +225,7 @@ Feature: Bind an application to a service using custom naming strategies
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-naming-error
+                    name: $scenario_id-backend
             """
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding "binding-request-naming-error" should be changed to "False"
-        Then jq ".status.conditions[] | select(.type=="CollectionReady").reason" of Service Binding "binding-request-naming-error" should be changed to "NamingStrategyError"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").status" of Service Binding should be changed to "False"
+        Then jq ".status.conditions[] | select(.type=="CollectionReady").reason" of Service Binding should be changed to "NamingStrategyError"

--- a/test/acceptance/features/customEnvVar.feature
+++ b/test/acceptance/features/customEnvVar.feature
@@ -15,24 +15,24 @@ Feature: Inject custom env variable into application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-with-tag-sequence
+                name: $scenario_id-backend
             spec:
                 host: example.common
                 tags:
                     - "centos7-12.3"
                     - "123"
             """
-        * Generic test application "foo" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: custom-env-var-from-sequence
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: foo
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -40,13 +40,13 @@ Feature: Inject custom env variable into application
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-with-tag-sequence
+                    name: $scenario_id-backend
                     id: backend
                 mappings:
                    - name: TAGS
                      value: '{{ .backend.spec.tags }}'
             """
-        Then Service Binding "custom-env-var-from-sequence" is ready
+        Then Service Binding is ready
         And The application env var "TAGS" has value "[centos7-12.3 123]"
 
     Scenario: Map from service resource is injected into application using custom env variables without specifying annotations
@@ -55,24 +55,24 @@ Feature: Inject custom env variable into application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-with-user-labels-map
+                name: $scenario_id-backend
             spec:
                 host: example.common
                 userLabels:
                     archive: "false"
                     environment: "demo"
             """
-        * Generic test application "foo2" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: custom-env-var-from-map
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: foo2
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -80,13 +80,13 @@ Feature: Inject custom env variable into application
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-with-user-labels-map
+                    name: $scenario_id-backend
                     id: backend
                 mappings:
                    - name: USER_LABELS
                      value: '{{ .backend.spec.userLabels }}'
             """
-        Then Service Binding "custom-env-var-from-map" is ready
+        Then Service Binding is ready
         And The application env var "USER_LABELS" has value "map[archive:false environment:demo]"
 
     Scenario: Scalar from service resource is injected into application using custom env variables without specifying annotations
@@ -95,24 +95,24 @@ Feature: Inject custom env variable into application
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: backend-with-user-labels-archive
+                name: $scenario_id-backend
             spec:
                 host: example.common
                 userLabels:
                     archive: "false"
                     environment: "demo"
             """
-        * Generic test application "foo3" is running
+        * Generic test application is running
         When Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: custom-env-var-from-scalar
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: foo3
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -120,12 +120,12 @@ Feature: Inject custom env variable into application
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: backend-with-user-labels-archive
+                    name: $scenario_id-backend
                     id: backend
                 mappings:
                    - name: USER_LABELS_ARCHIVE
                      value: '{{ .backend.spec.userLabels.archive }}'
             """
-        Then Service Binding "custom-env-var-from-scalar" is ready
+        Then Service Binding is ready
         And The application env var "USER_LABELS_ARCHIVE" has value "false"
 

--- a/test/acceptance/features/immutableBindings.feature
+++ b/test/acceptance/features/immutableBindings.feature
@@ -20,13 +20,13 @@ Feature: Successful Service Binding are Immutable
         """
 
     Scenario: Cannot update a ready Service Binding
-        Given Generic test application "app-immutable" is running
+        Given Generic test application is running
         And Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-immutable
+                name: $scenario_id-binding
             spec:
                 services:
                   - group: stable.example.com
@@ -34,21 +34,21 @@ Feature: Successful Service Binding are Immutable
                     kind: Backend
                     name: service-immutable
                 application:
-                    name: app-immutable
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        When Service Binding "binding-immutable" is ready
+        When Service Binding is ready
         Then Service Binding is unable to be applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-immutable
+                name: $scenario_id-binding
             spec:
                 application:
-                    name: app-immutable-2
+                    name: $scenario_id-2
                     group: apps
                     version: v1
                     resource: deployments
@@ -60,13 +60,13 @@ Feature: Successful Service Binding are Immutable
             """
 
     Scenario: Can update metadata on a ready Service Binding
-        Given Generic test application "app-immutable-3" is running
+        Given Generic test application is running
         And Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-immutable-3
+                name: $scenario_id-binding
             spec:
                 services:
                   - group: stable.example.com
@@ -74,18 +74,18 @@ Feature: Successful Service Binding are Immutable
                     kind: Backend
                     name: service-immutable
                 application:
-                    name: app-immutable-3
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        When Service Binding "binding-immutable-3" is ready
+        When Service Binding is ready
         Then Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-immutable-3
+                name: $scenario_id-binding
                 annotations:
                     foo: bar
                 labels:
@@ -97,7 +97,7 @@ Feature: Successful Service Binding are Immutable
                     kind: Backend
                     name: service-immutable
                 application:
-                    name: app-immutable-3
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -109,7 +109,7 @@ Feature: Successful Service Binding are Immutable
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-immutable-2
+                name: $scenario_id-binding
             spec:
                 services:
                   - group: stable.example.com
@@ -122,14 +122,14 @@ Feature: Successful Service Binding are Immutable
                     version: v1
                     resource: deployments
             """
-        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "binding-immutable-2" should be changed to "False"
-        When Generic test application "app2" is running
+        And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding should be changed to "False"
+        When Generic test application is running
         And Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-immutable-2
+                name: $scenario_id-binding
             spec:
                 services:
                   - group: stable.example.com
@@ -137,23 +137,23 @@ Feature: Successful Service Binding are Immutable
                     kind: Backend
                     name: service-immutable
                 application:
-                    name: app2
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        Then Service Binding "binding-immutable-2" is ready
+        Then Service Binding is ready
 
 
     @spec
     Scenario: SPEC Cannot update a ready Service Binding
-        Given Generic test application "spec-app-immutable" is running
+        Given Generic test application is running
         And Service Binding is applied
             """
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: spec-binding-immutable
+                name: $scenario_id-binding
             spec:
                 type: foo
                 service:
@@ -161,17 +161,17 @@ Feature: Successful Service Binding are Immutable
                   kind: Backend
                   name: service-immutable
                 workload:
-                    name: spec-app-immutable
+                    name: $scenario_id
                     apiVersion: apps/v1
                     kind: Deployment
             """
-        When Service Binding "spec-binding-immutable" is ready
+        When Service Binding is ready
         Then Service Binding is unable to be applied
             """
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: spec-binding-immutable
+                name: $scenario_id-binding
             spec:
                 service:
                   apiVersion: stable.example.com/v1
@@ -184,13 +184,13 @@ Feature: Successful Service Binding are Immutable
             """
     @spec
     Scenario: SPEC Can update metadata on a ready Service Binding
-        Given Generic test application "spec-app-immutable-2" is running
+        Given Generic test application is running
         And Service Binding is applied
             """
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: spec-binding-immutable-2
+                name: $scenario_id-binding
             spec:
                 type: foo
                 service:
@@ -198,17 +198,17 @@ Feature: Successful Service Binding are Immutable
                   kind: Backend
                   name: service-immutable
                 workload:
-                    name: spec-app-immutable-2
+                    name: $scenario_id
                     apiVersion: apps/v1
                     kind: Deployment
             """
-        When Service Binding "spec-binding-immutable-2" is ready
+        When Service Binding is ready
         Then Service Binding is applied
             """
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: spec-binding-immutable-2
+                name: $scenario_id-binding
                 annotations:
                     foo: bar
                 labels:
@@ -220,7 +220,7 @@ Feature: Successful Service Binding are Immutable
                   kind: Backend
                   name: service-immutable
                 workload:
-                    name: spec-app-immutable-2
+                    name: $scenario_id
                     apiVersion: apps/v1
                     kind: Deployment
             """

--- a/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
+++ b/test/acceptance/features/injectSecretAtCustomSchemaPath.feature
@@ -56,7 +56,7 @@ Feature: Insert service binding to a custom location in application resource
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-csp
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
@@ -72,7 +72,7 @@ Feature: Insert service binding to a custom location in application resource
                     kind: Backend
                     name: service-csp
             """
-        Then Service Binding "binding-request-csp" is ready
+        Then Service Binding is ready
         And Secret has been injected in to CR "demo-appconfig-csp" of kind "AppConfig" at path "{.spec.spec.containers[0].envFrom[0].secretRef.name}"
 
     Scenario: Specify secret's path in Service Binding
@@ -91,7 +91,7 @@ Feature: Insert service binding to a custom location in application resource
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-ssp
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
@@ -107,5 +107,5 @@ Feature: Insert service binding to a custom location in application resource
                     kind: Backend
                     name: service-csp
             """
-        Then Service Binding "binding-request-ssp" is ready
+        Then Service Binding is ready
         And Secret has been injected in to CR "demo-appconfig-ssp" of kind "AppConfig" at path "{.spec.spec.secret}"

--- a/test/acceptance/features/steps/app.py
+++ b/test/acceptance/features/steps/app.py
@@ -2,6 +2,7 @@ from openshift import Openshift
 from command import Command
 from environment import ctx
 from behave import step
+from util import substitute_scenario_id
 import polling2
 import json
 
@@ -51,6 +52,9 @@ class App(object):
 @step(u'jsonpath "{json_path}" on "{res_name}" should return no value')
 def resource_jsonpath_value(context, json_path, res_name, json_value=""):
     openshift = Openshift()
+    json_path = substitute_scenario_id(context, json_path)
+    res_name = substitute_scenario_id(context, res_name)
+    json_value = substitute_scenario_id(context, json_value)
     (crdName, name) = res_name.split("/")
     polling2.poll(lambda: openshift.get_resource_info_by_jsonpath(crdName, name, context.namespace.name, json_path) == json_value,
                   step=5, timeout=800, ignore_exceptions=(json.JSONDecodeError,))

--- a/test/acceptance/features/steps/service_binding.py
+++ b/test/acceptance/features/steps/service_binding.py
@@ -3,8 +3,7 @@ import polling2
 import json
 from behave import step, when, then
 from openshift import Openshift
-from string import Template
-from util import scenario_id
+from util import substitute_scenario_id
 
 
 class ServiceBinding(object):
@@ -64,7 +63,7 @@ def sbr_is_applied(context, user=None):
         ns = context.namespace.name
     else:
         ns = None
-    resource = Template(context.text).substitute(scenario_id=scenario_id(context))
+    resource = substitute_scenario_id(context, context.text)
     binding = ServiceBinding(resource, ns)
     assert binding.create(user) is not None, "Service binding not created"
     context.bindings[binding.name] = binding
@@ -74,7 +73,8 @@ def sbr_is_applied(context, user=None):
 @when(u'Invalid Service Binding is applied')
 @then(u'Service Binding is unable to be applied')
 def invalid_sbr_is_applied(context):
-    sbr = ServiceBinding(context.text, context.namespace.name)
+    resource = substitute_scenario_id(context, context.text)
+    sbr = ServiceBinding(resource, context.namespace.name)
     # Get resource version of sbr if sbr is available
     if sbr.name in context.bindings.keys():
         context.resource_version = sbr.get_info_by_jsonpath("{.metadata.resourceVersion}")
@@ -86,6 +86,8 @@ def invalid_sbr_is_applied(context):
 def sbo_is_ready(context, sbr_name=None):
     if sbr_name is None:
         sbr_name = list(context.bindings.values())[0].name
+    else:
+        sbr_name = substitute_scenario_id(context, sbr_name)
     sbo_jq_is(context, '.status.conditions[] | select(.type=="CollectionReady").status', sbr_name, 'True')
     sbo_jq_is(context, '.status.conditions[] | select(.type=="InjectionReady").status', sbr_name, 'True')
     sbo_jq_is(context, '.status.conditions[] | select(.type=="Ready").status', sbr_name, 'True')
@@ -102,6 +104,9 @@ def sbo_is_ready(context, sbr_name=None):
 def sbo_jq_is(context, jq_expression, sbr_name=None, json_value=""):
     if sbr_name is None:
         sbr_name = list(context.bindings.values())[0].name
+    else:
+        sbr_name = substitute_scenario_id(context, sbr_name)
+    json_value = substitute_scenario_id(context, json_value)
     polling2.poll(lambda: json.loads(
         context.bindings[sbr_name].get_info_by_jsonpath(jq_expression)) == json_value,
                   step=5, timeout=800, ignore_exceptions=(json.JSONDecodeError,))
@@ -109,15 +114,17 @@ def sbo_jq_is(context, jq_expression, sbr_name=None, json_value=""):
 
 @when(u'Service binding "{sb_name}" is deleted')
 def service_binding_is_deleted(context, sb_name):
-    sb = context.bindings[sb_name]
+    resource = substitute_scenario_id(context, sb_name)
+    sb = context.bindings[resource]
     context.sb_secret = sb.get_secret_name()
     sb.delete()
 
 
 @then(u'Service Binding "{sb_name}" is not updated')
 def validate_persistent_sb(context, sb_name):
+    resource = substitute_scenario_id(context, sb_name)
     json_path = "{.metadata.resourceVersion}"
-    assert context.resource_version == context.bindings[sb_name].get_info_by_jsonpath(json_path), "Service Binding got update"
+    assert context.resource_version == context.bindings[resource].get_info_by_jsonpath(json_path), "Service Binding got update"
 
 
 @step(u'Service Binding "{sbr_name}" has the binding secret name set in the status')
@@ -126,7 +133,7 @@ def sbo_secret_name_has_been_set(context, sbr_name=None):
     if sbr_name is None:
         sbr_name = list(context.bindings.values())[0].name
     else:
-        sbr_name = Template(sbr_name).substitute(scenario_id=scenario_id(context))
+        sbr_name = substitute_scenario_id(context, sbr_name)
     polling2.poll(lambda: context.bindings[sbr_name].get_secret_name() != "",
                   step=5, timeout=800,  ignore_exceptions=(json.JSONDecodeError,))
 

--- a/test/acceptance/features/steps/util.py
+++ b/test/acceptance/features/steps/util.py
@@ -1,5 +1,10 @@
 import os
+from string import Template
 
 
 def scenario_id(context):
     return f"{os.path.basename(os.path.splitext(context.scenario.filename)[0]).lower()}-{context.scenario.line}"
+
+
+def substitute_scenario_id(context, text="$scenario_id"):
+    return Template(text).substitute(scenario_id=scenario_id(context))

--- a/test/acceptance/features/unbindAppToService.feature
+++ b/test/acceptance/features/unbindAppToService.feature
@@ -14,7 +14,7 @@ Feature: Unbind an application from a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: example-backend
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host: path={.spec.host}
                     service.binding/username: path={.spec.username}
@@ -22,17 +22,17 @@ Feature: Unbind an application from a service
                 host: example.com
                 username: foo
             """
-        * Generic test application "generic-app-a-d-u" is running
+        * Generic test application is running
         * Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-a-d-u
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: generic-app-a-d-u
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -40,13 +40,13 @@ Feature: Unbind an application from a service
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: example-backend
+                    name: $scenario_id-backend
                     id: backend
             """
-        * Service Binding "binding-request-a-d-u" is ready
+        * Service Binding is ready
         * The application env var "BACKEND_HOST" has value "example.com"
         * The application env var "BACKEND_USERNAME" has value "foo"
-        When Service binding "binding-request-a-d-u" is deleted
+        When Service binding "$scenario_id-binding" is deleted
         Then The env var "BACKEND_HOST" is not available to the application
         * The env var "BACKEND_USERNAME" is not available to the application
         * Service Binding secret is not present
@@ -57,7 +57,7 @@ Feature: Unbind an application from a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: example-backend
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host: path={.spec.host}
                     service.binding/username: path={.spec.username}
@@ -65,17 +65,17 @@ Feature: Unbind an application from a service
                 host: example.com
                 username: foo
             """
-        * Generic test application "generic-app-a-d-u" is running
+        * Generic test application is running
         * Service Binding is applied
             """
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: binding-request-a-d-u
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
-                    name: generic-app-a-d-u
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
@@ -83,10 +83,10 @@ Feature: Unbind an application from a service
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: example-backend
+                    name: $scenario_id-backend
                     id: backend
             """
-        * Service Binding "binding-request-a-d-u" is ready
+        * Service Binding is ready
         * The application env var "BACKEND_HOST" has value "example.com"
         * The application env var "BACKEND_USERNAME" has value "foo"
         * BackingService is deleted
@@ -94,7 +94,7 @@ Feature: Unbind an application from a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: example-backend
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host: path={.spec.host}
                     service.binding/username: path={.spec.username}
@@ -102,19 +102,19 @@ Feature: Unbind an application from a service
                 host: example.com
                 username: foo
             """
-        When Service binding "binding-request-a-d-u" is deleted
+        When Service binding "$scenario_id-binding" is deleted
         Then The env var "BACKEND_HOST" is not available to the application
         * The env var "BACKEND_USERNAME" is not available to the application
         * Service Binding secret is not present
 
     Scenario: Remove bindings projected as files from generic test application
-        Given Generic test application "remove-bindings-as-files-app" is running
+        Given Generic test application is running
         * The Custom Resource is present
             """
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: remove-bindings-as-files-app-backend
+                name: $scenario_id-backend
                 annotations:
                     "service.binding/host": "path={.spec.host}"
                     "service.binding/port": "path={.spec.port}"
@@ -127,33 +127,33 @@ Feature: Unbind an application from a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: remove-bindings-as-files-app-sb
+                name: $scenario_id-binding
             spec:
                 services:
                 -   group: stable.example.com
                     version: v1
                     kind: Backend
-                    name: remove-bindings-as-files-app-backend
+                    name: $scenario_id-backend
 
                 application:
-                    name: remove-bindings-as-files-app
+                    name: $scenario_id
                     group: apps
                     version: v1
                     resource: deployments
             """
-        * Service Binding "remove-bindings-as-files-app-sb" is ready
-        * Content of file "/bindings/remove-bindings-as-files-app-sb/host" in application pod is
+        * Service Binding is ready
+        * Content of file "/bindings/$scenario_id-binding/host" in application pod is
             """
             example.common
             """
-        * Content of file "/bindings/remove-bindings-as-files-app-sb/port" in application pod is
+        * Content of file "/bindings/$scenario_id-binding/port" in application pod is
             """
             8080
             """
-        When Service Binding "remove-bindings-as-files-app-sb" is deleted
+        When Service Binding "$scenario_id-binding" is deleted
         Then The application got redeployed 2 times so far
-        * File "/bindings/remove-bindings-as-files-app-sb/host" is unavailable in application pod
-        * File "/bindings/remove-bindings-as-files-app-sb/port" is unavailable in application pod
+        * File "/bindings/$scenario_id-binding/host" is unavailable in application pod
+        * File "/bindings/$scenario_id-binding/port" is unavailable in application pod
         * Service Binding secret is not present
 
     Scenario: Remove not ready binding
@@ -162,7 +162,7 @@ Feature: Unbind an application from a service
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: example-backend
+                name: $scenario_id-backend
                 annotations:
                     service.binding/host: path={.spec.host}
                     service.binding/username: path={.spec.username}
@@ -175,7 +175,7 @@ Feature: Unbind an application from a service
             apiVersion: binding.operators.coreos.com/v1alpha1
             kind: ServiceBinding
             metadata:
-                name: unready-binding
+                name: $scenario_id-binding
             spec:
                 bindAsFiles: false
                 application:
@@ -189,20 +189,20 @@ Feature: Unbind an application from a service
                     kind: Backend
                     name: example-backend
             """
-        * jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding "unready-binding" should be changed to "False"
-        When Service binding "unready-binding" is deleted
-        Then Service Binding "unready-binding" is not persistent in the cluster
+        * jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding should be changed to "False"
+        When Service binding "$scenario_id-binding" is deleted
+        Then Service Binding "$scenario_id-binding" is not persistent in the cluster
 
     @smoke
     @spec
     Scenario: SPEC Remove bindings from test application
-        Given Generic test application "spec-remove-bindings-as-files-app" is running
+        Given Generic test application is running
         * The Custom Resource is present
             """
             apiVersion: "stable.example.com/v1"
             kind: Backend
             metadata:
-                name: remove-bindings-as-files-app-backend
+                name: $scenario_id-backend
                 annotations:
                     "service.binding/host": "path={.spec.host}"
                     "service.binding/port": "path={.spec.port}"
@@ -215,35 +215,35 @@ Feature: Unbind an application from a service
             apiVersion: servicebinding.io/v1alpha3
             kind: ServiceBinding
             metadata:
-                name: spec-remove-bindings-as-files-app-sb
+                name: $scenario_id-binding
             spec:
                 type: mysql
                 service:
                   apiVersion: stable.example.com/v1
                   kind: Backend
-                  name: remove-bindings-as-files-app-backend
+                  name: $scenario_id-backend
 
                 workload:
-                    name: spec-remove-bindings-as-files-app
+                    name: $scenario_id
                     apiVersion: apps/v1
                     kind: Deployment
             """
-        * Service Binding "spec-remove-bindings-as-files-app-sb" is ready
-        * Content of file "/bindings/spec-remove-bindings-as-files-app-sb/host" in application pod is
+        * Service Binding is ready
+        * Content of file "/bindings/$scenario_id-binding/host" in application pod is
             """
             example.common
             """
-        * Content of file "/bindings/spec-remove-bindings-as-files-app-sb/port" in application pod is
+        * Content of file "/bindings/$scenario_id-binding/port" in application pod is
             """
             8080
             """
-        * Content of file "/bindings/spec-remove-bindings-as-files-app-sb/type" in application pod is
+        * Content of file "/bindings/$scenario_id-binding/type" in application pod is
             """
             mysql
             """
-        When Service Binding "spec-remove-bindings-as-files-app-sb" is deleted
+        When Service Binding "$scenario_id-binding" is deleted
         Then The application got redeployed 2 times so far
-        * File "/bindings/spec-remove-bindings-as-files-app-sb/host" is unavailable in application pod
-        * File "/bindings/spec-remove-bindings-as-files-app-sb/port" is unavailable in application pod
-        * File "/bindings/spec-remove-bindings-as-files-app-sb/type" is unavailable in application pod
+        * File "/bindings/$scenario_id-binding/host" is unavailable in application pod
+        * File "/bindings/$scenario_id-binding/port" is unavailable in application pod
+        * File "/bindings/$scenario_id-binding/type" is unavailable in application pod
         * Service Binding secret is not present


### PR DESCRIPTION
This helps ensure less implicit dependencies between various acceptance tests; this was done as a part of investigating test concurrency.

### Motivation

We want to reduce implicit dependencies between acceptance tests, since that will help make our tests repeatable and more consistent.

### Changes

Acceptance tests should now be using `$scenario_id` (or names derived from it) in most places.

### Testing

Run acceptance tests.