### PR TITLE
Fix 'Service Binding is ready' step assertions

### DIFF
--- a/test/acceptance/features/steps/service_binding.py
+++ b/test/acceptance/features/steps/service_binding.py
@@ -107,8 +107,12 @@ def sbo_is_ready(context, sbr_name=None):
     sbo_jq_is(context, '.status.conditions[] | select(.type=="Ready").status', sbr_name, 'True')
     sb = context.bindings[sbr_name]
     if sb.crdName == "servicebindings.servicebinding.io":
-        assert sb.get_info_by_jsonpath("{.metadata.generation") == sb.get_info_by_jsonpath("{.status.observedGeneration"), \
-            f"Service binding {sb.name} observed generation not equal to generation"
+        generation = sb.get_info_by_jsonpath("{.metadata.generation}")
+        assert generation is not None, f"Unable to get Service Binding {sb.name} generation"
+        observedGeneration = sb.get_info_by_jsonpath("{.status.observedGeneration}")
+        assert observedGeneration is not None, f"Unable to get Service Binding {sb.name} observed generation"
+        assert generation == observedGeneration, \
+            f"Service binding {sb.name} observed generation ({observedGeneration}) not equal to generation ({generation})"
     context.sb_secret = context.bindings[sbr_name].get_secret_name()
 
 


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

One of the `Service Binding is ready` step's assertions is to compare SB `generation` and `observedGeneration`. There is a typo in the both JSON paths, both resulting in Error and returning a `None` value.

This can be spotted in the test std output:

```
,---------,-
| COMMAND : kubectl get servicebindings.servicebinding.io bindapptoprovisionedservice-246-binding -o "jsonpath={.metadata.generation" -n test-ns-d58f
'---------'-
ERROR MESSGE: b'error: error parsing jsonpath {.metadata.generation, unclosed action\n'
ERROR CODE: 1
Error getting value for servicebindings.servicebinding.io/bindapptoprovisionedservice-246-binding in test-ns-d58f path={.metadata.generation: error: error parsing jsonpath {.metadata.generation, unclosed action

,---------,-
| COMMAND : kubectl get servicebindings.servicebinding.io bindapptoprovisionedservice-246-binding -o "jsonpath={.status.observedGeneration" -n test-ns-d58f
'---------'-
ERROR MESSGE: b'error: error parsing jsonpath {.status.observedGeneration, unclosed action\n'
ERROR CODE: 1
Error getting value for servicebindings.servicebinding.io/bindapptoprovisionedservice-246-binding in test-ns-d58f path={.status.observedGeneration: error: error parsing jsonpath {.status.observedGeneration, unclosed action
```

Comparing those `None` values always passes the assertion even if the actual values differed  - which case is supposed to fail the assertion.

# Changes

This PR:
 * Fixes the typo in above mentioned JSON paths
 * Adds additional assertions for ensuring the compared values are not `None`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

