### PR TITLE
Disable scenarios for architectures other then amd64

### DIFF
--- a/test/acceptance/features/gettingStartedGuide.feature
+++ b/test/acceptance/features/gettingStartedGuide.feature
@@ -21,6 +21,9 @@ Feature: Getting Started Guide
     * Service Binding is deleted
 
   @olm
+  @disable.arch.ppc64le
+  @disable.arch.s390x
+  @disable.arch.arm64
   Scenario: Connecting PetClinic application to an Operator-backed PostgreSQL database
     Given Crunchy Data Postgres operator is running
     * PetClinic sample application is installed

--- a/test/acceptance/features/supportExistingOperatorBackedServices.feature
+++ b/test/acceptance/features/supportExistingOperatorBackedServices.feature
@@ -1,5 +1,8 @@
 @olm
 @supported-operator
+@disable.arch.ppc64le
+@disable.arch.s390x
+@disable.arch.arm64
 Feature: Support a number of existing operator-backed services out of the box
 
   As a user of Service Binding operator


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

# Changes

Currently, all acceptance tests assume that SBO to be installed in Kubernetes or OpenShift clusters deployed on `amd64` machines.

While SBO itself can run on the alternative architectures, some of the acceptance tests scenarios cannot.

This PR:
* Introduces tags to diable scenarios/feature for various alternative architectures (`@disable.arch.ppc64le`, `@disable.arch.s390x`, `@disable.arch.arm64`)
* Marks scenarios that cannot run on respective architectures with those tags.

To disable those scenarios, append the following into `EXTRA_BEHAVE_ARGS` env variable for that acceptance test run: 
```
EXTRA_BEHAVE_ARGS="... --tags=~@disable.arch.<arch> ..."
```

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

