### PR TITLE
Include pod logs while collecting kube resources in GitHub actions

### DIFF
--- a/.github/actions/collect-kube-resources/action.yaml
+++ b/.github/actions/collect-kube-resources/action.yaml
@@ -32,6 +32,12 @@ runs:
           for res in $(cat resources.namespaced.list | grep -v secrets); do
             kubectl get ${res} --ignore-not-found -n ${ns} -o yaml > ${OUTPUT}/${res}.yaml;
           done
+          mkdir -p $OUTPUT/pod;
+          for p in $(kubectl get pods -n ${ns} -o name); do
+            for c in $(kubectl get $p -n ${ns} -o jsonpath='{.spec.containers[].name}'); do
+              kubectl logs -n ${ns} $p -c $c > $OUTPUT/$p.$c.log;
+            done;
+          done;
           find ${OUTPUT} -size 0 -delete
         done
 
@@ -42,6 +48,12 @@ runs:
           for res in $(cat resources.namespaced.list); do
             kubectl get ${res} --ignore-not-found -n ${ns} -o yaml > ${OUTPUT}/${res}.yaml;
           done
+          mkdir -p $OUTPUT/pod;
+          for p in $(kubectl get pods -n ${ns} -o name); do
+            for c in $(kubectl get $p -n ${ns} -o jsonpath='{.spec.containers[].name}'); do
+              kubectl logs -n ${ns} $p -c $c > $OUTPUT/$p.$c.log;
+            done;
+          done;
           find ${OUTPUT} -size 0 -delete
         fi
 


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

# Changes

Currently, in GitHub actions for acceptance testing PR checks a set of kube resources is collected and archived for possible debugging or failures analysis. What is missing and can be quite useful are the actual Pod logs.

This PR:
 * Modifies the `./.github/actions/collect-kube-resources` GH action to collect and include logs from Pods in operator and test namespaces.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

