### PR TITLE
webhooks: validate workload resource mapping resources

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,10 @@
 domain: operators.coreos.com
-layout: go.kubebuilder.io/v3
+layout:
+- go.kubebuilder.io/v3
 multigroup: true
+plugins:
+  manifests.sdk.operatorframework.io/v2: {}
+  scorecard.sdk.operatorframework.io/v2: {}
 projectName: service-binding-operator
 repo: github.com/redhat-developer/service-binding-operator
 resources:
@@ -30,12 +34,20 @@ resources:
     webhookVersion: v1
 - api:
     crdVersion: v1
+  controller: true
+  domain: operators.coreos.com
+  group: spec
+  kind: ClusterWorkloadResourceMapping
+  path: github.com/redhat-developer/service-binding-operator/apis/spec/v1alpha3
+  version: v1alpha3
+  webhooks:
+    validation: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
   domain: operators.coreos.com
   group: binding
   kind: BindableKinds
   path: github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1
   version: v1alpha1
 version: "3"
-plugins:
-  manifests.sdk.operatorframework.io/v2: {}
-  scorecard.sdk.operatorframework.io/v2: {}

--- a/apis/spec/v1alpha3/clusterworkloadresourcemapping_types.go
+++ b/apis/spec/v1alpha3/clusterworkloadresourcemapping_types.go
@@ -92,9 +92,13 @@ type ClusterWorkloadResourceMappingList struct {
 	Items []ClusterWorkloadResourceMapping `json:"items"`
 }
 
