### PR TITLE
Add/Remove acceptance-tests-skipped label for PRs

### DIFF
--- a/.github/actions/check-skip-acceptance-tests/action.yaml
+++ b/.github/actions/check-skip-acceptance-tests/action.yaml
@@ -1,6 +1,11 @@
 # action.yml
 name: 'Check if acceptance tests can be skipped'
 description: 'Check if acceptance tests can be skipped based on the PR content'
+inputs:
+  set-label:
+    description: "Name of the label to be set/un-set on PRs. Label would not be set/unset if empty"
+    required: false
+    default: ""
 outputs:
   can_skip:
     description: "true if acceptance teststests can be skipped"
@@ -18,6 +23,9 @@ runs:
           let overallCount = 0;
           let pageSize = 100;
           let maxPages = 30;
+
+          const labelName = "${{ inputs.set-label }}"
+          const setLabel = labelName.length > 0
 
           do {
             const result = await github.rest.pulls.listFiles({
@@ -66,11 +74,37 @@ runs:
           const canSkip = (overallCount == 0 && currentPage <= maxPages)
           if(canSkip){
             console.log("The PR changes neither SBO release, images nor manifests, nor the acceptance testing framework, nor the related CI. Execution of the acceptance tests CAN be skipped. (See https://issues.redhat.com/browse/APPSVC-1116)")
+            if(setLabel){
+              console.log("Setting label: " + labelName)
+              const result = await github.rest.issues.addLabels({
+                owner: context.payload.repository.owner.login,
+                repo: context.payload.repository.name,
+                issue_number: context.payload.number,
+                labels: [labelName]
+              })
+            }
           } else {
             if (currentPage > maxPages) {
               console.log("Overall the PR changes more than the maximum number of " + (pageSize * maxPages) + " files and so cannot be determined if any of those beyond effect SBO release, images or manifests, or the acceptance testing framework, or the related CI. The acceptance tests CAN NOT be skipped.")
             } else {
               console.log("The PR changes files that effect SBO release, images or manifests, or the acceptance testing framework, or the related CI. The acceptance tests CAN NOT be skipped.")
+            }
+            if(setLabel){
+              const labels = await github.rest.issues.listLabelsOnIssue({
+                owner: context.payload.repository.owner.login,
+                repo: context.payload.repository.name,
+                issue_number: context.payload.number,
+                per_page: 100
+              })
+              if(labels.data.filter(f => f.name == labelName).length > 0){
+                console.log("Removing label: " + labelName)
+                const result = await github.rest.issues.removeLabel({
+                  owner: context.payload.repository.owner.login,
+                  repo: context.payload.repository.name,
+                  issue_number: context.payload.number,
+                  name: labelName
+                })
+              }
             }
           }
 

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,0 +1,21 @@
+name: "Manage acceptance-tests-skipped label"
+
+on:
+  pull_request_target:
+    branches:
+      - master
+
+jobs:
+  acceptance-tests-skipped-label:
+    name: "Manage acceptance-tests-skipped label"
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v2
+
+      - name: Check if acceptance tests can be skipped
+        id: check-skip-acceptance
+        uses: ./.github/actions/check-skip-acceptance-tests
+        with:
+          set-label: acceptance-tests-skipped


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Follow-up to: https://github.com/redhat-developer/service-binding-operator/pull/1150

# Changes

This PR:
* Extends the `check-skip-acceptance-tests` GitHub Action to be able to set or unset the specified label on a PR that can skip (or can't skip resp.)
* Adds a `pull_request_target` scoped workflow using that action to set or unset `acceptance-tests-skipped` label

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

