### PR TITLE
Add support for servicebinding.io API for performance testing

### DIFF
--- a/test/performance/collect-kpi.sh
+++ b/test/performance/collect-kpi.sh
@@ -17,6 +17,7 @@ NS_PREFIX=${NS_PREFIX:-entanglement}
 SBO_METRICS=$(find $METRICS -type f -name 'pod-info.service-binding-operator-*.csv')
 
 SCENARIOS="nosb-inv nosb-val sb-inc sb-inv sb-val"
+#SCENARIOS="nosb-val"
 
 USER_NS_PREFIXES=""
 for scenario in $SCENARIOS; do
@@ -40,12 +41,14 @@ if [ -z $PROCESS_ONLY ]; then
 fi
 
 for scenario in $SCENARIOS; do
-    ns_prefix=$NS_PREFIX-$scenario
-    output=$RESULTS/$scenario.kpi.yaml
-    echo "- name: $scenario" >$output
-    echo "  metrics:" >>$output
-    for i in 5 6 7; do
-        python $WS/kpi.py -c "$(readlink -m $RESULTS/$ns_prefix.sbr-timestamps.csv)" -x 1 -y $i -d "%Y-%m-%d %H:%M:%S" | indent >>$output
+    for sb_api in binding.operators.coreos.com servicebinding.io; do
+        ns_prefix=$NS_PREFIX-$scenario
+        output=$RESULTS/$scenario.$sb_api.kpi.yaml
+        echo "- name: $scenario.$sb_api" >$output
+        echo "  metrics:" >>$output
+        for i in 4 5 6; do
+            python $WS/kpi.py -c "$(readlink -m $RESULTS/$ns_prefix.$sb_api.timestamps.csv)" -x 1 -y $i -d "%Y-%m-%d %H:%M:%S" | indent >>$output
+        done
+        cat $output >>$kpi_yaml
     done
-    cat $output >>$kpi_yaml
 done

--- a/test/performance/deploy-sbr.sh
+++ b/test/performance/deploy-sbr.sh
@@ -1,11 +1,17 @@
 #!/bin/bash -x
 
 SBR_YAML=${1:-sbo-test.sbr.yaml}
-
-APP_NAME=$(yq e '.spec.application.name' $SBR_YAML)
+SB_API=$(yq e '.apiVersion | sub("^(.*)/.*$", "${1}")' $SBR_YAML)
+if [ "$SB_API" == "servicebinding.io" ]; then
+    WORKLOAD_NAME=$(yq e '.spec.workload.name' $SBR_YAML)
+    WORKLOAD_KIND=$(yq e '.spec.workload.kind' $SBR_YAML)
+else
+    WORKLOAD_NAME=$(yq e '.spec.application.name' $SBR_YAML)
+    WORKLOAD_KIND=$(yq e '.spec.application.kind' $SBR_YAML)
+fi
 SBR_NAME=$(yq e '.metadata.name' $SBR_YAML)
 USER_NS_PREFIX=${2:-entanglement}
-oc get deploy --all-namespaces -o json | jq -rc '.items[] | select(.metadata.name | contains("'$APP_NAME'")).metadata.namespace' | grep $USER_NS_PREFIX >workload.namespace.list
+oc get $WORKLOAD_KIND --all-namespaces -o json | jq -rc '.items[] | select(.metadata.name | contains("'$WORKLOAD_NAME'")).metadata.namespace' | grep $USER_NS_PREFIX >workload.namespace.list
 
 no_ns=$(cat workload.namespace.list | wc -l)
 
@@ -23,7 +29,7 @@ wait
 #Wait for the all the service bindings to get status
 retries=360
 until [[ $retries == 0 ]]; do
-    sb_with_status_set=$(oc get sbr --all-namespaces -o json | jq -rc '.items[]| select(.metadata.namespace | contains("'$USER_NS_PREFIX'")) | select(.status != null).metadata.name' | wc -l)
+    sb_with_status_set=$(oc get servicebindings.$SB_API --all-namespaces -o json | jq -rc '.items[]| select(.metadata.namespace | contains("'$USER_NS_PREFIX'")) | select(.status != null).metadata.name' | wc -l)
     [ $no_ns != $sb_with_status_set ] || break
     echo "Waiting for all the Service Binding resources to be processed by operator... currently only $sb_with_status_set/$no_ns are"
     sleep 10

--- a/test/performance/kpi.py
+++ b/test/performance/kpi.py
@@ -70,11 +70,19 @@ for rowmap in rows:
 
 metrics = {}
 metrics["name"] = y_header
