### PR TITLE
Create non-admin user for acceptance tests for OpenShift only if it does not exist

### DIFF
--- a/test/acceptance/openshift-setup.sh
+++ b/test/acceptance/openshift-setup.sh
@@ -7,19 +7,24 @@ HTPASSWD_SECRET=acceptance-tests-htpass
 USER=acceptance-tests-dev
 USER_TOKEN=acceptance-tests-dev
 
-oc get secret $HTPASSWD_SECRET -n openshift-config >/dev/null 2>&1 \
-  || oc create secret generic $HTPASSWD_SECRET --from-file=htpasswd=$HTPASSWD_FILE -n openshift-config
-
-oc patch oauth cluster --type merge -p '{"spec":{"identityProviders":[{"htpasswd":{"fileData":{"name":"'$HTPASSWD_SECRET'"}},"mappingMethod":"claim","name":"acceptance-tests","challenge":"true","login":true,"type":"HTPasswd"}]}}'
-
 CURRENT_CTX=$(oc config current-context)
+oc login -u $USER -p $USER_TOKEN --loglevel=10 --insecure-skip-tls-verify=true
 
-retries=50
-until [[ $retries == 0 ]]; do
-  oc login -u $USER -p $USER_TOKEN && break
-  sleep 5
-  retries=$(($retries - 1))
-done
+if [ $? -eq 0 ]; then
+  echo "User $USER is already set up, skipping..."
+else
+  oc get secret $HTPASSWD_SECRET -n openshift-config >/dev/null 2>&1 \
+    || oc create secret generic $HTPASSWD_SECRET --from-file=htpasswd=$HTPASSWD_FILE -n openshift-config
+
+  oc patch oauth cluster --type merge -p '{"spec":{"identityProviders":[{"htpasswd":{"fileData":{"name":"'$HTPASSWD_SECRET'"}},"mappingMethod":"claim","name":"acceptance-tests","challenge":"true","login":true,"type":"HTPasswd"}]}}'
+
+  retries=50
+  until [[ $retries == 0 ]]; do
+    oc login -u $USER -p $USER_TOKEN && break
+    sleep 5
+    retries=$(($retries - 1))
+  done;
+fi
 
 oc config set-credentials $USER --token=$(oc whoami --show-token)
 


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

# Changes



# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

