### PR TITLE
Temporarily disable Cloud Native Postgres operator scenario for openshift 4.10

### DIFF
--- a/test/acceptance/features/supportExistingOperatorBackedServices.feature
+++ b/test/acceptance/features/supportExistingOperatorBackedServices.feature
@@ -236,6 +236,7 @@ Feature: Support a number of existing operator-backed services out of the box
            """
     And File "/bindings/$scenario_id/password" exists in application pod
 
+  @disable-openshift-4.10
   Scenario: Bind test application to Postgres instance provisioned by Cloud Native Postgres operator
     Given Cloud Native Postgres operator is running
     * Generic test application is running


### PR DESCRIPTION
### Motivation
Currently the Cloud Native Postgres operator is not available among certified operators for OpenShift 4.10 (since 4.10 is yet to be released) and so the respective scenario fails for all PRs.

### Changes
This PR:
* Along with https://github.com/openshift/release/pull/25188 this PR temporarily disables Cloud Native Postgres operator scenario for openshift 4.10

### Testing
PR checks