### PR TITLE
This is our PostgreSQL Service Endpoint Definition (SED)

### DIFF
--- a/charts/seds/psql-sed/.helmignore
+++ b/charts/seds/psql-sed/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/seds/psql-sed/Chart.yaml
+++ b/charts/seds/psql-sed/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: psql-sed
+description: A Helm chart for PostgreSQL Service Endpoint Definition (SED)
+
+
+type: application
+
+version: 1.0.0
+
+
+appVersion: "1.0.0"
+
+kubeVersion: ">=1.20.0"
+
+annotations:
+  charts.openshift.io/provider: RedHat
+  charts.openshift.io/name: PostgreSQL Service Endpoint Definition (SED)
+  charts.openshift.io/supportURL: https://github.com/dperaza4dustbit/helm-chart
+  charts.openshift.io/archs: x86_64

--- a/charts/seds/psql-sed/README.md
+++ b/charts/seds/psql-sed/README.md
@@ -1,0 +1,9 @@
+This helm chart defines a PostgreSQL Service Endpoint Definition (SED). When the SED is installed it will provide the user with the oportunity to provide connection information as well as credentials to authenticate. The following are the values that can be customized when the SED chart is installed:
+
+1. Hostname
+1. Port
+1. Username
+1. Password
+1. Databasename
+
+The SED Chart will render a secret with the connection information. This secret is compliant with the Service Binding Specification [Well Known Secret Entries](https://github.com/servicebinding/spec#well-known-secret-entries). Therefore, the secret rendered by PostgreSQL SED Chart is a bindable service endpoint that can be projected to workloads using the Service [Binding Direct Secret Reference](https://github.com/servicebinding/spec#well-known-secret-entries).

--- a/charts/seds/psql-sed/templates/_helpers.tpl
+++ b/charts/seds/psql-sed/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ssm-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ssm-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ssm-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ssm-service.labels" -}}
+helm.sh/chart: {{ include "ssm-service.chart" . }}
+{{ include "ssm-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ssm-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ssm-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ssm-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ssm-service.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/seds/psql-sed/templates/sed.yaml
+++ b/charts/seds/psql-sed/templates/sed.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "io.servicebinding.{{ .Release.Name }}"
+type: servicebinding.io/postgresql
+stringData:
+  type: postgresql
+  provider: redhat
+  host: "{{ .Values.postgresql.sed.hostname }}"
+  port: {{ .Values.postgresql.sed.port | quote }}
+  username: "{{ .Values.postgresql.sed.username }}"
+  password: "{{ .Values.postgresql.sed.password }}"
+  database: "{{ .Values.postgresql.sed.databasename }}"

--- a/charts/seds/psql-sed/templates/tests/test-psql-connection.yaml
+++ b/charts/seds/psql-sed/templates/tests/test-psql-connection.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-sed-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: "{{ .Release.Name }}-sed-test"
+      image: "registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest"
+      imagePullPolicy: "IfNotPresent"
+      env:
+        - name: POSTGRESQL_HOST
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: host
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: username
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: password
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: database
+        - name: PSQL_SERVICE_PORT
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: port
+      command:
+        - /bin/bash
+        - -ec
+        - |
+          psql -d $POSTGRESQL_DATABASE -h $POSTGRESQL_HOST -p $PSQL_SERVICE_PORT -U $POSTGRESQL_USER -c "select 1"
+  restartPolicy: Never

--- a/charts/seds/psql-sed/values.schema.json
+++ b/charts/seds/psql-sed/values.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": [
+    "postgresql"
+  ],
+  "properties": {
+    "postgresql": {
+      "type": "object",
+      "required": [
+        "sed"
+      ],
+      "properties": {
+        "sed": {
+          "type": "object",
+          "required": [
+            "hostname",
+            "port",
+            "username",
+            "password",
+            "databasename"
+          ],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "password": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "databasename": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/seds/psql-sed/values.yaml
+++ b/charts/seds/psql-sed/values.yaml
@@ -1,0 +1,7 @@
+postgresql:
+  sed:
+    hostname: myhostname
+    port: 5432
+    username: myuser
+    password: mypassword
+    databasename: mydatabase


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This SED can be used in cases where the service was provisioned
either manually or via a Helm Chart. It will allow developer to
test their binding data in a standard manner regardless of how the
PostgreSQL database was provisioned or the backend cloud. The
assumption here is that there is no CR representing the service in
kubernetes.

/kind enhancement

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

