### PR TITLE
Add missing manifest and make targets for MySQL Cluster Sample

### DIFF
--- a/samples/apps/spring-petclinic/Makefile
+++ b/samples/apps/spring-petclinic/Makefile
@@ -25,6 +25,10 @@ deploy-postgresql:
 deploy-pgcluster:
 	kubectl apply -f pgcluster-deployment.yaml -n $(NAMESPACE)
 
+.PHONY: deploy-mysqlcluster
+deploy-mysqlcluster:
+	kubectl apply -f mysqlcluster-deployment.yaml -n $(NAMESPACE)
+
 .PHONY: build-app
 build-app:
 	docker build -f Dockerfile.app -t $(PETCLINIC_APP_IMAGE) .
@@ -46,6 +50,11 @@ deploy-app:
 	sed -e 's,quay.io/service-binding/spring-petclinic:latest,'$(PETCLINIC_APP_IMAGE)',g' petclinic-deployment.yaml | \
 	kubectl apply -f - -n $(NAMESPACE) --wait
 
+.PHONY: deploy-app-mysql
+deploy-app-mysql:
+	sed -e 's,quay.io/service-binding/spring-petclinic:latest,'$(PETCLINIC_APP_IMAGE)',g' petclinic-mysql-deployment.yaml | \
+	kubectl apply -f - -n $(NAMESPACE) --wait
+
 .PHONY: bind-postgresql
 bind-postgresql:
 	kubectl apply -f petclinic-postgresql-binding.yaml -n $(NAMESPACE)
@@ -54,6 +63,10 @@ bind-postgresql:
 bind-pgcluster:
 	kubectl apply -f petclinic-pgcluster-binding.yaml -n $(NAMESPACE)
 
+.PHONY: bind-mysqlcluster
+bind-mysqlcluster:
+	kubectl apply -f petclinic-mysqlcluster-binding.yaml -n $(NAMESPACE)
+
 .PHONY: unbind-postgresql
 unbind-postgresql:
 	kubectl delete -f petclinic-postgresql-binding.yaml -n $(NAMESPACE)
@@ -61,3 +74,7 @@ unbind-postgresql:
 .PHONY: unbind-pgcluster
 unbind-pgcluster:
 	kubectl delete -f petclinic-pgcluster-binding.yaml -n $(NAMESPACE)
+
+.PHONY: unbind-mysqlcluster
+unbind-mysqlcluster:
+	kubectl delete -f petclinic-mysqlcluster-binding.yaml -n $(NAMESPACE)

--- a/samples/apps/spring-petclinic/petclinic-mysqlcluster-binding.yaml
+++ b/samples/apps/spring-petclinic/petclinic-mysqlcluster-binding.yaml
@@ -1,0 +1,18 @@
+# tag::service-binding[]
+apiVersion: binding.operators.coreos.com/v1alpha1
+kind: ServiceBinding
+metadata:
+  name:
+    spring-petclinic-mysqlcluster
+spec:
+  services:
+    - group: pxc.percona.com
+      version: v1-10-0
+      kind: PerconaXtraDBCluster
+      name: minimal-cluster
+  application:
+    name: spring-petclinic
+    group: apps
+    version: v1
+    resource: deployments
+# end::service-binding[]


### PR DESCRIPTION
issue: #1124


# Changes

Added petclinic-mysqlcluster-binding.yaml containing a manifest for the ServiceBinding.
Added the following  make targets:
- deploy-mysqlcluster: to create the cluster
- deploy-app-mysql: to create the modified Spring-Petclinic Application
- bind-mysqlcluster: to create the ServiceBinding
- unbind-mysqlcluster: to delete the ServiceBinding



# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [X] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [X] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

