### PR TITLE
Add LeaseDuration and RenewDeadline timeouts for operator

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"os"
 	"sync"
-
-	v1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	v1beta1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"time"
 
 	"github.com/redhat-developer/service-binding-operator/apis/webhooks"
+	v1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1beta1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 
 	crdcontrollers "github.com/redhat-developer/service-binding-operator/controllers/crd"
 
@@ -54,6 +54,10 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	// see https://github.com/operator-framework/operator-sdk/issues/1813
+	leaseDuration = 15 * time.Second
+	renewDeadline = 10 * time.Second
 )
 
 func init() {
@@ -112,6 +116,8 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "8fa65150.coreos.com",
+		LeaseDuration:          &leaseDuration,
+		RenewDeadline:          &renewDeadline,
 		Namespace:              watchNamespace,
 	})
 	if err != nil {


### PR DESCRIPTION
So... when deploying Service Binding Operator on a bare-metal
environment I'm running into THIS issue *a lot*:

https://github.com/operator-framework/operator-sdk/issues/1813

Why? Because my bare-metal cluster is running 100's of containers and
unfortunately it takes a while to get the leader. Usually it's within a
few seconds, but if there is some HDD usage, it'll take a little while.

What a lot of operator maintainers have done, is implemented the
LeaseDuration and RenewDeadline commands to the operator so that us
bare-metal people can increase the timeouts.

In this PR I have:
- Added this to the `main.go` file
- Set the default 30 / 20 second timeouts.

So that we have the ability to change the settings via a configmap /
yaml within k8s:
```yaml
    leaderElection:
      leaderElect: false
      resourceName: <example-domain>.io
      leaseDuration: "30s"
      renewDeadline: "20s"
```

This would have no impact on current functionality, but help those who
are experiencing high amount of restarts / CrashLoopback's of the
service binding operator pod:

```sh
$ k get pods -A
operators       pgo-f96b88c9d-z2nfx                                               1/1     Running                 0                 18h
operators       service-binding-operator-7795b785b4-wh265                         0/1     CrashLoopBackOff        225 (2m30s ago)   23h
```

And the output here:

```sh
{"level":"error","ts":1643209250.576585,"logger":"controller","msg":"Reconciler error","reconcilerGroup":"apiextensions.k8s.io","reconcilerKind":"CustomResourceDefinition","controller":"customresourcedefinition","name":"orders.acme.cert-manager.io","namespace":"","error":"no matches for kind \"Order\" in version \"acme.cert-manager.io/v1alpha2\"","stacktrace":"g$
thub.com/go-logr/zapr.(*zapLogger).Error\n\t/workspace/vendor/github.com/go-logr/zapr/zapr.go:132\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:246\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWork$
tem\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:218\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:197\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/workspace/vendor/k8s.io/apimachinery/$
kg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
E0126 15:00:50.850700       1 leaderelection.go:321] error retrieving resource lock operators/8fa65150.coreos.com: Get "https://10.96.0.1:443/api/v1/namespaces/operators/configmaps/8fa65150.coreos.com": context deadline exceeded
I0126 15:00:50.850783       1 leaderelection.go:278] failed to renew lease operators/8fa65150.coreos.com: timed out waiting for the condition
{"level":"info","ts":1643209250.8508487,"logger":"controller","msg":"Stopping workers","reconcilerGroup":"servicebinding.io","reconcilerKind":"ServiceBinding","controller":"servicebinding"}
{"level":"error","ts":1643209250.8508205,"logger":"setup","msg":"problem running manager","error":"leader election lost","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/workspace/vendor/github.com/go-logr/zapr/zapr.go:132\nmain.main\n\t/workspace/main.go:175\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:204"}
{"level":"info","ts":1643209250.8509405,"logger":"controller-runtime.webhook","msg":"shutting down webhook server"}
```

Which would fix:

Fixes https://github.com/redhat-developer/odo/issues/5396