### PR TITLE
Print subject access review error to logs.

### DIFF
--- a/pkg/reconcile/pipeline/context/impl.go
+++ b/pkg/reconcile/pipeline/context/impl.go
@@ -18,6 +18,7 @@ import (
 	v1 "k8s.io/api/authorization/v1"
 	clientauthzv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/redhat-developer/service-binding-operator/pkg/converter"
 	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
@@ -33,7 +34,10 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-var _ pipeline.Context = &bindingImpl{}
+var (
+	_          pipeline.Context = &bindingImpl{}
+	contextLog                  = ctrl.Log.WithName("pipeline-context")
+)
 
 type impl struct {
 	client dynamic.Interface
@@ -188,6 +192,7 @@ func (i *impl) canPerform(gvr *schema.GroupVersionResource, name string, namespa
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
+		contextLog.Error(err, "unable to review subject access")
 		return false
 	}
 	return sar.Status.Allowed


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Related to: #1172 

# Changes

Currently, if error occurs which is related to getting Subject Access Review for a ClusterWorkloadResourceMapping resources. The error is not shown to explain the reason and only the `false` value is returned.

This PR adds an error log for such events to see the root cause of the error.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

