### PR TITLE
Fix operator-sdk version  in merge-to-master GH action

### DIFF
--- a/.github/workflows/merge-to-master.yaml
+++ b/.github/workflows/merge-to-master.yaml
@@ -6,8 +6,7 @@ on:
       - master
 
 env:
-  SDK_VERSION: "1.3.0"
-  OPM_VERSION: "1.15.2"
+  SDK_VERSION: "1.16.0"
   GO111MODULE: on
   K8S_VERSION: "1.19.2"
   CONTAINER_RUNTIME: "docker"


### PR DESCRIPTION
Currently merge-to-master GH action fails to release the SBO to quay.io because of old version of operator-sdk (pre-#1094) used.

# Changes

Fixes merge-to-master GH action missed by #1094 

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, test, documentation, enhancement
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

