### PR TITLE
Remove the last usage of obsolete package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
 	github.com/operator-framework/api v0.3.8
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.22.1
 	k8s.io/apiextensions-apiserver v0.22.1

--- a/pkg/binding/annotationmapper.go
+++ b/pkg/binding/annotationmapper.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/pkg/errors"
 )
 
 type UnstructuredResourceReader func(namespace string, name string) (*unstructured.Unstructured, error)
@@ -92,7 +90,7 @@ func (m *annotationBackedDefinitionBuilder) Build() (Definition, error) {
 
 	mod, err := newModel(m.value)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not create binding model for annotation key %s and value %s", m.name, m.value)
+		return nil, fmt.Errorf("could not create binding model for annotation key %s and value %s: %w", m.name, m.value, err)
 	}
 
 	switch {

--- a/pkg/reconcile/pipeline/builder/pipeline_test.go
+++ b/pkg/reconcile/pipeline/builder/pipeline_test.go
@@ -1,9 +1,10 @@
 package builder_test
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/golang/mock/gomock"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
 	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline/builder"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,7 +128,6 @@ github.com/operator-framework/api/pkg/lib/version
 github.com/operator-framework/api/pkg/operators
 github.com/operator-framework/api/pkg/operators/v1alpha1
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
The github.com/pkg/errors package is no more maintaned:
https://github.com/pkg/errors/issues/245

Signed-off-by: Baiju Muthukadan <baiju.m.mail@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, test, documentation, enhancement
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

