### PR TITLE
Tag acceptance testing scenarios that are a result of external users' feedback

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,5 +20,6 @@ As the author of this PR, please check off the items in this checklist:
   included if any changes are user facing
 - [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
   included if any functionality added or changed. For bugfixes please include tests that can catch regressions
+- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
 - [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)
 

--- a/test/acceptance/features/bindAppToMultipleServices.feature
+++ b/test/acceptance/features/bindAppToMultipleServices.feature
@@ -8,6 +8,7 @@ Feature: Bind a single application to multiple services
         * Service Binding Operator is running
         * CustomResourceDefinition backends.stable.example.com is available
 
+    @external-feedback
     Scenario: Bind two backend services by creating 2 SBRs to a single application
         Given Generic test application is running
         * The Custom Resource is present
@@ -79,6 +80,7 @@ Feature: Bind a single application to multiple services
         And The application got redeployed 2 times so far
         And The application does not get redeployed again with 5 minutes
 
+    @external-feedback
     Scenario: Bind two backend services by creating 1 SBR to a single application
         Given Generic test application is running
         * The Custom Resource is present

--- a/test/acceptance/features/bindAppToProvisionedService.feature
+++ b/test/acceptance/features/bindAppToProvisionedService.feature
@@ -52,6 +52,7 @@ Feature: Bind application to provisioned service
                     name: provisioned-secret-2
             """
 
+  @external-feedback
   Scenario: Bind application to provisioned service
     Given Generic test application is running
     When Service Binding is applied
@@ -84,6 +85,7 @@ Feature: Bind application to provisioned service
             """
 
   @openshift
+  @external-feedback
   Scenario: Bind provisioned service to application deployed as deployment config
     Given Generic test application is running as deployment config
     When Service Binding is applied
@@ -117,6 +119,7 @@ Feature: Bind application to provisioned service
 
 
   @negative
+  @external-feedback
   Scenario: Fail binding to provisioned service if secret name is not provided
     Given The Custom Resource Definition is present
             """
@@ -187,6 +190,7 @@ Feature: Bind application to provisioned service
     And jq ".status.conditions[] | select(.type=="Ready").status" of Service Binding should be changed to "False"
     And jq ".status.conditions[] | select(.type=="CollectionReady").reason" of Service Binding should be changed to "ErrorReadingBinding"
 
+  @external-feedback
   Scenario: Bind application to provisioned service that has binding annotations as well
     Given OLM Operator "provisioned_backend_with_annotations" is running
     * The Custom Resource is present
@@ -238,6 +242,7 @@ Feature: Bind application to provisioned service
 
   @spec
   @smoke
+  @external-feedback
   Scenario: SPEC Bind application to provisioned service
     Given Generic test application is running
     When Service Binding is applied
@@ -272,6 +277,7 @@ Feature: Bind application to provisioned service
             """
 
   @spec
+  @external-feedback
   Scenario: SPEC Bind application to provisioned service and inject type/provider from values set on service binding
     Given Generic test application is running
     When Service Binding is applied
@@ -311,6 +317,7 @@ Feature: Bind application to provisioned service
             """
 
   @spec
+  @external-feedback
   Scenario: SPEC Bind application to provisioned service and inject binding into folder specified by .spec.name
     Given Generic test application is running
     When Service Binding is applied
@@ -382,6 +389,7 @@ Feature: Bind application to provisioned service
 
 
   @spec
+  @external-feedback
   Scenario: SPEC Inject specified bindings as env vars
     Given Generic test application is running
     When Service Binding is applied

--- a/test/acceptance/features/bindAppToService.feature
+++ b/test/acceptance/features/bindAppToService.feature
@@ -566,6 +566,7 @@ Feature: Bind an application to a service
         And The application env var "BACKEND_PORTS_FTP" has value "22"
         And The application env var "BACKEND_PORTS_TCP" has value "8080"
 
+    @external-feedback
     Scenario: Custom environment variable is injected into the application under the declared name ignoring global and service env prefix
         Given Generic test application is running
         * CustomResourceDefinition backends.stable.example.com is available
@@ -924,6 +925,7 @@ Feature: Bind an application to a service
         And The application env var "SECRET_WORD" has value "aGVsbG8="
 
     @negative
+    @external-feedback
     Scenario: Do not bind as env if there is no binding data is collected from the service
         Given Generic test application is running
         * The Service is present

--- a/test/acceptance/features/bindAppToServiceAnnotations.feature
+++ b/test/acceptance/features/bindAppToServiceAnnotations.feature
@@ -561,6 +561,7 @@ Feature: Bind an application to a service using annotations
         Then Service Binding is ready
         And The application env var "BACKEND_HOST_INTERNAL_DB" has value "internal.db.stable.example.com"
 
+    @external-feedback
     Scenario: Application cannot be bound to service containing annotation with an invalid sourceValue value
         Given Generic test application is running
         And CustomResourceDefinition backends.stable.example.com is available

--- a/test/acceptance/features/bindAppToServiceUsingSecret.feature
+++ b/test/acceptance/features/bindAppToServiceUsingSecret.feature
@@ -515,6 +515,7 @@ Feature: Bind values from a secret referred in backing service resource
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
+    @external-feedback
     Scenario: Inject into app all keys from a secret existing in a same namespace with service and different from the service binding
         Given The Custom Resource Definition is present
             """
@@ -606,6 +607,7 @@ Feature: Bind values from a secret referred in backing service resource
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond"
         And The application env var "BACKEND_PASSWORD" has value "hunter2"
 
+    @external-feedback
     Scenario: Inject data from secret referred in field belonging to list
         Given The Secret is present
             """
@@ -745,6 +747,7 @@ Feature: Bind values from a secret referred in backing service resource
             bar
             """
 
+    @external-feedback
     Scenario: Inject binding to an application from a Secret resource referred as service with mappings
         Given The Secret is present
             """
@@ -795,6 +798,7 @@ Feature: Bind values from a secret referred in backing service resource
             foo:bar
             """
 
+    @external-feedback
     Scenario: Inject binding to an application from a Secret resource created later referred as service 
         Given Generic test application is running
         When Service Binding is applied
@@ -837,6 +841,7 @@ Feature: Bind values from a secret referred in backing service resource
             bar
             """
 
+    @external-feedback
     Scenario: Inject binding to an application from two Secret resources referred as services
         Given Generic test application is running
         * The Secret is present
@@ -899,7 +904,9 @@ Feature: Bind values from a secret referred in backing service resource
             bar2
 
             """
+
     @spec
+    @external-feedback
     Scenario: SPEC Inject binding to an application from a Secret resource referred as service
         Given The Secret is present
             """

--- a/test/acceptance/features/discoverBindableResources.feature
+++ b/test/acceptance/features/discoverBindableResources.feature
@@ -6,6 +6,8 @@ Feature: Discover bindable resources in a cluster
     Background:
         Given Namespace [TEST_NAMESPACE] is used
         And Service Binding Operator is running
+
+    @external-feedback
     Scenario: Discover the list of bindable kinds by reading status part of cluster-scoped BindableKinds resource
         Given OLM Operator "provisioned_backend_with_annotations" is running
         And OLM Operator "backend_with_annotations" is running
@@ -15,6 +17,7 @@ Feature: Discover bindable resources in a cluster
         And Kind BindableBackend with apiVersion stable.example.com/v1 is listed in bindable kinds
 
     @crdv1beta1
+    @external-feedback
     Scenario: Discover bindable service when defined by v1beta1 CRD API
         Given OLM Operator "provisioned_backend_crdv1beta1" is running
         Then bindablekinds/bindable-kinds is available in the cluster

--- a/test/acceptance/features/gettingStartedGuide.feature
+++ b/test/acceptance/features/gettingStartedGuide.feature
@@ -7,6 +7,7 @@ Feature: Getting Started Guide
     Given Namespace [TEST_NAMESPACE] is used
     * Service Binding Operator is running
 
+  @external-feedback
   Scenario: Connecting PetClinic application to PostgreSQL database
     Given PetClinic sample application is installed
     * PostgreSQL database is running

--- a/test/acceptance/features/immutableBindings.feature
+++ b/test/acceptance/features/immutableBindings.feature
@@ -59,6 +59,7 @@ Feature: Successful Service Binding are Immutable
                     name: service-immutable
             """
 
+    @external-feedback
     Scenario: Can update metadata on a ready Service Binding
         Given Generic test application is running
         And Service Binding is applied

--- a/test/acceptance/features/injectBindingsAsFiles.feature
+++ b/test/acceptance/features/injectBindingsAsFiles.feature
@@ -158,6 +158,7 @@ Feature: Bindings get injected as files in application
         * Service Binding InjectionReady.reason is "NoBindingData"
 
     @spec
+    @external-feedback
     Scenario: SPEC Inject bindings gathered through annotations into application at default location
         Given Generic test application is running
         * The Custom Resource is present
@@ -206,6 +207,7 @@ Feature: Bindings get injected as files in application
             mysql
             """
 
+    @external-feedback
     Scenario: SERVICE_BINDING_ROOT is not defined twice in the deployment after binding two services
         Given Generic test application is running
         * The env var "SERVICE_BINDING_ROOT" is not available to the application

--- a/test/acceptance/features/supportExistingOperatorBackedServices.feature
+++ b/test/acceptance/features/supportExistingOperatorBackedServices.feature
@@ -89,6 +89,7 @@ Feature: Support a number of existing operator-backed services out of the box
            redisSecret!
            """
 
+  @external-feedback
   Scenario: Bind test application to Postgres provisioned by Crunchy Data Postgres operator
     Given Crunchy Data Postgres operator is running
     * Generic test application is running
@@ -319,6 +320,7 @@ Feature: Support a number of existing operator-backed services out of the box
            """
     And File "/bindings/$scenario_id/password" exists in application pod
 
+  @external-feedback
   Scenario: Bind test application to Postgres instance provisioned by Cloud Native Postgres operator
     Given Cloud Native Postgres operator is running
     * Generic test application is running

--- a/test/acceptance/features/unbindAppToService.feature
+++ b/test/acceptance/features/unbindAppToService.feature
@@ -107,6 +107,7 @@ Feature: Unbind an application from a service
         * The env var "BACKEND_USERNAME" is not available to the application
         * Service Binding secret is not present
 
+    @external-feedback
     Scenario: Remove bindings projected as files from generic test application
         Given Generic test application is running
         * The Custom Resource is present
@@ -195,6 +196,7 @@ Feature: Unbind an application from a service
 
     @smoke
     @spec
+    @external-feedback
     Scenario: SPEC Remove bindings from test application
         Given Generic test application is running
         * The Custom Resource is present


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

# Changes

This PR:
* Adds the `@external-feedback` tag to the acceptance scenarios that has been added as a result of an external feedback such as a bug report (to verify that the bug was fixed) or a feature request (to ensure the feature's behavior is as expected).
* Adds an item to the Submitter Checklist in the PR template to ensure that `All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with "@external-feedback" tag.`

This would allow to measure the amount of QE adoption of the external feedback in terms or (number of scenarios based on external feedback)/(number of all scenarios) and so the quality maturity.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