+func init() {
+	SchemeBuilder.Register(&ClusterWorkloadResourceMapping{}, &ClusterWorkloadResourceMappingList{})
+}
+
 var DefaultTemplate = ClusterWorkloadResourceMappingTemplate{
 	Version:     "*",
-	Annotations: "",
+	Annotations: ".spec.template.spec.annotations",
 	Volumes:     ".spec.template.spec.volumes",
 	Containers: []ClusterWorkloadResourceMappingContainer{
 		{

--- a/apis/spec/v1alpha3/clusterworkloadresourcemapping_webhook.go
+++ b/apis/spec/v1alpha3/clusterworkloadresourcemapping_webhook.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/util/jsonpath"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (r *ClusterWorkloadResourceMapping) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-servicebinding-io-v1alpha3-clusterworkloadresourcemapping,mutating=false,failurePolicy=fail,sideEffects=None,groups=servicebinding.io,resources=clusterworkloadresourcemappings,verbs=create;update,versions=v1alpha3,name=vclusterworkloadresourcemapping.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &ClusterWorkloadResourceMapping{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (m *ClusterWorkloadResourceMapping) ValidateCreate() error {
+	return m.validate()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (m *ClusterWorkloadResourceMapping) ValidateUpdate(old runtime.Object) error {
+	return m.validate()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (m *ClusterWorkloadResourceMapping) ValidateDelete() error {
+	// don't currently need validation of resource removal
+	return nil
+}
+
+func (m *ClusterWorkloadResourceMapping) validate() error {
+	errs := field.ErrorList{}
+	path := field.NewPath("spec")
+	versions := map[string]int{}
+
+	for i, template := range m.Spec.Versions {
+		childPath := path.Child(fmt.Sprintf("versions[%d]", i))
+		if template.Version == "" {
+			errs = append(errs, field.Required(childPath.Child("version"), "field \"version\" required"))
+		} else if strings.TrimSpace(template.Version) == "" {
+			errs = append(errs, field.Invalid(childPath.Child("version"), template.Version, "Whitespace-only version field forbidden"))
+		} else if _, ok := versions[template.Version]; ok {
+			errs = append(errs, field.Duplicate(childPath, template.Version))
+		}
+
+		versions[template.Version] = i
+		errs = append(errs, template.validate(childPath)...)
+	}
+
+	return errs.ToAggregate()
+}
+
+func (template *ClusterWorkloadResourceMappingTemplate) validate(path *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+	for i, container := range template.Containers {
+		child := path.Child(fmt.Sprintf("containers[%d]", i))
+		errs = append(errs, container.validate(child)...)
+	}
+
+	errs = append(errs, validateRestrictedPath(path.Child("volumes"), template.Volumes)...)
+	errs = append(errs, validateRestrictedPath(path.Child("annotations"), template.Annotations)...)
+
+	return errs
+}
+
+func (container *ClusterWorkloadResourceMappingContainer) validate(path *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+
+	errs = append(errs, validateRestrictedPath(path.Child("name"), container.Name)...)
+	errs = append(errs, validateRestrictedPath(path.Child("env"), container.Env)...)
+	errs = append(errs, validateRestrictedPath(path.Child("volumeMounts"), container.VolumeMounts)...)
+
+	if container.Path == "" {
+		errs = append(errs, field.Required(path.Child("path"), "field \"path\" required"))
+	} else {
+		jsonpath := jsonpath.New("")
+		formatted := fmt.Sprintf("{%s}", container.Path)
+		if err := jsonpath.Parse(formatted); err != nil {
+			errs = append(errs, field.Invalid(path.Child("path"), container.Path, "Invalid JSONPath"))
+		}
+	}
+
+	return errs
+}
+
+func validateRestrictedPath(fieldPath *field.Path, value string) field.ErrorList {
+	if value != "" {
+		return isValidRestrictedJsonPath(fieldPath, value)
+	}
+	return nil
+}
+
+func isValidRestrictedJsonPath(fieldPath *field.Path, path string) field.ErrorList {
+	errs := field.ErrorList{}
+	parser, err := jsonpath.Parse("", fmt.Sprintf("{%s}", path))
+	if err != nil {
+		return append(errs, field.Invalid(fieldPath, path, "Unable to parse fixed JSONPath"))
+	}
+	if len(verifyJsonPath(parser.Root, fieldPath, path)) != 0 {
+		errs = append(errs, field.Invalid(fieldPath, path, "Invalid fixed JSONPath"))
+	}
+	return errs
+}
+
+func verifyJsonPath(node jsonpath.Node, path *field.Path, value string) field.ErrorList {
+	errs := field.ErrorList{}
+	switch node.Type() {
+	case jsonpath.NodeField:
+		break
+	case jsonpath.NodeList:
+		list := node.(*jsonpath.ListNode)
+		for _, node := range list.Nodes {
+			errs = append(errs, verifyJsonPath(node, path, value)...)
+		}
+	default:
+		errs = append(errs, field.Invalid(path, node.Type().String(), "Invalid node type"))
+	}
+	return errs
+}

--- a/apis/spec/v1alpha3/clusterworkloadresourcemapping_webhook_test.go
+++ b/apis/spec/v1alpha3/clusterworkloadresourcemapping_webhook_test.go
@@ -1,0 +1,222 @@
+package v1alpha3
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var _ = Describe("Validation Webhook", func() {
+	invalidEntries := []TableEntry{
+		Entry("Duplicate versions",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version: "v1",
+						},
+						{
+							Version: "v1",
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Duplicate(field.NewPath("spec", "versions[1]"), "v1"),
+			}.ToAggregate(),
+		),
+		Entry("Invalid restricted jsonpath - annotations",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version:     "v1",
+							Annotations: ".spec.template.spec.annotations[*]",
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec", "versions[0]", "annotations"), ".spec.template.spec.annotations[*]", "Invalid fixed JSONPath"),
+			}.ToAggregate(),
+		),
+		Entry("Invalid restricted jsonpath - volumes",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version: "v1",
+							Volumes: ".spec.template.spec.volumes[*]",
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec", "versions[0]", "volumes"), ".spec.template.spec.volumes[*]", "Invalid fixed JSONPath"),
+			}.ToAggregate(),
+		),
+		Entry("Invalid restricted jsonpath - container name",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version: "v1",
+							Containers: []ClusterWorkloadResourceMappingContainer{
+								{
+									Path: ".spec.template.spec.containers[*]",
+									Name: ".name[*]",
+								},
+							},
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec", "versions[0]", "containers[0]", "name"), ".name[*]", "Invalid fixed JSONPath"),
+			}.ToAggregate(),
+		),
+		Entry("Invalid restricted jsonpath - container env",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version: "v1",
+							Containers: []ClusterWorkloadResourceMappingContainer{
+								{
+									Path: ".spec.template.spec.containers[*]",
+									Env:  ".env[*]",
+								},
+							},
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec", "versions[0]", "containers[0]", "env"), ".env[*]", "Invalid fixed JSONPath"),
+			}.ToAggregate(),
+		),
+		Entry("Invalid restricted jsonpath - container volumeMounts",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version: "v1",
+							Containers: []ClusterWorkloadResourceMappingContainer{
+								{
+									Path:         ".spec.template.spec.containers[*]",
+									VolumeMounts: ".volumeMounts[*]",
+								},
+							},
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec", "versions[0]", "containers[0]", "volumeMounts"), ".volumeMounts[*]", "Invalid fixed JSONPath"),
+			}.ToAggregate(),
+		),
+		Entry("Invalid restricted jsonpath - failed to parse",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version: "v1",
+							Containers: []ClusterWorkloadResourceMappingContainer{
+								{
+									Path:         ".spec.template.spec.containers[*]",
+									VolumeMounts: ".volumeMounts[*",
+								},
+							},
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec", "versions[0]", "containers[0]", "volumeMounts"), ".volumeMounts[*", "Unable to parse fixed JSONPath"),
+			}.ToAggregate(),
+		),
+		Entry("Invalid jsonpath - path",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version: "v1",
+							Containers: []ClusterWorkloadResourceMappingContainer{
+								{
+									Path: ".spec.template.spec.containers[*",
+								},
+							},
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec", "versions[0]", "containers[0]", "path"), ".spec.template.spec.containers[*", "Invalid JSONPath"),
+			}.ToAggregate(),
+		),
+		Entry("Required version field",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Annotations: "",
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Required(field.NewPath("spec", "versions[0]", "version"), "field \"version\" required"),
+			}.ToAggregate(),
+		),
+		Entry("Required version field",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version: " \t\n",
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec", "versions[0]", "version"), " \t\n", "Whitespace-only version field forbidden"),
+			}.ToAggregate(),
+		),
+		Entry("Required path field",
+			ClusterWorkloadResourceMapping{
+				Spec: ClusterWorkloadResourceMappingSpec{
+					Versions: []ClusterWorkloadResourceMappingTemplate{
+						{
+							Version: "v1",
+							Containers: []ClusterWorkloadResourceMappingContainer{
+								{
+									Name: "",
+								},
+							},
+						},
+					},
+				},
+			},
+			field.ErrorList{
+				field.Required(field.NewPath("spec", "versions[0]", "containers[0]", "path"), "field \"path\" required"),
+			}.ToAggregate(),
+		),
+	}
+	DescribeTable("Reporting errors on invalid mappings",
+		func(mapping ClusterWorkloadResourceMapping, expected error) {
+			Expect(mapping.validate()).To(Equal(expected))
+		},
+		invalidEntries...,
+	)
+	It("should accept valid resources", func() {
+		mapping := ClusterWorkloadResourceMapping{
+			Spec: ClusterWorkloadResourceMappingSpec{
+				Versions: []ClusterWorkloadResourceMappingTemplate{
+					DefaultTemplate,
+				},
+			},
+		}
+		Expect(mapping.validate()).To(BeNil())
+	})
+})

