### PR TITLE
Project certificates together with other Crunchy Postgres bindings

### DIFF
--- a/pkg/binding/registry/registry.go
+++ b/pkg/binding/registry/registry.go
@@ -23,9 +23,11 @@ func New() Registry {
 			},
 			schema.GroupVersionKind{Group: "postgres-operator.crunchydata.com", Version: "v1beta1", Kind: "PostgresCluster"}: {
 				"service.binding/type":     "postgresql",
+				"service.binding/provider": "crunchydata",
 				"service.binding":          "path={.metadata.name}-pguser-{.metadata.name},objectType=Secret",
 				"service.binding/database": "path={.metadata.name}-pguser-{.metadata.name},objectType=Secret,sourceKey=dbname",
 				"service.binding/username": "path={.metadata.name}-pguser-{.metadata.name},objectType=Secret,sourceKey=user",
+				"service.binding/cert":     "path={.metadata.name}-cluster-cert,objectType=Secret",
 			},
 			schema.GroupVersionKind{Group: "pxc.percona.com", Version: "v1-8-0", Kind: "PerconaXtraDBCluster"}: {
 				"service.binding/type":     "mysql",

--- a/test/acceptance/features/requirements.txt
+++ b/test/acceptance/features/requirements.txt
@@ -1,5 +1,5 @@
 behave==1.2.6
 requests==2.24.0
-polling2==0.4.6
+polling2==0.5.0
 PyYAML==5.4
 semver==2.13.0

--- a/test/acceptance/features/supportExistingOperatorBackedServices.feature
+++ b/test/acceptance/features/supportExistingOperatorBackedServices.feature
@@ -146,6 +146,10 @@ Feature: Support a number of existing operator-backed services out of the box
            """
            postgresql
            """
+    And Content of file "/bindings/$scenario_id/provider" in application pod is
+           """
+           crunchydata
+           """
     And Content of file "/bindings/$scenario_id/host" in application pod is
            """
            hippo-primary.$NAMESPACE.svc
@@ -159,6 +163,11 @@ Feature: Support a number of existing operator-backed services out of the box
            hippo
            """
     And File "/bindings/$scenario_id/password" exists in application pod
+    And File "/bindings/$scenario_id/ca.crt" exists in application pod
+    And File "/bindings/$scenario_id/tls.crt" exists in application pod
+    And File "/bindings/$scenario_id/tls.key" exists in application pod
+    And Application can connect to the projected Postgres database
+
 
   @crdv1beta1
   Scenario: Bind test application to Mysql provisioned by Percona Mysql operator


### PR DESCRIPTION
Crunchy operator provisions Postgres instances and creates at the same certificates that might be required for some clients.

* added service binding annotation for locating and exposing certificates
* acceptance test updated to assert if postgres connection can be really established
* acceptance test update to assert if the certifactes are projected
* added `provider` binding with value `crunchydata`
* fixed the bug in `test/acceptance/resources/apps/sbo-generic-test-app/postgres-ready.sh` - password can contain special characters and hence needs to be urlencoded before constructing Postgres connection url.
* `polling2` library updated to 0.5.0 so that polling decorator can be used to implement `assert_file_exist` method in `test/acceptance/features/steps/generic_testapp.py`

Related to #1078 