### PR TITLE
Use certified-operators catalog source for Crunchy Postgres Operator in acceptance tests

### DIFF
--- a/test/acceptance/features/steps/crunchypostgresoperator.py
+++ b/test/acceptance/features/steps/crunchypostgresoperator.py
@@ -8,11 +8,12 @@ class CrunchyPostgresOperator(Operator):
     def __init__(self, name="pgo"):
         self.name = name
         if ctx.cli == "oc":
-            self.operator_catalog_source_name = "community-operators"
+            self.operator_catalog_source_name = "certified-operators"
+            self.package_name = "crunchy-postgres-operator"
         else:
             self.operator_catalog_source_name = "operatorhubio-catalog"
+            self.package_name = "postgresql"
         self.operator_catalog_channel = "v5"
-        self.package_name = "postgresql"
 
 
 @given(u'Crunchy Data Postgres operator is running')


### PR DESCRIPTION
Currently, the Crunchy Postgres Operator in acceptance tests running on OpenShift uses `community-operators` catalog source to install the operator for testing.

The above operator is currently not available in `community-operators` catalog for not-yet-released OpenShift v4.10 which causes the `4.10-acceptance` to fail constantly.

However, the operator is available in the `certified-operators` catalog for all the tested version of OpenShift.

# Changes

This PR:
* Changes the catalog source from which the `Crunchy Postgres Operator` is installed for testing with OpenShift to `certified-operators`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

