### PR TITLE
Fix generated filenames for controller role and rolebinding to follow naming convention in bundle

### DIFF
--- a/make/build.mk
+++ b/make/build.mk
@@ -25,7 +25,7 @@ bundle: manifests kustomize yq kubectl-slice push-image
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(YQ) e -i '.metadata.annotations.containerImage="$(OPERATOR_REPO_REF)@$(OPERATOR_IMAGE_SHA_REF)"' bundle/manifests/service-binding-operator.clusterserviceversion.yaml
 	# this is needed because operator-sdk 1.16 filters out aggregated cluster role and the accompanied binding
-	$(KUSTOMIZE) build config/manifests | $(YQ) e 'select((.kind == "ClusterRole" and .metadata.name == "service-binding-controller-role") or (.kind == "ClusterRoleBinding" and .metadata.name == "service-binding-controller-rolebinding"))' - | $(KUBECTL_SLICE) -o bundle/manifests
+	$(KUSTOMIZE) build config/manifests | $(YQ) e 'select((.kind == "ClusterRole" and .metadata.name == "service-binding-controller-role") or (.kind == "ClusterRoleBinding" and .metadata.name == "service-binding-controller-rolebinding"))' - | $(KUBECTL_SLICE) -o bundle/manifests -t '{{.metadata.name}}_{{.apiVersion | replace "/" "_"}}_{{.kind | lower}}.yaml'
 	operator-sdk bundle validate ./bundle --select-optional name=operatorhub
 
 .PHONY: registry-login


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Currently, the bundle manifests generated by `make bundle` follow a certain naming convention: `service-binding-<name>-<group>_<version>-<kind>.yaml` except for the `clusterrole-service-binding-controller-role.yaml` and `clusterrolebinding-service-binding-controller-rolebinding.yaml` files.

For the RedHat downstream releases, those 2 files need to be manually renamed to follow the above naming convention.

# Changes

This PR:
* Fixes the generated names of the above 2 files to follow the bundle manifest's file naming convention

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

