### PR TITLE
Define behavior (scenarios) for optional annotation mapping

### DIFF
--- a/test/acceptance/features/bindAppToServiceAnnotationsOptional.feature
+++ b/test/acceptance/features/bindAppToServiceAnnotationsOptional.feature
@@ -1,0 +1,132 @@
+@annotations
+@disabled
+@external-feedback
+Feature: Bind an application to a service using optional annotations
+
+    As a user of Service Binding Operator
+    I want to bind application to services that expose optional bindable information
+    via annotations placed on service's CRD or CR.
+
+    Background:
+        Given Namespace [TEST_NAMESPACE] is used
+        * Service Binding Operator is running
+        * OLM Operator "custom_app" is running
+        * CustomResourceDefinition backends.stable.example.com is available
+
+    Scenario: Bind to the application with annotations and with optional source field present
+        Given Generic test application is running
+        And The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: AppConfig
+            metadata:
+                name: $scenario_id
+                annottions:
+                    service.binding/uri: "path={.spec.uri},optional"
+                    service.binding/image: "path={.spec.image}"
+            spec:
+                uri: "youknow.where"
+                image: "busybox"
+            """
+        When Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: AppConfig
+                    name: $scenario_id
+                application:
+                    group: apps
+                    version: v1
+                    resource: deployments
+                    name: $scenario_id
+            """
+        Then Service Binding is ready
+        * Content of file "/bindings/$scenario_id/uri" in application pod is
+            """
+            youknow.where
+            """
+        * Content of file "/bindings/$scenario_id/image" in application pod is
+            """
+            busybox
+            """
+
+    Scenario: Bind to the application with annotations and with missing optional source field to be excluded
+        Given Generic test application is running
+        And The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: AppConfig
+            metadata:
+                name: $scenario_id
+                annottions:
+                    service.binding/uri: "path={.spec.uri},optional"
+                    service.binding/image: "path={.spec.image}"
+            spec:
+                image: "busybox"
+            """
+        When Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: AppConfig
+                    name: $scenario_id
+                application:
+                    group: apps
+                    version: v1
+                    resource: deployments
+                    name: $scenario_id
+            """
+        Then Service Binding is ready
+        * File "/bindings/$scenario_id/uri" is unavailable in application pod
+        * Content of file "/bindings/$scenario_id/image" in application pod is
+            """
+            busybox
+            """
+
+    @negative
+    Scenario: Bind to the application with annotations and with missing non-optional source field to cause binding failure
+        Given Generic test application is running
+        And The Custom Resource is present
+            """
+            apiVersion: "stable.example.com/v1"
+            kind: AppConfig
+            metadata:
+                name: $scenario_id
+                annottions:
+                    service.binding/uri: "path={.spec.uri}"
+                    service.binding/image: "path={.spec.image}"
+            spec:
+                image: "busybox"
+            """
+        When Service Binding is applied
+            """
+            apiVersion: binding.operators.coreos.com/v1alpha1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                services:
+                  - group: stable.example.com
+                    version: v1
+                    kind: AppConfig
+                    name: $scenario_id
+                application:
+                    group: apps
+                    version: v1
+                    resource: deployments
+                    name: $scenario_id
+            """
+        Then Service Binding CollectionReady.status is "False"
+        And Service Binding CollectionReady.reason is "ValueNotFound"


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

This PR defines the behavior for the new feature optional annotation mapping feature (https://issues.redhat.com/browse/APPSVC-1123)

The scenarios are `@disabled` intentionally not to fail until the actual feature is implemented. Removing of the `@disabled` tag should be part of the PR that implements it. 

# Changes

This PR:
* Adds scenarios for the optional annotation mapping

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

