### PR TITLE
Added Spring Petclinic Application Deployment  yaml compatible with MySQL and custom resource yaml for creating instance of PerconaXtraDB cluster

### DIFF
--- a/samples/apps/spring-petclinic/mysqlcluster-deployment.yaml
+++ b/samples/apps/spring-petclinic/mysqlcluster-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: pxc.percona.com/v1-10-0
+kind: PerconaXtraDBCluster
+metadata:
+  name: minimal-cluster
+spec:
+  crVersion: 1.10.0
+  secretsName: minimal-cluster-secrets
+  allowUnsafeConfigurations: true
+  upgradeOptions:
+    apply: 8.0-recommended
+    schedule: "0 4 * * *"
+  pxc:
+    size: 1
+    image: percona/percona-xtradb-cluster:8.0.23-14.1
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 6G
+  haproxy:
+    enabled: true
+    size: 1
+    image: perconalab/percona-xtradb-cluster-operator:main-haproxy
+  logcollector:
+    enabled: true
+    image: perconalab/percona-xtradb-cluster-operator:main-logcollector

--- a/samples/apps/spring-petclinic/petclinic-mysql-deployment.yaml
+++ b/samples/apps/spring-petclinic/petclinic-mysql-deployment.yaml
@@ -1,0 +1,46 @@
+---
+# tag::app-deployment[]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-petclinic
+  labels:
+    app: spring-petclinic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spring-petclinic
+  template:
+    metadata:
+      labels:
+        app: spring-petclinic
+    spec:
+      containers:
+        - name: app
+          image: quay.io/service-binding/spring-petclinic:latest
+          imagePullPolicy: Always
+          env:
+          - name: SPRING_PROFILES_ACTIVE
+            value: mysql
+          ports:
+          - name: http
+            containerPort: 8080
+# end::app-deployment[]
+---
+# tag::app-service[]
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: spring-petclinic
+  name: spring-petclinic
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: spring-petclinic
+# end::app-service[]


### PR DESCRIPTION
This PR adds  yaml files to samples/apps/spring-petclinic which are used to create spring petclinic application deployment compatible with mysql and also the custom resource yaml for creating instance of PerconaXtraDB cluster

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

