### PR TITLE
Pin Crunchy PostgreSQL Operator version to v5.0.5 for acceptance tests with Minikube

### DIFF
--- a/test/acceptance/features/steps/crunchypostgresoperator.py
+++ b/test/acceptance/features/steps/crunchypostgresoperator.py
@@ -13,6 +13,7 @@ class CrunchyPostgresOperator(Operator):
         else:
             self.operator_catalog_source_name = "operatorhubio-catalog"
             self.package_name = "postgresql"
+            self.operator_subscription_csv_version = "postgresoperator.v5.0.5"
         self.operator_catalog_channel = "v5"
 
 

--- a/test/acceptance/features/steps/olm.py
+++ b/test/acceptance/features/steps/olm.py
@@ -14,6 +14,7 @@ class Operator(object):
     operator_catalog_source_name = ""
     operator_catalog_image = ""
     operator_catalog_channel = ""
+    operator_subscription_csv_version = None
     package_name = ""
 
     def is_running(self, wait=False):
@@ -36,8 +37,10 @@ class Operator(object):
                 return False
         return self.openshift.wait_for_package_manifest(self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel)
 
-    def install_operator_subscription(self):
-        install_sub_output = self.openshift.create_operator_subscription(self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel)
+    def install_operator_subscription(self, csv_version=None):
+        install_sub_output = self.openshift.create_operator_subscription(
+            self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel,
+            self.operator_subscription_csv_version if csv_version is None else csv_version)
         if re.search(r'.*subscription.operators.coreos.com/%s\s(unchanged|created)' % self.package_name, install_sub_output) is None:
             print("Failed to create {} operator subscription".format(self.package_name))
             return False

--- a/test/acceptance/features/steps/openshift.py
+++ b/test/acceptance/features/steps/openshift.py
@@ -381,14 +381,14 @@ spec:
         last_revision_status = output.split(" ")[-1]
         return last_revision_status
 
-    def create_operator_subscription_to_namespace(self, package_name, namespace, operator_source_name, channel):
+    def create_operator_subscription_to_namespace(self, package_name, namespace, operator_source_name, channel, csv_version=None):
         operator_subscription = self.operator_subscription_to_namespace_yaml_template.format(
             name=package_name, namespace=namespace, operator_source_name=operator_source_name, olm_namespace=self.olm_namespace,
-            channel=channel, csv_version=self.get_current_csv(package_name, operator_source_name, channel))
+            channel=channel, csv_version=self.get_current_csv(package_name, operator_source_name, channel) if csv_version is None else csv_version)
         return self.apply(operator_subscription)
 
-    def create_operator_subscription(self, package_name, operator_source_name, channel):
-        return self.create_operator_subscription_to_namespace(package_name, self.operators_namespace, operator_source_name, channel)
+    def create_operator_subscription(self, package_name, operator_source_name, channel, csv_version=None):
+        return self.create_operator_subscription_to_namespace(package_name, self.operators_namespace, operator_source_name, channel, csv_version)
 
     def get_resource_list_in_namespace(self, resource_plural, name_pattern, namespace):
         print(f"Searching for {resource_plural} that matches {name_pattern} in {namespace} namespace")


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Recently, the Crunchy PostgreSQL Operator has been released to version `5.1.0` in [Operatorhub.io](https://operatorhub.io/operator/postgresql/). That version of the operator has set the minimal version of k8s to `v1.20.0` which is incompatible with our acceptance tests executed with Minikube which is set to k8s `v1.19.2`.

Additionally, the acceptance tests are set to install the latest version of Crunchy PostgreSQL Operator.

That causes the acceptance tests using the Crunchy PostgreSQL Operator to fail because the operator is not being installed properly into the Minikube cluster.

# Changes

This PR:
* Pins the version of Crunchy PostgreSQL Operator for acceptance tests with Minikube to `v5.0.5` which is still compatible with k8s `v1.19.2`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

