### PR TITLE
Re-enable Cloud Native Postgres operator scenario for openshift 4.10 and switch catalog source to Operatorhub.io

### DIFF
--- a/test/acceptance/features/steps/cloudnativepostgresoperator.py
+++ b/test/acceptance/features/steps/cloudnativepostgresoperator.py
@@ -8,11 +8,9 @@ class CloudNativePostgresOperator(Operator):
     def __init__(self, name="cloud-native-postgresql"):
         self.name = name
         self.pod_name_pattern = "postgresql-operator-controller-manager.*"
-        if ctx.cli == "oc":
-            self.operator_catalog_source_name = "certified-operators"
-        else:
-            self.operator_catalog_source_name = "operatorhubio-catalog"
+        self.operator_catalog_source_name = "operatorhubio-catalog"
         self.operator_catalog_channel = "stable"
+        self.operator_catalog_image = "quay.io/operatorhubio/catalog:latest"
         self.package_name = name
 
 
@@ -20,6 +18,8 @@ class CloudNativePostgresOperator(Operator):
 def install(_context):
     operator = CloudNativePostgresOperator()
     if not operator.is_running():
+        if ctx.cli == "oc":
+            operator.install_catalog_source()
         operator.install_operator_subscription()
         operator.is_running(wait=True)
     print("Cloud Native Postgres operator is running")

--- a/test/acceptance/features/supportExistingOperatorBackedServices.feature
+++ b/test/acceptance/features/supportExistingOperatorBackedServices.feature
@@ -319,7 +319,6 @@ Feature: Support a number of existing operator-backed services out of the box
            """
     And File "/bindings/$scenario_id/password" exists in application pod
 
-  @disable-openshift-4.10
   Scenario: Bind test application to Postgres instance provisioned by Cloud Native Postgres operator
     Given Cloud Native Postgres operator is running
     * Generic test application is running


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

# Changes

Currently the Cloud Native Postgres operator is not available among certified operators for OpenShift 4.10 and 4.11 and so the respective scenario fails for all PRs.

This PR:
* Changes the catalog source to install Cloud Native Postgres operator from to [Operatorhub.io](https://operatorhub.io/operator/cloud-native-postgresql)
* Re-enables Cloud Native Postgres operator scenario for OpenShift 4.10

### Testing
PR checks

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

