### PR TITLE
Do not skip acceptance tests if the main Dockerfile is changed.

### DIFF
--- a/.github/actions/check-skip-acceptance-tests/action.yaml
+++ b/.github/actions/check-skip-acceptance-tests/action.yaml
@@ -45,23 +45,24 @@ runs:
                 f.filename.startsWith("build") ||
                 f.filename.startsWith("config") ||
                 f.filename.startsWith("controllers") ||
-                f.filename.startsWith("hack/get-test-namespace") ||
-                f.filename.startsWith("hack/remove-sbr-finalizers.sh") ||
-                f.filename.startsWith("hack/test-cleanup.sh") ||
+                f.filename === "hack/get-test-namespace" ||
+                f.filename === "hack/remove-sbr-finalizers.sh" ||
+                f.filename === "hack/test-cleanup.sh" ||
                 f.filename.startsWith("controllers") ||
-                f.filename.startsWith("make/acceptance.mk") ||
-                f.filename.startsWith("make/build.mk") ||
-                f.filename.startsWith("make/common.mk") ||
-                f.filename.startsWith("make/release.mk") ||
-                f.filename.startsWith("make/version.mk") ||
+                f.filename === "make/acceptance.mk" ||
+                f.filename === "make/build.mk" ||
+                f.filename === "make/common.mk" ||
+                f.filename === "make/release.mk" ||
+                f.filename === "make/version.mk" ||
                 f.filename.startsWith("pkg") ||
                 f.filename.startsWith("test/acceptance") ||
                 f.filename.startsWith("tools") ||
                 f.filename.startsWith("vendor") ||
-                f.filename.startsWith("go.mod") ||
-                f.filename.startsWith("go.sum") ||
-                f.filename.startsWith("install.sh") ||
-                f.filename.startsWith("main.go")
+                f.filename === "Dockerfile" ||
+                f.filename === "go.mod" ||
+                f.filename === "go.sum" ||
+                f.filename === "install.sh" ||
+                f.filename === "main.go"
               )
             fileSet.forEach(i => console.log(" > " + i.status + ": " + i.filename))
             overallCount = overallCount + fileSet.length


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Currently the skip detector misses the main `Dockerfile` as in case of #1166. This PR:
* Includes the main `Dockerfile`
* Changes the filter to match files exactly (instead of using `.startsWith` method as for directories)

The skipping filter for acceptance tests with OpenShift (CI) is covered by https://github.com/openshift/release/pull/29427

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