-metrics["first"] = normalize_value(float(rows[0][y_header]))
-metrics["minimum"] = normalize_value(min)
-metrics["average"] = normalize_value(statistics.mean(values))
-metrics["median"] = normalize_value(statistics.median(values))
-metrics["maximum"] = normalize_value(max)
-metrics["last"] = normalize_value(float(rows[count - 1][y_header]))
+if count > 0:
+    metrics["first"] = normalize_value(float(rows[0][y_header]))
+    metrics["minimum"] = normalize_value(min)
+    metrics["average"] = normalize_value(statistics.mean(values))
+    metrics["median"] = normalize_value(statistics.median(values))
+    metrics["maximum"] = normalize_value(max)
+    metrics["last"] = normalize_value(float(rows[count - 1][y_header]))
+else:
+    metrics["first"] = "n/a"
+    metrics["minimum"] = "n/a"
+    metrics["average"] = "n/a"
+    metrics["median"] = "n/a"
+    metrics["maximum"] = "n/a"
+    metrics["last"] = "n/a"
 
 print(yaml.dump([metrics]))

--- a/test/performance/kpidiff.py
+++ b/test/performance/kpidiff.py
@@ -1,6 +1,5 @@
 
 import argparse
-import sys
 import yaml
 
 ap = argparse.ArgumentParser()

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -27,11 +27,13 @@ yes | go run setup/main.go --template=$WS/user-workloads/valid/sbo-test.with-sbr
 
 yes | go run setup/main.go --template=$WS/user-workloads/valid/sbo-test.without-sbr.user-workloads.yaml --users $USERS_PER_SCENARIO --default $DEFAULT_WORKLOADS --custom $USERS_PER_SCENARIO --operators-limit 0 --workloads $SBO_NAMESPACE:$SBO_DEPLOYMENT --username $USER_NS_PREFIX-nosb-val > $OUTPUT_DIR/$USER_NS_PREFIX-nosb-val.log
 $WS/deploy-sbr.sh $WS/user-workloads/valid/sbo-test.sbr.yaml $USER_NS_PREFIX-nosb-val > $OUTPUT_DIR/$USER_NS_PREFIX-nosb-val.deploy-sbr.log
+$WS/deploy-sbr.sh $WS/user-workloads/valid/sbo-test.sbr.spec.yaml $USER_NS_PREFIX-nosb-val >> $OUTPUT_DIR/$USER_NS_PREFIX-nosb-val.deploy-sbr.log
 
 yes | go run setup/main.go --template=$WS/user-workloads/invalid/sbo-test.with-sbr.user-workloads.yaml --users $USERS_PER_SCENARIO --default $DEFAULT_WORKLOADS --custom $USERS_PER_SCENARIO --operators-limit 0 --workloads $SBO_NAMESPACE:$SBO_DEPLOYMENT --username $USER_NS_PREFIX-sb-inv > $OUTPUT_DIR/$USER_NS_PREFIX-sb-inv.log
 
 yes | go run setup/main.go --template=$WS/user-workloads/invalid/sbo-test.without-sbr.user-workloads.yaml --users $USERS_PER_SCENARIO --default $DEFAULT_WORKLOADS --custom $USERS_PER_SCENARIO --operators-limit 0 --workloads $SBO_NAMESPACE:$SBO_DEPLOYMENT --username $USER_NS_PREFIX-nosb-inv > $OUTPUT_DIR/$USER_NS_PREFIX-nosb-inv.log
-  $WS/deploy-sbr.sh $WS/user-workloads/invalid/sbo-test.sbr.yaml $USER_NS_PREFIX-nosb-inv > $OUTPUT_DIR/$USER_NS_PREFIX-nosb-inv.deploy-sbr.log
+$WS/deploy-sbr.sh $WS/user-workloads/invalid/sbo-test.sbr.yaml $USER_NS_PREFIX-nosb-inv > $OUTPUT_DIR/$USER_NS_PREFIX-nosb-inv.deploy-sbr.log
+$WS/deploy-sbr.sh $WS/user-workloads/invalid/sbo-test.sbr.spec.yaml $USER_NS_PREFIX-nosb-inv >> $OUTPUT_DIR/$USER_NS_PREFIX-nosb-inv.deploy-sbr.log
 
 yes | go run setup/main.go --template=$WS/user-workloads/incomplete/sbo-test.with-sbr.user-workloads.yaml --users $USERS_PER_SCENARIO --default $DEFAULT_WORKLOADS --custom $USERS_PER_SCENARIO --operators-limit 0 --workloads $SBO_NAMESPACE:$SBO_DEPLOYMENT --username $USER_NS_PREFIX-sb-inc > $OUTPUT_DIR/$USER_NS_PREFIX-sb-inc.log
 

