### PR TITLE
Upgrade codecov-action from deprecated v1 to v3

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -56,7 +56,7 @@ jobs:
           make test
 
       - name: Upload Code Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: cover.out
           verbose: true


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

# Changes

`codecov/codecov-action@v1` has been [deprecated](https://github.com/marketplace/actions/codecov#%EF%B8%8F--deprecration-of-v1), so this PR upgrades the version to the latest version ATM (`v3`)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

