### PR TITLE
Avoid expression evaluation in the script

### DIFF
--- a/hack/prepare-operatorhub-pr.sh
+++ b/hack/prepare-operatorhub-pr.sh
@@ -16,7 +16,7 @@ rm -rf out/operatorhub-pr-files
 mkdir out/operatorhub-pr-files/service-binding-operator -p
 mv ${TMP_OCI_PATH}-unpacked/rootfs out/operatorhub-pr-files/service-binding-operator/$1
 
-cat <<EOD
+cat <<'EOD'
 Done.
 
 Now you can submit the content of out/operatorhub-pr-files/service-binding-operator


### PR DESCRIPTION
Ref.
https://stackoverflow.com/questions/22697688/how-to-cat-eof-a-file-containing-code

The `stable` text is getting evaluted and producing an error.
