### PR TITLE
Upgrade codecov-action from deprecated v1 to v3 for merge-to-master

### DIFF
--- a/.github/workflows/merge-to-master.yaml
+++ b/.github/workflows/merge-to-master.yaml
@@ -66,7 +66,7 @@ jobs:
           make test
 
       - name: Upload Code Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: cover.out
           verbose: true


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

# Changes
Followup to #1129 which missed `merge-to-master` workflow. That caused the PR check coverage data and those for `master` used as a base for comparison to differ and as a result always to fail the CodeCov PR check.

This PR:
* upgrades the codecov-action to version `v3` matching the PR checks.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

