### PR TITLE
Upgrade cert manager from v1.1.0 to v1.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ uninstall: manifests kustomize
 
 .PHONY: deploy-cert-manager
 deploy-cert-manager:
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
+	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.0/cert-manager.yaml
 	kubectl rollout status -n cert-manager deploy/cert-manager-webhook -w --timeout=120s
 
 .PHONY: deploy


### PR DESCRIPTION
### Motivation

We need this to enable local testing on `minikube` clusters; cert-manager's `v1beta1` resources were deprecated.

### Changes

Updates the `deploy-cert-manager` make rule to use cert-manager v1.6.0.

### Testing

Deploy a cluster using `make deploy`.