### PR TITLE
Set channels to 'stable' for Operatorhub.io PR metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,8 +267,8 @@ release-operator: push-image push-bundle-image push-index-image
 .PHONY: prepare-operatorhub-pr
 ## prepare files for OperatorHub PR
 ## use this target when the operator needs to be released as upstream operator
-prepare-operatorhub-pr:
-	./hack/prepare-operatorhub-pr.sh $(VERSION) $(OPERATOR_BUNDLE_IMAGE_REF)
+prepare-operatorhub-pr: yq
+	PATH=$(PWD)/bin:$(PATH) ./hack/prepare-operatorhub-pr.sh $(VERSION) $(OPERATOR_BUNDLE_IMAGE_REF)
 
 .PHONY: deploy-from-index-image
 ## deploy the operator from a given index image

--- a/hack/prepare-operatorhub-pr.sh
+++ b/hack/prepare-operatorhub-pr.sh
@@ -3,6 +3,7 @@
 # Required CLIs
 # - https://github.com/opencontainers/umoci
 # - https://github.com/containers/skopeo
+# - github.com/mikefarah/yq
 
 # Usage:
 # prepare-operatorhu-pr.sh <version> <bundle-image-ref>
@@ -15,6 +16,9 @@ umoci unpack --image $TMP_OCI_PATH:bundle --rootless ${TMP_OCI_PATH}-unpacked
 rm -rf out/operatorhub-pr-files
 mkdir out/operatorhub-pr-files/service-binding-operator -p
 mv ${TMP_OCI_PATH}-unpacked/rootfs out/operatorhub-pr-files/service-binding-operator/$1
+
+yq eval -i '.annotations."operators.operatorframework.io.bundle.channel.default.v1" |= "stable"' out/operatorhub-pr-files/service-binding-operator/$1/metadata/annotations.yaml
+yq eval -i '.annotations."operators.operatorframework.io.bundle.channels.v1" |= "stable"' out/operatorhub-pr-files/service-binding-operator/$1/metadata/annotations.yaml
 
 cat <<'EOD'
 Done.


### PR DESCRIPTION
# Changes

Currently, when performing a release to Operatorhub.io a manual step is required to set the bundle channel to `stable` in the `metadata/annotations.yaml` file after `make prepare-operatorhub-pr` is executed (as described in [`docs/community-release.md`](https://github.com/redhat-developer/service-binding-operator/blob/40a4671acbbdcb0c80acc697d8525cfac2f3bfd9/docs/community-release.md#community-release)).

This PR:
* Modifies the `hack/prepare-operatorhub-pr.sh` script to set both the `operators.operatorframework.io.bundle.channel.default.v1` and `operators.operatorframework.io.bundle.channels.v1` to `stable` so that the above mentioned manual step is not required.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

