### PR TITLE
build: add recipe for generating mocks

### DIFF
--- a/hack/common.mk
+++ b/hack/common.mk
@@ -79,6 +79,9 @@ endif
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+gen-mocks: mockgen
+	PATH=$(shell pwd)/bin:$(shell printenv PATH) $(GO) generate $(V_FLAG) ./...
+
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen:
@@ -105,3 +108,7 @@ endef
 YQ = $(shell pwd)/bin/yq
 yq:
 	$(call go-get-tool,$(YQ),github.com/mikefarah/yq/v4@v4.9.8)
+
+MOCKGEN = $(shell pwd)/bin/mockgen
+mockgen:
+	$(call go-get-tool,$(MOCKGEN),github.com/golang/mock/mockgen@v1.6.0)


### PR DESCRIPTION
### Motivation

When making changes to mocked interfaces, I'd like a way for our build system to automatically regenerate our mocks.

### Changes

`mockgen` is now placed in `bin/`, so installing it globally is no longer required.

I don't have the new `gen-mocks` recipe as a dependency for running unit tests, since you're not likely going to need to run it very often.  Ideally, I'd have it as a dependency and have it run only when mocked interfaces have changed in some way, but I'm not sure how to teach `make` to do that kind of introspection.

### Testing

Run `make gen-mocks`; mocks should be regenerated.