### PR TITLE
This is our MongoDB Service Endpoint Definition(SED)

### DIFF
--- a/charts/seds/.helmignore
+++ b/charts/seds/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/seds/mongo-sed/Chart.yaml
+++ b/charts/seds/mongo-sed/Chart.yaml
@@ -1,0 +1,11 @@
+annotations:
+  charts.openshift.io/archs: x86_64
+  charts.openshift.io/name: MongoDB Service Endpoint Definition (SED)
+  charts.openshift.io/provider: RedHat
+apiVersion: v2
+appVersion: 1.0.0
+description: A Helm chart for MongoDB Service Endpoint Definition (SED)
+kubeVersion: '>=1.20.0'
+name: mongo-sed
+type: application
+version: 1.0.0

--- a/charts/seds/mongo-sed/README.md
+++ b/charts/seds/mongo-sed/README.md
@@ -1,0 +1,9 @@
+This helm chart defines a MongoDB Service Endpoint Definition (SED). When the SED is installed it will provide the user with the oportunity to provide connection information as well as credentials to authenticate. The following are the values that can be customized when the SED chart is installed:
+
+1. Hostname
+1. Port
+1. Username
+1. Password
+1. Databasename
+
+The SED Chart will render a secret with the connection information. This secret is compliant with the Service Binding Specification [Well Known Secret Entries](https://github.com/servicebinding/spec#well-known-secret-entries). Therefore, the secret rendered by MongoDB SED Chart is a bindable service endpoint that can be projected to workloads using the Service [Binding Direct Secret Reference](https://github.com/servicebinding/spec#well-known-secret-entries).

--- a/charts/seds/mongo-sed/templates/_helpers.tpl
+++ b/charts/seds/mongo-sed/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mysqlsecret.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mysqlsecret.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mysqlsecret.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mysqlsecret.labels" -}}
+helm.sh/chart: {{ include "mysqlsecret.chart" . }}
+{{ include "mysqlsecret.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mysqlsecret.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mysqlsecret.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mysqlsecret.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mysqlsecret.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/seds/mongo-sed/templates/sed.yaml
+++ b/charts/seds/mongo-sed/templates/sed.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name:  "io.servicebinding.{{ .Release.Name }}"
+type: servicebinding.io/mongodb
+stringData:
+  type: mongodb
+  provider: redhat
+  host: "{{ .Values.mongodb.sed.hostname }}"
+  port: {{ .Values.mongodb.sed.port | quote }}
+  username: "{{ .Values.mongodb.sed.username }}"
+  password: "{{ .Values.mongodb.sed.password }}"
+  database: "{{ .Values.mongodb.sed.databasename }}"

--- a/charts/seds/mongo-sed/templates/tests/test-mongodb-connection.yaml
+++ b/charts/seds/mongo-sed/templates/tests/test-mongodb-connection.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-sed-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: "{{ .Release.Name }}-sed-test"
+      image: "quay.io/opencloudio/ibm-mongodb@sha256:d8af61f68bce9ce744dd0b6b1734ba9a6cd4d85cd28baa5798b7470256be6dce"
+      imagePullPolicy: "IfNotPresent"
+      env:
+        - name: MONGODB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: host
+        - name: MONGODB_USER
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: username
+        - name: MONGODB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: password
+        - name: MONGODB_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: database
+        - name: MONGODB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: port
+      command:
+        - /bin/bash
+        - -ec
+        - |
+          mongo admin --host $MONGODB_HOST --authenticationDatabase $MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD
+  restartPolicy: Never

--- a/charts/seds/mongo-sed/values.schema.json
+++ b/charts/seds/mongo-sed/values.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": [
+    "mongodb"
+  ],
+  "properties": {
+    "mongodb": {
+      "type": "object",
+      "required": [
+        "sed"
+      ],
+      "properties": {
+        "sed": {
+          "type": "object",
+          "required": [
+            "hostname",
+            "port",
+            "username",
+            "password",
+            "databasename"
+          ],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "password": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9-_./]+$"
+            },
+            "databasename": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/seds/mongo-sed/values.yaml
+++ b/charts/seds/mongo-sed/values.yaml
@@ -1,0 +1,8 @@
+mongodb:
+  sed:
+    hostname: mymongo-mongodb
+    port: 27017
+    username: root
+    password: PCfT5MLN4Q
+    databasename: admin
+


### PR DESCRIPTION
This SED can be used in cases where the service was provisioned
either manually or via a Helm Chart. It will allow developer to
test their binding data in a standard manner regardless of how the
MongoDB database was provisioned or the backend cloud. The
assumption here is that there is no CR representing the service in
kubernetes.
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