--- a/config/crd/bases/binding.operators.coreos.com_bindablekinds.yaml
+++ b/config/crd/bases/binding.operators.coreos.com_bindablekinds.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: bindablekinds.binding.operators.coreos.com
 spec:

--- a/config/crd/bases/binding.operators.coreos.com_servicebindings.yaml
+++ b/config/crd/bases/binding.operators.coreos.com_servicebindings.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: servicebindings.binding.operators.coreos.com
 spec:
@@ -228,12 +229,13 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/crd/bases/servicebinding.io_clusterworkloadresourcemappings.yaml
+++ b/config/crd/bases/servicebinding.io_clusterworkloadresourcemappings.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: clusterworkloadresourcemappings.servicebinding.io
 spec:

--- a/config/crd/bases/servicebinding.io_servicebindings.yaml
+++ b/config/crd/bases/servicebinding.io_servicebindings.yaml
@@ -1,9 +1,10 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: servicebindings.servicebinding.io
 spec:
@@ -184,12 +185,13 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -45,6 +46,7 @@ webhooks:
     resources:
     - servicebindings
   sideEffects: None
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -71,6 +73,26 @@ webhooks:
     - UPDATE
     resources:
     - servicebindings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-servicebinding-io-v1alpha3-clusterworkloadresourcemapping
+  failurePolicy: Fail
+  name: vclusterworkloadresourcemapping.kb.io
+  rules:
+  - apiGroups:
+    - servicebinding.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterworkloadresourcemappings
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/main.go
+++ b/main.go
@@ -22,9 +22,10 @@ import (
 	"os"
 	"sync"
 
-	"github.com/redhat-developer/service-binding-operator/apis/webhooks"
 	v1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1beta1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
+	"github.com/redhat-developer/service-binding-operator/apis/webhooks"
 
 	crdcontrollers "github.com/redhat-developer/service-binding-operator/controllers/crd"
 
@@ -45,7 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	specv1alpha2 "github.com/redhat-developer/service-binding-operator/apis/spec/v1alpha3"
+	specv1alpha3 "github.com/redhat-developer/service-binding-operator/apis/spec/v1alpha3"
 	speccontrollers "github.com/redhat-developer/service-binding-operator/controllers/spec"
 	// +kubebuilder:scaffold:imports
 )
