### PR TITLE
fix(ci): collect kube resources and split acceptance testing jobs

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     env:
-      EXTRA_BEHAVE_ARGS: "--tags=~@knative --tags=~@openshift --tags=~@examples --tags=~@supported-operator --tags=~@optional-annotations --tags=~@disable-github-actions"
+      EXTRA_BEHAVE_ARGS: "--tags=~@knative --tags=~@openshift --tags=~@examples --tags=~@supported-operator --tags=~@optional-annotations --tags=~@workload-resource-mapping --tags=~@disable-github-actions"
       TEST_RUN: Acceptance_tests_Kubernetes_with_OLM
 
     steps:
@@ -116,7 +116,7 @@ jobs:
           make SKIP_REGISTRY_LOGIN=true -o registry-login test-acceptance-with-bundle
 
       - name: Collect Kube resources
-        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         continue-on-error: true
         uses: ./.github/actions/collect-kube-resources
         with:
@@ -137,7 +137,7 @@ jobs:
           testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
 
       - uses: actions/upload-artifact@v2
-        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         with:
           name: kubernetes-with-olm-test-results
           path: ${{ env.TEST_RESULTS }}
@@ -196,7 +196,7 @@ jobs:
           make SKIP_REGISTRY_LOGIN=true -o registry-login test-acceptance-with-bundle
 
       - name: Collect Kube resources
-        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         continue-on-error: true
         uses: ./.github/actions/collect-kube-resources
         with:
@@ -217,11 +217,10 @@ jobs:
           testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
 
       - uses: actions/upload-artifact@v2
-        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         with:
-          name: supported-operators-kubernetes
+          name: optional-annotations
           path: ${{ env.TEST_RESULTS }}
-
 
   acceptance-supported-operators:
     name: Supported Operators Acceptance Tests with Kubernetes and using OLM
@@ -277,7 +276,7 @@ jobs:
           make SKIP_REGISTRY_LOGIN=true -o registry-login test-acceptance-with-bundle
 
       - name: Collect Kube resources
-        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         continue-on-error: true
         uses: ./.github/actions/collect-kube-resources
         with:
@@ -298,9 +297,89 @@ jobs:
           testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
 
       - uses: actions/upload-artifact@v2
-        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         with:
           name: supported-operators-kubernetes
+          path: ${{ env.TEST_RESULTS }}
+
+  acceptance-workload-resource-mapping:
+    name: Workload Resource Mapping Acceptance Tests with Kubernetes and using OLM
+    runs-on: ubuntu-20.04
+
+    env:
+      EXTRA_BEHAVE_ARGS: "--tags=@workload-resource-mapping --tags=~@disable-github-actions"
+      TEST_RUN: Workload_Resource_Mapping_Acceptance_tests_Kubernetes_with_OLM
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v2
+
+      - name: Check if acceptance tests can be skipped
+        id: check-skip-acceptance
+        uses: ./.github/actions/check-skip-acceptance-tests
+
+      - name: Set up Python
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+          architecture: "x64"
+
+      - name: Setup-cli
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        uses: ./.github/actions/setup-cli
+        with:
+          start-minikube: true
+
+      - name: Wait for push
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        uses: lewagon/wait-on-check-action@1b1630e169116b58a4b933d5ad7effc46d3d312d
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: "Push operator images (PR)"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 60
+
+      - name: Extract image references
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
+        with:
+          names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
+
+      - name: Acceptance tests
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        timeout-minutes: 60
+        run: |
+          source ./operator.refs
+          export CATSRC_NAME=sbo-pr-checks
+
+          make SKIP_REGISTRY_LOGIN=true -o registry-login test-acceptance-with-bundle
+
+      - name: Collect Kube resources
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
+        continue-on-error: true
+        uses: ./.github/actions/collect-kube-resources
+        with:
+          operator-namespace: operators
+          olm-namespace: olm
+          test-namespace-file: out/test-namespace
+          output-path: ${{env.TEST_RESULTS}}
+
+      - name: Setup Testspace
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        uses: testspace-com/setup-testspace@v1
+        with:
+          domain: ${{ github.repository_owner }}
+
+      - name: Publish tests results to Testspace
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        run: |
+          testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
+        with:
+          name: workload-resource-mapping
           path: ${{ env.TEST_RESULTS }}
 
   acceptance_without_olm:
@@ -374,7 +453,7 @@ jobs:
           make TEST_ACCEPTANCE_START_SBO=remote test-acceptance
 
       - name: Collect Kube resources
-        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         continue-on-error: true
         uses: ./.github/actions/collect-kube-resources
         with:
@@ -394,7 +473,7 @@ jobs:
           testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
 
       - uses: actions/upload-artifact@v2
-        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
+        if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         with:
           name: kubernetes-without-olm-test-results
           path: ${{ env.TEST_RESULTS }}

--- a/hack/collect-kube-resources.sh
+++ b/hack/collect-kube-resources.sh
@@ -5,7 +5,7 @@ OPNS="$(kubectl get namespaces -o name | grep -E '.*/(.+-)?operators$' || test $
 OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE:-${OPNS#"namespace/"}}
 OLM_NAMESPACE="${OLM_NAMESPACE:-$(kubectl get catalogsources.operators.coreos.com --all-namespaces -o jsonpath='{.items[0].metadata.namespace}' --ignore-not-found=true)}"
 OUTPUT_PATH=${OUTPUT_PATH:-out/acceptance-tests/resources}
-TEST_NAMESPACE_FILE=${TEST_NAMESPACE_FILE:-$OUTPUT_DIR/test-namespace}
+TEST_NAMESPACE_FILE=${TEST_NAMESPACE_FILE:-out/test-namespace}
 set +x
 
 echo "Collecting Kubernetes resources..."

--- a/test/acceptance/features/workloadResourceMapping.feature
+++ b/test/acceptance/features/workloadResourceMapping.feature
@@ -1,3 +1,4 @@
+@workload-resource-mapping
 Feature: Bind services to workloads based on workload resource mapping
 
     As a user, I would like to be able to use workload resource bindings as defined by the specification.


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Currently, when acceptance tests fail, the kube resources are not collected and archived by GH actions for debug purposes.

Additionally, one of the acceptance tests started to fail recently in the Kubernetes with OLM job due to too many pods being created in the minikube. That prevented creation of the pods for the test which caused the test to fail.

# Changes
This PR:
* Enables collecting and archiving kube resources for GH actions for situations when acceptance tests failed.
* Moves Workload Resource Mapping PR Check acceptance tests to the separate job.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