--- a/test/performance/user-workloads/incomplete/sbo-test.with-sbr.user-workloads.yaml
+++ b/test/performance/user-workloads/incomplete/sbo-test.with-sbr.user-workloads.yaml
@@ -75,4 +75,20 @@ objects:
         name: sbo-perf-app-incomplete
         group: apps
         version: v1
-        resource: deployments
+        kind: Deployment
+  - apiVersion: servicebinding.io/v1alpha3
+    kind: ServiceBinding
+    metadata:
+      name: service-binding-incomplete
+    spec:
+      type: busybox
+      service:
+        apiVersion: v1
+        kind: Service
+        name: sbo-perf-svc-incomplete
+      workload:
+        selector:
+          matchLabels:
+            app-custom: sbo-perf-app-incomplete
+        apiVersion: apps/v1
+        kind: Deployment

--- a/test/performance/user-workloads/invalid/sbo-test.sbr.spec.yaml
+++ b/test/performance/user-workloads/invalid/sbo-test.sbr.spec.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: servicebinding.io/v1alpha3
+kind: ServiceBinding
+metadata:
+  name: service-binding-cron-invalid
+spec:
+  type: busybox
+  service:
+    apiVersion: v1
+    kind: Service
+    name: sbo-perf-svc-invalid
+  workload:
+    apiVersion: batch/v1
+    kind: CronJob
+    name: sbo-perf-cronjob-invalid

--- a/test/performance/user-workloads/invalid/sbo-test.sbr.yaml
+++ b/test/performance/user-workloads/invalid/sbo-test.sbr.yaml
@@ -17,4 +17,4 @@ spec:
     name: sbo-perf-app-invalid
     group: apps
     version: v1
-    resource: deployments
+    kind: Deployment

--- a/test/performance/user-workloads/invalid/sbo-test.with-sbr.user-workloads.yaml
+++ b/test/performance/user-workloads/invalid/sbo-test.with-sbr.user-workloads.yaml
@@ -126,4 +126,64 @@ objects:
         name: sbo-perf-app-invalid
         group: apps
         version: v1
-        resource: deployments
+        kind: Deployment
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: sbo-perf-cronjob-invalid
+    spec:
+      schedule: '@hourly'
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - name: wakeup
+                  image: busybox
+                  args:
+                    - /bin/sh
+                    - '-c'
+                    - date; echo 'Wake up!'
+              restartPolicy: Never
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: sbo-perf-cronjobs-view
+      labels:
+        servicebinding.io/controller: "true"
+    rules:
+      - apiGroups:
+          - batch
+        resources:
+          - cronjobs
+        verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+  - apiVersion: servicebinding.io/v1alpha3
+    kind: ClusterWorkloadResourceMapping
+    metadata:
+      name: cronjobs.batch
+    spec:
+      versions:
+        - version: "*"
+          volumes: .spec.jobTemplate.spec.template.spec.volumes
+          containers:
+            - path: .spec.jobTemplate.spec.template.spec.containers[*]
+            - path: .spec.jobTemplate.spec.template.spec.initContainers[*]
+  - apiVersion: servicebinding.io/v1alpha3
+    kind: ServiceBinding
+    metadata:
+      name: service-binding-cron-valid
+    spec:
+      type: busybox
+      service:
+        apiVersion: v1
+        kind: Service
+        name: sbo-perf-svc-invalid
+      workload:
+        apiVersion: batch/v1
+        kind: CronJob
+        name: sbo-perf-cronjob-invalid

--- a/test/performance/user-workloads/invalid/sbo-test.without-sbr.user-workloads.yaml
+++ b/test/performance/user-workloads/invalid/sbo-test.without-sbr.user-workloads.yaml
@@ -108,3 +108,49 @@ objects:
       to:
         kind: "Service"
         name: sbo-perf-svc-invalid
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: sbo-perf-cronjob-invalid
+    spec:
+      schedule: '@hourly'
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - name: wakeup
+                  image: busybox
+                  args:
+                    - /bin/sh
+                    - '-c'
+                    - date; echo 'Wake up!'
+              restartPolicy: Never
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: sbo-perf-cronjobs-view
+      labels:
+        servicebinding.io/controller: "true"
+    rules:
+      - apiGroups:
+          - batch
+        resources:
+          - cronjobs
+        verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+  - apiVersion: servicebinding.io/v1alpha3
+    kind: ClusterWorkloadResourceMapping
+    metadata:
+      name: cronjobs.batch
+    spec:
+      versions:
+        - version: "*"
+          volumes: .spec.jobTemplate.spec.template.spec.volumes
+          containers:
+            - path: .spec.jobTemplate.spec.template.spec.containers[*]
+            - path: .spec.jobTemplate.spec.template.spec.initContainers[*]

