### PR TITLE
Add check for single commit PR

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -283,3 +283,22 @@ jobs:
           name: kubernetes-without-olm-test-results
           path: ${{ env.TEST_RESULTS }}
         if: always()
+
+  single-commit:
+    name: Single commit PR
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Verify number of commits in the PR is 1
+        run: |
+          COMMIT_COUNT="$(git log --oneline ${{github.event.pull_request.base.sha}}..${{github.event.pull_request.head.sha}} | wc -l)"
+          if ! [ $COMMIT_COUNT -eq 1 ]; then
+            echo "Number of commits in the PR ($COMMIT_COUNT) must not be greater than one."
+            echo "Please squash all PR commits into a single one (https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)"
+            exit 1
+          fi


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

# Changes

Currently, we encourage contributors to keep PRs with a single commit. For instance:
* https://github.com/redhat-developer/service-binding-operator/pull/1079#pullrequestreview-825251177
* https://github.com/redhat-developer/service-binding-operator/pull/1074#pullrequestreview-807109474
* https://github.com/redhat-developer/service-binding-operator/pull/1064#pullrequestreview-788323390
* ...

This PR:
* Introduces a simple PR check to verify automatically that a PR does not have more than 1 commit.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

