### PR TITLE
Switch release versions of docs to vX.Y.Z-docs branches

### DIFF
--- a/antora-playbook.github.yaml
+++ b/antora-playbook.github.yaml
@@ -7,10 +7,10 @@ content:
     - branches: HEAD
       start_paths: docs/userguide, docs/devguide
       url: https://github.com/redhat-developer/service-binding-operator
-    - branches: v1.0.1
+    - branches: v1.0.1-docs
       start_paths: docs/userguide, docs/devguide
       url: https://github.com/redhat-developer/service-binding-operator
-    - branches: v1.0.0
+    - branches: v1.0.0-docs
       start_paths: docs/userguide
       url: https://github.com/redhat-developer/service-binding-operator
 ui:

--- a/antora-playbook.local.yaml
+++ b/antora-playbook.local.yaml
@@ -7,10 +7,10 @@ content:
     - branches: HEAD
       start_paths: docs/userguide, docs/devguide
       url: ./
-    - branches: v1.0.1
+    - branches: v1.0.1-docs
       start_paths: docs/userguide, docs/devguide
       url: ./
-    - branches: v1.0.0
+    - branches: v1.0.0-docs
       start_paths: docs/userguide
       url: ./
 ui:


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Currently, the release version docs are sources in `vX.Y.Z` branches which makes it ambiguous with the release tags.

Switching to (renaming) the `vX.Y.Z-docs` branches makes it unique and clear what the purpose of the branches actually is.

# Changes

This PR:
* Switches the release versions sources to use the `vX.Y.Z-docs` branches.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

