### PR TITLE
docs: use workload terminology for spec API

### DIFF
--- a/docs/userguide/modules/binding-workloads-using-sbo/pages/creating-service-binding.adoc
+++ b/docs/userguide/modules/binding-workloads-using-sbo/pages/creating-service-binding.adoc
@@ -29,10 +29,10 @@ spec:
     kind: Deployment
     name: online-banking
   services: <2>
-  - version: v1alpha1 
-    group: example.com 
-    kind: AccountService 
-    name: prod-account-service 
+  - version: v1alpha1
+    group: example.com
+    kind: AccountService
+    name: prod-account-service
 ----
 <1> Specifies a list of service resources.
 <2> The sample application that points to a Deployment or any other similar resource with an embedded PodSpec.
@@ -45,7 +45,7 @@ kind: ServiceBinding
 metadata:
   name: account-service
 spec:
-  application:  <1>
+  workload:  <1>
     apiVersion: apps/v1
     kind: Deployment
     name: online-banking

--- a/docs/userguide/modules/exposing-binding-data/pages/provisioned-service.adoc
+++ b/docs/userguide/modules/exposing-binding-data/pages/provisioned-service.adoc
@@ -69,7 +69,7 @@ spec:
     apiVersion: example.com/v1alpha1
     kind: AccountService
     name: prod-account-service
-  application:
+  workload:
     apiVersion: apps/v1
     kind: Deployment
     name: nodejs-app


### PR DESCRIPTION
The specification hasn't used the noun "application" to refer to workloads for a little while, but our documentation still had a few references to that terminology.  This changes them to use "workload" instead.

Signed-off-by: Andy Sadler <ansadler@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind docs

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

