### PR TITLE
Add missing cluster role and binding for reading ClusterWorkloadResourceMapping for any authenticated subject

### DIFF
--- a/config/rbac/clusterworkloadresourcemappings_viewer_role.yaml
+++ b/config/rbac/clusterworkloadresourcemappings_viewer_role.yaml
@@ -1,0 +1,16 @@
+# permissions for end users to view bindablekinds.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: clusterworkloadresourcemappings-viewer-role
+rules:
+- apiGroups:
+  - servicebinding.io
+  resources:
+  - clusterworkloadresourcemappings
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/rbac/clusterworkloadresourcemappings_viewer_rolebinding.yaml
+++ b/config/rbac/clusterworkloadresourcemappings_viewer_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clusterworkloadresourcemappings-viewer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-binding-clusterworkloadresourcemappings-viewer-role
+subjects:
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
 - servicebinding_viewer_role.yaml
 - bindablekinds_viewer_role.yaml
 - bindablekinds_viewer_rolebinding.yaml
+- clusterworkloadresourcemappings_viewer_role.yaml
+- clusterworkloadresourcemappings_viewer_rolebinding.yaml
 - servicebinding_controller_role.yaml
 - servicebinding_controller_rolebinding.yaml
 # operators supproted out of the box


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

There are cluster role and binding missing to read the CWRM resources to any users. This is something that (according to the dev sandbox team) is not part of the dev sandbox configuration, but is supposed to be part of the SBO bundle - similarly as in case of the `BindableKinds` resource.

# Changes

This PR adds missing `ClusterRole` and `ClusterRoleBinding` for reading (`get`, `list`, `watch`) the `ClusterWorkloadResourceMapping` resources to any authenticated subject (incl. dev sandbox users).

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

