### PR TITLE
Fixed exposed host binding item for databases provisioned by Cloud Native Postgres Operator

### DIFF
--- a/pkg/binding/registry/registry.go
+++ b/pkg/binding/registry/registry.go
@@ -59,7 +59,8 @@ func New() Registry {
 			},
 			schema.GroupVersionKind{Group: "postgresql.k8s.enterprisedb.io", Version: "v1", Kind: "Cluster"}: {
 				"service.binding/type":     "postgresql",
-				"service.binding/host":     "path={.metadata.name}",
+				"service.binding/host":     "path={.status.writeService}",
+				"service.binding/provider": "enterprisedb",
 				"service.binding":          "path={.metadata.name}-{.spec.bootstrap.initdb.owner},objectType=Secret",
 				"service.binding/database": "path={.spec.bootstrap.initdb.database}",
 			},

--- a/test/acceptance/features/steps/cloudnativepostgresoperator.py
+++ b/test/acceptance/features/steps/cloudnativepostgresoperator.py
@@ -7,6 +7,7 @@ class CloudNativePostgresOperator(Operator):
 
     def __init__(self, name="cloud-native-postgresql"):
         self.name = name
+        self.pod_name_pattern = "postgresql-operator-controller-manager.*"
         if ctx.cli == "oc":
             self.operator_catalog_source_name = "certified-operators"
         else:

--- a/test/acceptance/features/steps/generic_testapp.py
+++ b/test/acceptance/features/steps/generic_testapp.py
@@ -12,7 +12,7 @@ class GenericTestApp(App):
 
     deployment_name_pattern = "{name}"
 
-    def __init__(self, name, namespace, app_image="quay.io/service-binding/generic-test-app:20211112"):
+    def __init__(self, name, namespace, app_image="quay.io/service-binding/generic-test-app:20211209"):
         App.__init__(self, name, namespace, app_image, "8080")
 
     def get_env_var_value(self, name):
@@ -84,6 +84,11 @@ def check_file_value(context, file_path):
     value = Template(context.text.strip()).substitute(NAMESPACE=context.namespace.name)
     resource = substitute_scenario_id(context, file_path)
     polling2.poll(lambda: context.application.get_file_value(resource) == value, step=5, timeout=400)
+
+
+@step(u'Application can connect to the projected Postgres database')
+def postgres_can_connect(context):
+    check_file_exists(context, "/postgres-ready")
 
 
 @step(u'File "{file_path}" exists in application pod')

--- a/test/acceptance/features/supportExistingOperatorBackedServices.feature
+++ b/test/acceptance/features/supportExistingOperatorBackedServices.feature
@@ -277,9 +277,13 @@ Feature: Support a number of existing operator-backed services out of the box
            """
            postgresql
            """
+    And Content of file "/bindings/$scenario_id/provider" in application pod is
+           """
+           enterprisedb
+           """
     And Content of file "/bindings/$scenario_id/host" in application pod is
            """
-           postgres
+           postgres-rw
            """
     And Content of file "/bindings/$scenario_id/username" in application pod is
            """
@@ -290,6 +294,7 @@ Feature: Support a number of existing operator-backed services out of the box
            app
            """
     And File "/bindings/$scenario_id/password" exists in application pod
+    And Application can connect to the projected Postgres database
 
   Scenario: Bind test application to RabbitMQ instance provisioned by RabbitMq operator
     Given RabbitMQ operator is running

--- a/test/acceptance/resources/apps/sbo-generic-test-app/Dockerfile
+++ b/test/acceptance/resources/apps/sbo-generic-test-app/Dockerfile
@@ -4,6 +4,7 @@ RUN apk update && \
     apk add --no-cache \
     lighttpd \
     bash \
+    postgresql-client \
     jq && \
     rm -rf /var/cache/apk/*
 
@@ -12,6 +13,7 @@ RUN chmod -R go+rwx /run /var
 COPY conf/* /etc/lighthttpd/
 COPY start_http /bin/
 COPY env.sh /bin/
+COPY postgres-ready.sh /bin/
 
 EXPOSE 8080
 

--- a/test/acceptance/resources/apps/sbo-generic-test-app/README.md
+++ b/test/acceptance/resources/apps/sbo-generic-test-app/README.md
@@ -1,0 +1,10 @@
+Follow instructions on https://github.com/docker/buildx#building-multi-platform-images
+and https://docs.docker.com/buildx/working-with-buildx/
+
+Build and push with
+
+```shell
+docker buildx build --push \
+--platform "linux/amd64,linux/ppc64le,linux/arm64,linux/s390x" \
+-t quay.io/service-binding/generic-test-app:YYYYMMDD .
+```

--- a/test/acceptance/resources/apps/sbo-generic-test-app/conf/lighthttpd.conf
+++ b/test/acceptance/resources/apps/sbo-generic-test-app/conf/lighthttpd.conf
@@ -136,16 +136,27 @@ server.follow-symlink = "enable"
 server.modules = (
     "mod_access",
     "mod_alias",
-    "mod_cgi"
+    "mod_cgi",
+    "mod_setenv"
 )
+
 
 alias.url = (
     "/env" => "/tmp/env.json"
 )
 
+cgi.assign = ( ".sh" => "/bin/bash" )
+
 $HTTP["url"] =~ "^/env/(.+)$" {
   alias.url = ( "/env" => "/bin/env.sh" )
-  cgi.assign = ( ".sh" => "/bin/bash" )
+}
+
+$HTTP["url"] == "/postgres-ready" {
+  alias.url = ( "/postgres-ready" => "/bin/postgres-ready.sh" )
+  setenv.add-environment = (
+      "PATH" => env.PATH
+  )
+
 }
 
 mimetype.assign             = (

--- a/test/acceptance/resources/apps/sbo-generic-test-app/postgres-ready.sh
+++ b/test/acceptance/resources/apps/sbo-generic-test-app/postgres-ready.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Content-Type: text/plain"
+
+SERVICE_BINDING_ROOT=$(jq -r '.SERVICE_BINDING_ROOT // empty' /tmp/env.json)
+
+[ -z "$SERVICE_BINDING_ROOT" ] && echo -e "Status: 404 SERVICE_BINDING_ROOT Not Found\n" && exit
+
+for f in $(find $SERVICE_BINDING_ROOT -name type -type f); do
+  if [ $(cat $f) == "postgresql" ]; then
+    BINDING_DIR=$(dirname $f)
+    break
+  fi
+done
+
+[ -z "$BINDING_DIR" ] && echo -e "Status: 404 Postgres bindings Not Found\n" && exit
+
+PORT=5432
+[ -r "$BINDING_DIR/port" ] && PORT=$(cat $BINDING_DIR/port)
+
+psql postgresql://$(cat $BINDING_DIR/username):$(cat $BINDING_DIR/password)@$(cat $BINDING_DIR/host):$PORT/$(cat $BINDING_DIR/database) -c '\conninfo' >/tmp/psql 2>&1
+
+if [ $? != 0 ]; then
+  echo -e "Status: 500 cannot connect\n\n"
+  cat /tmp/psql
+else
+  echo -e "\nOK"
+fi


### PR DESCRIPTION
The appropriate database host name is stored in `.status.writeService` field, and it is NOT
equal to `Postgres` resource name.

Changes:
* servicebinding host annotation got updated
* added `provider` binding, the value is set to `enterprisedb`
* generic test application is extended with `/postgres-ready` endpoint that
returns `OK` if the connection to Postgres database can be established using the provided bindings
* New version of the test application got pushed to the registry for all supported arches
* Cloud Native Postgres acceptance test got update to assert the database connection

Fixes #1077 