### PR TITLE
Introduce sample application (spring-petclinic + postgresql) to be used in quickstart

### DIFF
--- a/samples/apps/spring-petclinic/Dockerfile.app
+++ b/samples/apps/spring-petclinic/Dockerfile.app
@@ -1,0 +1,26 @@
+# ---
+FROM --platform=amd64 maven:3.8.4-openjdk-11 as builder
+
+ARG PETCLINIC_REPO=https://github.com/spring-projects/spring-petclinic.git
+ARG PETCLINIC_COMMIT=a7439c74ea718c4f59fe6c7c643c4afe59d7e718
+ENV PETCLINIC_DIR=/petclinic
+
+RUN git clone "${PETCLINIC_REPO}" ${PETCLINIC_DIR} && \
+    git --git-dir=${PETCLINIC_DIR}/.git reset --hard "${PETCLINIC_COMMIT}"
+
+COPY patch /patch
+
+RUN for i in /patch/*.patch; do echo " -> Applying $i"; git -C ${PETCLINIC_DIR} apply --verbose $i; done
+
+WORKDIR ${PETCLINIC_DIR}
+
+RUN mvn package -DskipTests -Dmaven.artifact.threads=4
+
+# ---
+FROM registry.redhat.io/ubi8/openjdk-11-runtime as runtime
+
+COPY --from=builder /petclinic/target/spring-petclinic-*.jar /tmp/petclinic.jar
+
+EXPOSE 8080
+
+CMD ["java", "-Dorg.springframework.cloud.bindings.boot.enable=true", "-jar", "/tmp/petclinic.jar"]

--- a/samples/apps/spring-petclinic/Makefile
+++ b/samples/apps/spring-petclinic/Makefile
@@ -1,0 +1,60 @@
+PETCLINIC_REPO ?= quay.io/service-binding/spring-petclinic
+PETCLINIC_APP_IMAGE ?= $(PETCLINIC_REPO):latest
+
+NAMESPACE ?= my-postgresql
+
+MULTIARCH_PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+
+# one of "openshift", "minikube"
+KUBERNETES_RUNTIME ?= minikube
+
+.PHONY: namespace
+namespace:
+ifeq ($(KUBERNETES_RUNTIME), openshift)
+	-oc new-project $(NAMESPACE)
+else ifeq ($(KUBERNETES_RUNTIME), minikube)
+	-kubectl create namespace $(NAMESPACE)
+	kubectl config set-context --current --namespace=$(NAMESPACE)
+endif
+
+.PHONY: deploy-database
+deploy-database:
+	kubectl apply -f db-deployment.yaml -n $(NAMESPACE)
+
+.PHONY: annotate-database
+annotate-database:
+	kubectl annotate --overwrite=true deployment -n ${NAMESPACE} spring-petclinic-postgresql \
+	service.binding/type="postgresql" \
+    service.binding/host="path={.metadata.name}.{.metadata.namespace}" \
+    service.binding/port="path={.spec.template.spec.containers[0].ports[0].containerPort}" \
+    service.binding="path={.spec.template.spec.volumes[0].secret.secretName},objectType=Secret"
+
+.PHONY: build-app
+build-app:
+	docker build -f Dockerfile.app -t $(PETCLINIC_APP_IMAGE) .
+
+.PHONY: push-app
+push-app:
+	docker push $(PETCLINIC_APP_IMAGE)
+
+.PHONY: build-app-multiarch
+build-app-multiarch:
+	docker buildx build --platform "$(MULTIARCH_PLATFORMS)" -f Dockerfile.app -t $(PETCLINIC_APP_IMAGE) .
+
+.PHONY: push-app-multiarch
+push-app-multiarch:
+	docker buildx build --push --platform "$(MULTIARCH_PLATFORMS)" -f Dockerfile.app -t $(PETCLINIC_APP_IMAGE) .
+
+.PHONY: deploy-app
+deploy-app:
+	PETCLINIC_APP_IMAGE=$(PETCLINIC_APP_IMAGE) \
+	NAMESPACE=$(NAMESPACE) \
+	$(KUBERNETES_RUNTIME)/deploy-app.sh
+
+.PHONY: bind
+bind:
+	kubectl apply -f service-binding.yaml -n $(NAMESPACE)
+
+.PHONY: unbind
+unbind:
+	kubectl delete -f service-binding.yaml -n $(NAMESPACE)

--- a/samples/apps/spring-petclinic/app-deployment.yaml
+++ b/samples/apps/spring-petclinic/app-deployment.yaml
@@ -1,0 +1,46 @@
+---
+# tag::app-deployment[]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-petclinic
+  labels:
+    app: spring-petclinic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spring-petclinic
+  template:
+    metadata:
+      labels:
+        app: spring-petclinic
+    spec:
+      containers:
+        - name: app
+          image: quay.io/service-binding/spring-petclinic:latest
+          imagePullPolicy: Always
+          env:
+          - name: SPRING_PROFILES_ACTIVE
+            value: postgres
+          ports:
+          - name: http
+            containerPort: 8080
+# end::app-deployment[]
+---
+# tag::app-service[]
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: spring-petclinic
+  name: spring-petclinic
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: spring-petclinic
+# end::app-service[]

--- a/samples/apps/spring-petclinic/db-deployment.yaml
+++ b/samples/apps/spring-petclinic/db-deployment.yaml
@@ -1,0 +1,70 @@
+---
+# tag::db-secret[]
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spring-petclinic-postgresql
+stringData:
+  database: spring-petclinic-postgresql-db
+  username: spring-petclinic-postgresql-user
+  password: spring-petclinic-postgresql-passwd
+# end::db-secret[]
+---
+# tag::db-deployment[]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-petclinic-postgresql
+  labels:
+    app: spring-petclinic-postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spring-petclinic-postgresql
+  template:
+    metadata:
+      labels:
+        app: spring-petclinic-postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: postgres:13
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB_FILE
+              value: /secrets/database
+            - name: POSTGRES_PASSWORD_FILE
+              value: /secrets/password
+            - name: POSTGRES_USER_FILE
+              value: /secrets/username
+            - name: PGDATA
+              value: /tmp/data
+          volumeMounts:
+            - name: spring-petclinic-postgresql
+              mountPath: "/secrets"
+              readOnly: true
+          ports:
+            - name: postgresql
+              containerPort: 5432
+      volumes:
+        - name: spring-petclinic-postgresql
+          secret:
+            secretName: spring-petclinic-postgresql
+# end::db-deployment[]
+---
+# tag::db-service[]
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: spring-petclinic-postgresql
+  name: spring-petclinic-postgresql
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    app: spring-petclinic-postgresql
+# end::db-service[]

--- a/samples/apps/spring-petclinic/minikube/deploy-app.sh
+++ b/samples/apps/spring-petclinic/minikube/deploy-app.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+NAMESPACE=${NAMESPACE:-my-postgresql}
+
+sed -e 's,quay.io/service-binding/spring-petclinic:latest,'${PETCLINIC_APP_IMAGE}',g' app-deployment.yaml | \
+kubectl apply -f - -n ${NAMESPACE} --wait
+
+echo ""
+echo "Petclinic application is running and available at $(minikube service spring-petclinic -n ${NAMESPACE} --url)"
+echo ""

--- a/samples/apps/spring-petclinic/openshift/deploy-app.sh
+++ b/samples/apps/spring-petclinic/openshift/deploy-app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+NAMESPACE=${NAMESPACE:-my-postgresql}
+
+sed -e 's,quay.io/service-binding/spring-petclinic:latest,'${PETCLINIC_APP_IMAGE}',g' app-deployment.yaml | \
+oc apply -f - -n ${NAMESPACE} --wait
+oc expose service/spring-petclinic -n ${NAMESPACE} || true
+
+echo ""
+echo "Petclinic application is running and available at http://$(oc get route spring-petclinic -n ${NAMESPACE} -o jsonpath={.spec.host})"
+echo ""

--- a/samples/apps/spring-petclinic/patch/pom.xml.patch
+++ b/samples/apps/spring-petclinic/patch/pom.xml.patch
@@ -1,0 +1,31 @@
+diff --git a/pom.xml b/pom.xml
+index fc907e4..cfeb8ff 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -58,6 +58,11 @@
+       <groupId>org.springframework.boot</groupId>
+       <artifactId>spring-boot-starter-thymeleaf</artifactId>
+     </dependency>
++    <dependency>
++      <groupId>org.springframework.cloud</groupId>
++      <artifactId>spring-cloud-bindings</artifactId>
++      <version>1.8.0</version>
++    </dependency>
+     <dependency>
+       <groupId>org.springframework.boot</groupId>
+       <artifactId>spring-boot-starter-test</artifactId>
+@@ -261,6 +266,14 @@
+         <enabled>false</enabled>
+       </snapshots>
+     </repository>
++    <repository>
++      <snapshots>
++        <enabled>true</enabled>
++      </snapshots>
++      <id>spring-release</id>
++      <name>Spring Release</name>
++      <url>https://repo.spring.io/release</url>
++    </repository>
+   </repositories>
+ 
+   <pluginRepositories>

--- a/samples/apps/spring-petclinic/service-binding.yaml
+++ b/samples/apps/spring-petclinic/service-binding.yaml
@@ -1,0 +1,17 @@
+# tag::service-binding[]
+apiVersion: binding.operators.coreos.com/v1alpha1
+kind: ServiceBinding
+metadata:
+  name: spring-petclinic
+spec:
+  services:
+    - group: apps
+      version: v1
+      kind: Deployment
+      name: spring-petclinic-postgresql
+  application:
+    name: spring-petclinic
+    group: apps
+    version: v1
+    resource: deployments
+# end::service-binding[]


### PR DESCRIPTION
### Motivation

Current quickstart uses only REST API server part of the Spring Petclinic as an application and Crunchy Postgresql Operator backed DB. It has couple of UX issues.

The current application:
* does not have UI so user must use `kubectl port-forward` and `curl` command to send requests to the application's API server and analyze responses for accessing and verifying that the application works as expected
* user has to manually run a script to initialize database with application schema and data (as one of the quickstart's steps)

The current database:
* requires installation of Crunchy Postgresql Operator (via OLM) that wouldn't be possible for user with kubernetes cluster without OLM
* uses an operator that is not available on other then `x86_64` architectures, which excludes all users on alternative architectures

### Changes

This PR:
* Introduces an alternative Sprint Petclinic application that improves UX:
    * has a UI for user to interact with
    * initializes database schema and data automatically, so user does not to do it manually - thus simlify the quickstart scenario
    * is based on https://github.com/spring-projects/spring-petclinic application enhanced by https://github.com/spring-cloud/spring-cloud-bindings library.
    * is multi-arch
* Introduces an alternative PostgreSQL deployment that:
    * is in a for of plain `Deployment` based on `postgres:13` image that is multi-arch
    * does not require OLM
* Both app and db including binding is tested on `minikube` and `openshift` clusters
* Is followed-up by https://github.com/redhat-developer/service-binding-operator/pull/1085
    * These app and db deployments are supposed to replace the ones used in SBO's quickstart eventually.

### Testing

The following steps involve running some convenient `Makefile` targets that serve here only to ease testing and will be replaced by the actual `kubectl` or `oc` commands and explained in the quickstart, eventually.

0. Set your environment
    * with minikube (default)
    `export KUBERNETES_RUNTIME=minikube`
    * with OpenShift
    `export KUBERNETES_RUNTIME=openshift`

1. Go to `samples/app/spring-petclinic` directory
`cd samples/app/spring-petclinic`

2. Create user namespace (`my-postgresql` by default)
`make namespace`

3. Deploy database Deployment
`make deploy-database`

4. Expose DB binding data by setting annotations on database Deployment
`make annotate-database`

5. Deploy application Deployment
`make deploy-app`
URL for the application UI is printed out so open it to access the application, but application's pod is stuck in `Init` state due unavailable DB.

6. Bind application to db
`make bind`

7. After the application pod is restarted, the application's pod is `Running` UI should show the web interface.
