### PR TITLE
Use mutil-arch generic test app image

### DIFF
--- a/test/acceptance/features/steps/generic_testapp.py
+++ b/test/acceptance/features/steps/generic_testapp.py
@@ -12,7 +12,7 @@ class GenericTestApp(App):
 
     deployment_name_pattern = "{name}"
 
-    def __init__(self, name, namespace, app_image="quay.io/redhat-developer/sbo-generic-test-app:20200923"):
+    def __init__(self, name, namespace, app_image="quay.io/service-binding/generic-test-app:20211112"):
         App.__init__(self, name, namespace, app_image, "8080")
 
     def get_env_var_value(self, name):


### PR DESCRIPTION
### Motivation

Running acceptance tests on non-Intel arches requires that our generic test app is multi-arch as well.

### Changes

The generic test app image is built and pushed to the new quay location with:

```
pushd test/acceptance/resources/apps/sbo-generic-test-app/ \
  && podman build --manifest sbo-generic-test-app:today \
    --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x . \
  && podman manifest push sbo-generic-test-app:today \
    quay.io/service-binding/generic-test-app:20211112 \
  && popd
```

and `GenericTestApp` is updated to use the new pullspec.

### Testing

Run the tests with this applied.