### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -228,6 +228,11 @@ jobs:
         with:
           start-minikube: true
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16"
+
       - name: Setup umoci cli
         run: |
           curl -Lo umoci https://github.com/opencontainers/umoci/releases/download/v${UMOCI_VERSION}/umoci.amd64

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ lint-go-code: $(GOLANGCI_LINT_BIN) fmt vet
 	$(Q)GOFLAGS="$(GOFLAGS)" GOCACHE="$(GOCACHE)" $(OUTPUT_DIR)/golangci-lint ${V_FLAG} run --deadline=30m
 
 $(GOLANGCI_LINT_BIN):
-	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.44.0
+	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.45.2
 
 .PHONY: lint-python-code
 ## Check the python code

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -88,37 +88,37 @@ gen-mocks: mockgen
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen:
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0)
 
 # Download kustomize locally if necessary
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize:
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
-define go-get-tool
+# go-install-tool will 'go install' any package $2 and install it to $1.
+define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef
 
 YQ = $(shell pwd)/bin/yq
 yq:
-	$(call go-get-tool,$(YQ),github.com/mikefarah/yq/v4@v4.9.8)
+	$(call go-install-tool,$(YQ),github.com/mikefarah/yq/v4@v4.9.8)
 
 KUBECTL_SLICE = $(shell pwd)/bin/kubectl-slice
 kubectl-slice:
-	$(call go-get-tool,$(KUBECTL_SLICE),github.com/patrickdappollonio/kubectl-slice@v1.1.0)
+	$(call go-install-tool,$(KUBECTL_SLICE),github.com/patrickdappollonio/kubectl-slice@v1.1.0)
 
 MOCKGEN = $(shell pwd)/bin/mockgen
 mockgen:
-	$(call go-get-tool,$(MOCKGEN),github.com/golang/mock/mockgen@v1.6.0)
+	$(call go-install-tool,$(MOCKGEN),github.com/golang/mock/mockgen@v1.6.0)
 
 .PHONY: opm
 OPM =  $(shell pwd)/bin/opm

--- a/pkg/naming/naming.go
+++ b/pkg/naming/naming.go
@@ -11,7 +11,7 @@ var TemplateError = errors.New("please check the namingStrategy template provide
 
 var templateFunctions = map[string]interface{}{
 	"upper": strings.ToUpper,
-	"title": strings.Title,
+	"title": strings.Title, //nolint
 	"lower": strings.ToLower,
 }
 

--- a/pkg/reconcile/pipeline/context/service/service_test.go
+++ b/pkg/reconcile/pipeline/context/service/service_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Service", func() {
 				}
 				ul := &unstructured.UnstructuredList{}
 				// compute kind
-				kind := strings.Title(gvr.Resource)[:len(gvr.Resource)-1]
+				kind := strings.Title(gvr.Resource)[:len(gvr.Resource)-1] //nolint
 
 				gvk := gvr.GroupVersion().WithKind(kind)
 				ou := resource(gvk, "child1", ns, id)
@@ -178,7 +178,7 @@ var _ = Describe("Service", func() {
 			for _, gvr := range bindableResourceGVRs {
 				ul := &unstructured.UnstructuredList{}
 				// compute kind
-				kind := strings.Title(gvr.Resource)[:len(gvr.Resource)-1]
+				kind := strings.Title(gvr.Resource)[:len(gvr.Resource)-1] //nolint
 				// fix for ConfigMap
 				if kind == "Configmap" {
 					kind = "ConfigMap"


### PR DESCRIPTION
# Changes

/kind bug

In commit ea79796cb ("update to operator-sdk 1.3.0 (#848)"), we upgraded controller-gen to 0.8.0.  However, v0.8.0 requires go 1.17 or greater, which is currently unavailable in Red Hat's container registries (i.e. there's no container on catalog.redhat.com); consequently, SBO is built with go 1.16.  Until that is rectified, downgrade controller-gen to 0.7.0, which builds with go 1.16.

At the same time, use `go install` instead of the deprecated `go get` when we install local build tools, such as controller-gen, yq, and kustomize.  This requires a version bump of kustomize to work correctly as well as adding an extra step to install a recent version of go in the non-OLM github actions acceptance test runner.

Finally, with the release of go 1.18, our go linting needs to become aware of this new release, since our linting runs with the latest release of go.  This can be fixed by updating the golangci/golangci-lint runner to v1.45.2; since v1.45.1, it will autodetect the language version of a project.

Signed-off-by: Andy Sadler <ansadler@redhat.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

