### PR TITLE
bind labeled workloads created after sb reconcile

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"flag"
+
 	"github.com/redhat-developer/service-binding-operator/pkg/client/kubernetes"
 
 	"github.com/go-logr/logr"
@@ -103,7 +104,7 @@ func (r *BindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	} else {
 		log.Info("Deleted, unbind the application")
 	}
-	retry, err := r.pipeline.Process(serviceBinding) // <.>
+	retry, delay, err := r.pipeline.Process(serviceBinding) // <.>
 	if !retry && err == nil {
 		if serviceBinding.HasDeletionTimestamp() {
 			if apis.MaybeRemoveFinalizer(serviceBinding) {
@@ -113,7 +114,7 @@ func (r *BindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 		}
 	}
-	result := ctrl.Result{Requeue: retry}
+	result := ctrl.Result{Requeue: retry, RequeueAfter: delay}
 	log.Info("Done", "retry", retry, "error", err)
 	if retry {
 		return result, err

--- a/docs/userguide/modules/creating-service-bindings/pages/binding-options.adoc
+++ b/docs/userguide/modules/creating-service-bindings/pages/binding-options.adoc
@@ -183,3 +183,58 @@ spec:
 <1>  Database service
 <2> Optional "id" field
 <3>  Translation service
+
+== Binding workloads from a label selector
+
+Sometimes, it may be useful to specify the workload being bound by using a label selector.  For
+instance, you may want to bind a service to every workload with the label `environment: production`
+set.  SBO is able to support this kind of binding by being able to bind with label selectors.  As an
+example, to project a single secret into multiple workloads, set up your application field like so:
+[source,yaml]
+----
+apiVersion: binding.operators.coreos.com/v1alpha1
+kind: ServiceBinding
+metadata:
+  name: multi-application-binding
+  namespace: service-binding-demo
+spec:
+  application:
+    labelSelector:
+      matchLabels:
+        environment: production
+    group: apps
+    version: v1
+    resource: deployments
+  services:
+    group: ""
+    version: v1
+    kind: Secret
+    name: super-secret-data
+----
+
+Or, using the spec API:
+[source,yaml]
+----
+apiVersion: servicebindings.io/v1alpha3
+kind: ServiceBinding
+metadata:
+  name: multi-application-binding
+  namespace: service-binding-demo
+spec:
+  workload:
+    selector:
+      matchLabels:
+        environment: production
+    apiVersion: app/v1
+    kind: Deployment
+  service:
+    apiVersion: v1
+    kind: Secret
+    name: super-secret-data
+----
+
+If a service binding is declared using these label selectors to pick up workloads, SBO will
+periodically attempt to find and bind new workloads that match the given label selector.
+
+As a note: it is currently forbidden to attempt a binding with both `name:` and `labelSelector`
+defined (or `selector` in the spec API).  Any attempt to do so will result in a error.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.15.0
 	github.com/operator-framework/api v0.3.8
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	k8s.io/api v0.22.1
 	k8s.io/apiextensions-apiserver v0.22.1
 	k8s.io/apimachinery v0.22.1

--- a/main.go
+++ b/main.go
@@ -19,11 +19,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"sync"
+
 	"github.com/redhat-developer/service-binding-operator/apis/webhooks"
 	v1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1beta1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"os"
-	"sync"
 
 	crdcontrollers "github.com/redhat-developer/service-binding-operator/controllers/crd"
 

--- a/pkg/reconcile/pipeline/builder/pipeline_integration_test.go
+++ b/pkg/reconcile/pipeline/builder/pipeline_integration_test.go
@@ -3,6 +3,7 @@ package builder_test
 import (
 	c "context"
 	"reflect"
+	"time"
 
 	"github.com/redhat-developer/service-binding-operator/apis"
 	"github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
@@ -128,9 +129,10 @@ var _ = Describe("Default Pipeline", func() {
 
 		p := builder.DefaultBuilder.WithContextProvider(context.Provider(client, authClient.SubjectAccessReviews(), typeLookup)).Build()
 
-		retry, err := p.Process(sb)
+		retry, delay, err := p.Process(sb)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(retry).To(BeFalse())
+		Expect(delay).To(Equal(time.Duration(0)))
 
 		u, err := client.Resource(v1alpha1.GroupVersionResource).Namespace(sb.Namespace).Get(c.Background(), sb.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/reconcile/pipeline/context/flow_ctrl.go
+++ b/pkg/reconcile/pipeline/context/flow_ctrl.go
@@ -1,11 +1,16 @@
 package context
 
-import "github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
+import (
+	"time"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
+)
 
 type flowCtrl struct {
 	retry bool
 	stop  bool
 	err   error
+	delay time.Duration
 }
 
 func (i *flowCtrl) FlowStatus() pipeline.FlowStatus {
@@ -13,6 +18,7 @@ func (i *flowCtrl) FlowStatus() pipeline.FlowStatus {
 		Retry: i.retry,
 		Stop:  i.stop,
 		Err:   i.err,
+		Delay: i.delay,
 	}
 }
 
@@ -20,6 +26,14 @@ func (i *flowCtrl) RetryProcessing(reason error) {
 	i.retry = true
 	i.stop = true
 	i.err = reason
+	i.delay = 0
+}
+
+func (i *flowCtrl) RetryProcessingWithDelay(reason error, delay time.Duration) {
+	i.retry = true
+	i.stop = reason != nil // for label selection
+	i.err = reason
+	i.delay = delay
 }
 
 func (i *flowCtrl) Error(err error) {

--- a/pkg/reconcile/pipeline/handler/project/impl.go
+++ b/pkg/reconcile/pipeline/handler/project/impl.go
@@ -49,6 +49,10 @@ func PreFlightCheck(mandatoryBindingKeys ...string) func(pipeline.Context) {
 
 func PostFlightCheck(ctx pipeline.Context) {
 	ctx.SetCondition(apis.Conditions().InjectionReady().Reason("ApplicationUpdated").Build())
+	if ctx.HasLabelSelector() {
+		// Force periodic reprocessing of this service binding to catch new workloads
+		ctx.DelayReprocessing(nil)
+	}
 }
 
 func InjectSecretRef(ctx pipeline.Context) {

--- a/pkg/reconcile/pipeline/mapping.go
+++ b/pkg/reconcile/pipeline/mapping.go
@@ -209,6 +209,10 @@ func addRaw(obj map[string]interface{}, resource interface{}, data []map[string]
 }
 
 func (container *MetaContainer) AddEnvVars(vars []corev1.EnvVar) error {
+	for _, v := range vars {
+		// ignore errors, we could be projecting env vars that don't exist yet
+		_ = container.RemoveEnvVars(v.Name)
+	}
 	var data []map[string]interface{}
 	for _, variable := range vars {
 		x, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&variable)
@@ -241,6 +245,8 @@ func (container *MetaContainer) RemoveEnvVars(name string) error {
 
 func (container *MetaContainer) AddEnvFromVar(envVar corev1.EnvFromSource) error {
 	if len(container.EnvFrom) != 0 {
+		// ignore errors, we could be projecting env vars that don't exist yet
+		_ = container.RemoveEnvFromVars(envVar.SecretRef.Name)
 		data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&envVar)
 		if err != nil {
 			return err

--- a/pkg/reconcile/pipeline/mocks/mocks_pipeline.go
+++ b/pkg/reconcile/pipeline/mocks/mocks_pipeline.go
@@ -147,6 +147,18 @@ func (mr *MockContextMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockContext)(nil).Close))
 }
 
+// DelayReprocessing mocks base method.
+func (m *MockContext) DelayReprocessing(arg0 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DelayReprocessing", arg0)
+}
+
+// DelayReprocessing indicates an expected call of DelayReprocessing.
+func (mr *MockContextMockRecorder) DelayReprocessing(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelayReprocessing", reflect.TypeOf((*MockContext)(nil).DelayReprocessing), arg0)
+}
+
 // EnvBindings mocks base method.
 func (m *MockContext) EnvBindings() []*pipeline.EnvBinding {
 	m.ctrl.T.Helper()
@@ -185,6 +197,20 @@ func (m *MockContext) FlowStatus() pipeline.FlowStatus {
 func (mr *MockContextMockRecorder) FlowStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlowStatus", reflect.TypeOf((*MockContext)(nil).FlowStatus))
+}
+
+// HasLabelSelector mocks base method.
+func (m *MockContext) HasLabelSelector() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasLabelSelector")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasLabelSelector indicates an expected call of HasLabelSelector.
+func (mr *MockContextMockRecorder) HasLabelSelector() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasLabelSelector", reflect.TypeOf((*MockContext)(nil).HasLabelSelector))
 }
 
 // Mappings mocks base method.

--- a/test/acceptance/features/bindMultipleAppsToSingleService.feature
+++ b/test/acceptance/features/bindMultipleAppsToSingleService.feature
@@ -6,6 +6,7 @@ Feature: Bind multiple applications to a single service
     Background:
         Given Namespace [TEST_NAMESPACE] is used
         * Service Binding Operator is running
+        * OLM Operator "custom_app" is running
 
     Scenario: Successfully bind two applications to a single service
         Given Test applications "gen-app-a-s-f-1" and "gen-app-a-s-f-2" is running
@@ -16,7 +17,7 @@ Feature: Bind multiple applications to a single service
             apiVersion: v1
             kind: Secret
             metadata:
-                name: backend-secret
+                name: $scenario_id-secret
             stringData:
                 username: AzureDiamond
                 password: hunter2
@@ -31,7 +32,7 @@ Feature: Bind multiple applications to a single service
                     service.binding: path={.status.data.dbCredentials},objectType=Secret,elementType=map
             status:
                 data:
-                    dbCredentials: backend-secret
+                    dbCredentials: $scenario_id-secret
             """
         When Service Binding is applied
             """
@@ -57,3 +58,232 @@ Feature: Bind multiple applications to a single service
         Then Service Binding is ready
         And The application env var "BACKEND_USERNAME" has value "AzureDiamond" in both apps
         And The application env var "BACKEND_PASSWORD" has value "hunter2" in both apps
+
+    Scenario: Bind applications via label selector after the service binding has been created
+        Given The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: $scenario_id-secret
+            stringData:
+                username: AzureDiamond
+                password: hunter2
+            """
+        And The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: AppConfig
+            metadata:
+                name: $scenario_id-appconfig-1
+                labels:
+                    app-custom: $scenario_id
+            spec:
+                spec:
+                    containers:
+                        - name: foo
+            """
+        And The Workload Resource Mapping is present
+            """
+            apiVersion: servicebinding.io/v1alpha3
+            kind: ClusterWorkloadResourceMapping
+            metadata:
+                name: appconfigs.stable.example.com
+            spec:
+                versions:
+                  - version: "*"
+                    containers:
+                      - path: .spec.spec.containers[*]
+                    volumes: .spec.spec.volumes
+            """
+        And Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id-binding
+            spec:
+                services:
+                  - group: ""
+                    version: v1
+                    kind: Secret
+                    name: $scenario_id-secret
+                application:
+                    labelSelector:
+                      matchLabels:
+                        app-custom: $scenario_id
+                    group: stable.example.com
+                    version: v1
+                    resource: appconfigs
+            """
+        And Service Binding is ready
+        And jsonpath "{.spec.spec.containers[0].volumeMounts}" on "appconfigs/$scenario_id-appconfig-1" should return "[{"mountPath":"/bindings/$scenario_id-binding","name":"$scenario_id-binding"}]"
+        And jsonpath "{.spec.spec.volumes}" on "appconfigs/$scenario_id-appconfig-1" should return "[{"name":"$scenario_id-binding","secret":{"secretName":"$scenario_id-secret"}}]"
+        When 2 minutes have passed
+        And The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: AppConfig
+            metadata:
+                name: $scenario_id-appconfig-2
+                labels:
+                    app-custom: $scenario_id
+            spec:
+                spec:
+                    containers:
+                        - name: bar
+            """
+        Then jsonpath "{.spec.spec.containers[0].volumeMounts}" on "appconfigs/$scenario_id-appconfig-2" should return "[{"mountPath":"/bindings/$scenario_id-binding","name":"$scenario_id-binding"}]"
+        And jsonpath "{.spec.spec.volumes}" on "appconfigs/$scenario_id-appconfig-2" should return "[{"name":"$scenario_id-binding","secret":{"secretName":"$scenario_id-secret"}}]"
+
+    Scenario: Bind applications via label selector as environment variables after the service binding has been created
+        Given The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: $scenario_id-secret
+            stringData:
+                username: AzureDiamond
+                password: hunter2
+            """
+        And The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: AppConfig
+            metadata:
+                name: $scenario_id-appconfig-1
+                labels:
+                    app-custom: $scenario_id
+            spec:
+                spec:
+                    containers:
+                        - name: foo
+            """
+        And The Workload Resource Mapping is present
+            """
+            apiVersion: servicebinding.io/v1alpha3
+            kind: ClusterWorkloadResourceMapping
+            metadata:
+                name: appconfigs.stable.example.com
+            spec:
+                versions:
+                  - version: "*"
+                    containers:
+                      - path: .spec.spec.containers[*]
+                    volumes: .spec.spec.volumes
+            """
+        And Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id-binding
+            spec:
+                bindAsFiles: false
+                services:
+                  - group: ""
+                    version: v1
+                    kind: Secret
+                    name: $scenario_id-secret
+                application:
+                    labelSelector:
+                      matchLabels:
+                        app-custom: $scenario_id
+                    group: stable.example.com
+                    version: v1
+                    resource: appconfigs
+            """
+        And Service Binding is ready
+        And Secret has been injected in to CR "$scenario_id-appconfig-1" of kind "appconfigs.stable.example.com" at path "{.spec.spec.containers[0].envFrom[0].secretRef.name}"
+        When 2 minutes have passed
+        And The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: AppConfig
+            metadata:
+                name: $scenario_id-appconfig-2
+                labels:
+                    app-custom: $scenario_id
+            spec:
+                spec:
+                    containers:
+                        - name: bar
+            """
+        Then Secret has been injected in to CR "$scenario_id-appconfig-2" of kind "appconfigs.stable.example.com" at path "{.spec.spec.containers[0].envFrom[0].secretRef.name}"
+
+    @spec
+    Scenario: Bind applications via label selector after the spec service binding has been created
+        Given The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: $scenario_id-secret
+            stringData:
+                username: AzureDiamond
+                password: hunter2
+                type:     secret
+            """
+        And The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: AppConfig
+            metadata:
+                name: $scenario_id-appconfig-1
+                labels:
+                    app-custom: $scenario_id
+            spec:
+                spec:
+                    containers:
+                        - name: foo
+            """
+        And The Workload Resource Mapping is present
+            """
+            apiVersion: servicebinding.io/v1alpha3
+            kind: ClusterWorkloadResourceMapping
+            metadata:
+                name: appconfigs.stable.example.com
+            spec:
+                versions:
+                  - version: "*"
+                    containers:
+                      - path: .spec.spec.containers[*]
+            """
+        And Service Binding is applied
+            """
+            apiVersion: servicebinding.io/v1alpha3
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id-binding
+            spec:
+                service:
+                    apiVersion: v1
+                    kind: Secret
+                    name: $scenario_id-secret
+                workload:
+                    selector:
+                        matchLabels:
+                            app-custom: $scenario_id
+                    apiVersion: stable.example.com/v1
+                    kind: AppConfig
+            """
+        And Service Binding is ready
+        And jsonpath "{.spec.spec.containers[0].volumeMounts}" on "appconfigs/$scenario_id-appconfig-1" should return "[{"mountPath":"/bindings/$scenario_id-binding","name":"$scenario_id-binding"}]"
+        And jsonpath "{.spec.template.spec.volumes}" on "appconfigs/$scenario_id-appconfig-1" should return "[{"name":"$scenario_id-binding","secret":{"secretName":"$scenario_id-secret"}}]"
+        When 2 minutes have passed
+        And The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: AppConfig
+            metadata:
+                name: $scenario_id-appconfig-2
+                labels:
+                    app-custom: $scenario_id
+            spec:
+                spec:
+                    containers:
+                        - name: bar
+            """
+        Then jsonpath "{.spec.spec.containers[0].volumeMounts}" on "appconfigs/$scenario_id-appconfig-2" should return "[{"mountPath":"/bindings/$scenario_id-binding","name":"$scenario_id-binding"}]"
+        And jsonpath "{.spec.template.spec.volumes}" on "appconfigs/$scenario_id-appconfig-2" should return "[{"name":"$scenario_id-binding","secret":{"secretName":"$scenario_id-secret"}}]"

--- a/test/acceptance/features/steps/generic_testapp.py
+++ b/test/acceptance/features/steps/generic_testapp.py
@@ -117,13 +117,15 @@ def check_file_unavailable(context, file_path):
 
 @step(u'Test applications "{first_app_name}" and "{second_app_name}" is running')
 def are_two_apps_running(context, first_app_name, second_app_name, bindingRoot=None):
-    application1 = GenericTestApp(first_app_name, context.namespace.name)
+    first = substitute_scenario_id(context, first_app_name)
+    application1 = GenericTestApp(first, context.namespace.name)
     if not application1.is_running():
         print("application1 is not running, trying to import it")
         application1.install(bindingRoot=bindingRoot)
     context.application1 = application1
 
-    application2 = GenericTestApp(second_app_name, context.namespace.name)
+    second = substitute_scenario_id(context, second_app_name)
+    application2 = GenericTestApp(second, context.namespace.name)
     if not application2.is_running():
         print("application2 is not running, trying to import it")
         application2.install(bindingRoot=bindingRoot)

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -10,6 +10,7 @@ import parse
 import binascii
 import yaml
 import json
+import time
 
 from behave import given, register_type, then, when, step
 from knative_serving import KnativeServing
@@ -316,7 +317,7 @@ def delete_yaml(context):
     assert result is not None, f"Unable to delete CR '{metadata_name}': {output}"
 
 
-@then(u'Secret has been injected in to CR "{cr_name}" of kind "{crd_name}" at path "{json_path}"')
+@step(u'Secret has been injected in to CR "{cr_name}" of kind "{crd_name}" at path "{json_path}"')
 def verify_injected_secretRef(context, cr_name, crd_name, json_path):
     sb = list(context.bindings.values())[0]
     name = substitute_scenario_id(context, cr_name)
@@ -463,3 +464,8 @@ def check_service_account_bound(context, cluster_role_name, cluster_rolebinding_
             continue
 
     assert subject_found, f"Could not find rolebinding for the role '{cluster_role_name}'"
+
+
+@step(u'{time_min} minutes have passed')
+def step_impl(context, time_min):
+    time.sleep(60 * int(time_min))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -213,6 +213,7 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
+## explicit
 golang.org/x/time/rate
 # golang.org/x/tools v0.1.2
 golang.org/x/tools/go/ast/inspector


### PR DESCRIPTION
# Changes

/kind enhancement

Workloads that we bound with label selectors won't get bound if they
were created after the service binding was first reconciled.  As a
workaround, periodically reconcile service bindings with label selectors
to pick up any new workloads.

This uses an exponential backoff strategy, which is the default for when
a duration before re-reconciling is not specified.  A fixed interval was
considered, but was decided against out of concerns for thundering herd
problems in a cluster.

Signed-off-by: Andy Sadler <ansadler@redhat.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