--- a/test/performance/user-workloads/valid/sbo-test.sbr.spec.yaml
+++ b/test/performance/user-workloads/valid/sbo-test.sbr.spec.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: servicebinding.io/v1alpha3
+kind: ServiceBinding
+metadata:
+  name: service-binding-cron-valid
+spec:
+  type: busybox
+  service:
+    apiVersion: v1
+    kind: Service
+    name: sbo-perf-svc-valid
+  workload:
+    apiVersion: batch/v1
+    kind: CronJob
+    name: sbo-perf-cronjob-valid

--- a/test/performance/user-workloads/valid/sbo-test.sbr.yaml
+++ b/test/performance/user-workloads/valid/sbo-test.sbr.yaml
@@ -17,4 +17,4 @@ spec:
     name: sbo-perf-app-valid
     group: apps
     version: v1
-    resource: deployments
+    kind: Deployment

--- a/test/performance/user-workloads/valid/sbo-test.with-sbr.user-workloads.yaml
+++ b/test/performance/user-workloads/valid/sbo-test.with-sbr.user-workloads.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   name: sbo-perf-with-sbr-valid
 objects:
@@ -126,4 +126,64 @@ objects:
         name: sbo-perf-app-valid
         group: apps
         version: v1
-        resource: deployments
+        kind: Deployment
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: sbo-perf-cronjob-valid
+    spec:
+      schedule: '@hourly'
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - name: wakeup
+                  image: busybox
+                  args:
+                    - /bin/sh
+                    - '-c'
+                    - date; echo 'Wake up!'
+              restartPolicy: Never
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: sbo-perf-cronjobs-view
+      labels:
+        servicebinding.io/controller: "true"
+    rules:
+      - apiGroups:
+          - batch
+        resources:
+          - cronjobs
+        verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+  - apiVersion: servicebinding.io/v1alpha3
+    kind: ClusterWorkloadResourceMapping
+    metadata:
+      name: cronjobs.batch
+    spec:
+      versions:
+        - version: "*"
+          volumes: .spec.jobTemplate.spec.template.spec.volumes
+          containers:
+            - path: .spec.jobTemplate.spec.template.spec.containers[*]
+            - path: .spec.jobTemplate.spec.template.spec.initContainers[*]
+  - apiVersion: servicebinding.io/v1alpha3
+    kind: ServiceBinding
+    metadata:
+      name: service-binding-cron-valid
+    spec:
+      type: busybox
+      service:
+        apiVersion: v1
+        kind: Service
+        name: sbo-perf-svc-valid
+      workload:
+        apiVersion: batch/v1
+        kind: CronJob
+        name: sbo-perf-cronjob-valid

--- a/test/performance/user-workloads/valid/sbo-test.without-sbr.user-workloads.yaml
+++ b/test/performance/user-workloads/valid/sbo-test.without-sbr.user-workloads.yaml
@@ -108,3 +108,49 @@ objects:
       to:
         kind: "Service"
         name: sbo-perf-svc-valid
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: sbo-perf-cronjob-valid
+    spec:
+      schedule: '@hourly'
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - name: wakeup
+                  image: busybox
+                  args:
+                    - /bin/sh
+                    - '-c'
+                    - date; echo 'Wake up!'
+              restartPolicy: Never
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: sbo-perf-cronjobs-view
+      labels:
+        servicebinding.io/controller: "true"
+    rules:
+      - apiGroups:
+          - batch
+        resources:
+          - cronjobs
+        verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+  - apiVersion: servicebinding.io/v1alpha3
+    kind: ClusterWorkloadResourceMapping
+    metadata:
+      name: cronjobs.batch
+    spec:
+      versions:
+        - version: "*"
+          volumes: .spec.jobTemplate.spec.template.spec.volumes
+          containers:
+            - path: .spec.jobTemplate.spec.template.spec.containers[*]
+            - path: .spec.jobTemplate.spec.template.spec.initContainers[*]


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Ref:
* https://issues.redhat.com/browse/APPSVC-1109
* https://issues.redhat.com/browse/APPSVC-1122

# Changes

This PR:
* Extends performance testing framework to support SPEC API resources
* SPEC API resources are added as user workloads to be used along with CoreOS resources in the performance test
* Adds workload resource mapping for `cronjobs.batch` resources
* Adds `CronJob` as one of the workloads to be bound and a `ServiceBinding` resource to bind it
* Adds service binding with a label selector in the `incomplete` scenario
* The overall number of simulated users is kept

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