@@ -59,7 +60,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
-	utilruntime.Must(specv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(specv1alpha3.AddToScheme(scheme))
 	utilruntime.Must(v1apiextensions.AddToScheme(scheme))
 	utilruntime.Must(v1beta1apiextensions.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
@@ -147,10 +148,15 @@ func main() {
 		os.Exit(1)
 	}
 	webhooks.SetupWithManager(mgr, serviceAccountName)
-	if err = (&specv1alpha2.ServiceBinding{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&specv1alpha3.ServiceBinding{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "SPEC ServiceBinding")
 		os.Exit(1)
 	}
+	if err = (&specv1alpha3.ClusterWorkloadResourceMapping{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "ClusterWorkloadResourceMapping")
+		os.Exit(1)
+	}
+
 	bindableKinds := &sync.Map{}
 	if err = (&crdcontrollers.CrdReconciler{
 		Client: mgr.GetClient(),

--- a/test/acceptance/features/steps/steps.py
+++ b/test/acceptance/features/steps/steps.py
@@ -469,3 +469,10 @@ def check_service_account_bound(context, cluster_role_name, cluster_rolebinding_
 @step(u'{time_min} minutes have passed')
 def step_impl(context, time_min):
     time.sleep(60 * int(time_min))
+
+
+@step(u'Invalid Workload Resource Mapping is applied')
+def invalid_mapping_is_applied(context):
+    openshift = Openshift()
+    resource = substitute_scenario_id(context, context.text)
+    context.expected_error = openshift.apply_invalid(resource)

--- a/test/acceptance/features/workloadResourceMapping.feature
+++ b/test/acceptance/features/workloadResourceMapping.feature
@@ -729,3 +729,51 @@ Feature: Bind services to workloads based on workload resource mapping
         And jsonpath "{.spec.spec.containers}" on "appconfigs/$scenario_id-appconfig" should return no value
         And jsonpath "{.spec.template.spec.containers[0].volumeMounts}" on "appconfigs/$scenario_id-appconfig" should return "[{"mountPath":"/bindings/$scenario_id-binding","name":"$scenario_id-binding"}]"
         And jsonpath "{.spec.spec.volumes}" on "appconfigs/$scenario_id-appconfig" should return "[{"name":"$scenario_id-binding","secret":{"secretName":"$scenario_id-secret"}}]"
+
+    @spec
+    @negative
+    Scenario: Multiple version entries with the same versions may not be specified
+        When Invalid Workload Resource Mapping is applied
+            """
+            apiVersion: servicebinding.io/v1alpha3
+            kind: ClusterWorkloadResourceMapping
+            metadata:
+                name: appconfigs.stable.example.com
+            spec:
+                versions:
+                  - version: "v1"
+                  - version: "v1"
+            """
+        Then Error message is thrown
+
+    @spec
+    @negative
+    Scenario: Invalid fixed jsonpaths may not be set
+        When Invalid Workload Resource Mapping is applied
+            """
+            apiVersion: servicebinding.io/v1alpha3
+            kind: ClusterWorkloadResourceMapping
+            metadata:
+                name: appconfigs.stable.example.com
+            spec:
+                versions:
+                  - version: "v1"
+                    annotations: .spec.template.spec.annotations[*]
+            """
+        Then Error message is thrown
+
+    @spec
+    @negative
+    Scenario: Required fields must be set
+        When Invalid Workload Resource Mapping is applied
+            """
+            apiVersion: servicebinding.io/v1alpha3
+            kind: ClusterWorkloadResourceMapping
+            metadata:
+                name: appconfigs.stable.example.com
+            spec:
+                versions:
+                  - containers:
+                      - name: .metadata.name
+            """
+        Then Error message is thrown


### PR DESCRIPTION
Implement validation webhooks for incoming & modified ClusterWorkloadResourceMapping.servicebinding.io resources.  Deletion is left unhandled; it's not clear if we need to implement deletion validation.

Signed-off-by: Andy Sadler <ansadler@redhat.com>

# Changes

/kind enhancement

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

