### PR TITLE
Extend the acceptance testing framework to support installing operator with both manual and automatic subscriptions

### DIFF
--- a/test/acceptance/features/steps/crunchypostgresoperator.py
+++ b/test/acceptance/features/steps/crunchypostgresoperator.py
@@ -1,3 +1,4 @@
+from subscription_install_mode import InstallMode
 from olm import Operator
 from environment import ctx
 from behave import given
@@ -21,6 +22,6 @@ class CrunchyPostgresOperator(Operator):
 def install(_context):
     operator = CrunchyPostgresOperator()
     if not operator.is_running():
-        operator.install_operator_subscription()
+        operator.install_operator_subscription(install_mode=InstallMode.Manual)
         operator.is_running(wait=True)
     print("Crunchy Data Postgres operator is running")

--- a/test/acceptance/features/steps/olm.py
+++ b/test/acceptance/features/steps/olm.py
@@ -1,6 +1,7 @@
 import re
 
 from command import Command
+from subscription_install_mode import InstallMode
 from openshift import Openshift
 
 
@@ -37,11 +38,12 @@ class Operator(object):
                 return False
         return self.openshift.wait_for_package_manifest(self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel)
 
-    def install_operator_subscription(self, csv_version=None):
+    def install_operator_subscription(self, csv_version=None, install_mode=InstallMode.Automatic):
         install_sub_output = self.openshift.create_operator_subscription(
             self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel,
-            self.operator_subscription_csv_version if csv_version is None else csv_version)
+            self.operator_subscription_csv_version if csv_version is None else csv_version, install_mode)
         if re.search(r'.*subscription.operators.coreos.com/%s\s(unchanged|created)' % self.package_name, install_sub_output) is None:
             print("Failed to create {} operator subscription".format(self.package_name))
             return False
+        self.openshift.approve_operator_subscription(self.package_name)
         return True

--- a/test/acceptance/features/steps/subscription_install_mode.py
+++ b/test/acceptance/features/steps/subscription_install_mode.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class InstallMode(Enum):
+    Automatic = "Automatic"
+    Manual = "Manual"


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Ref: https://issues.redhat.com/browse/APPSVC-1151

# Changes

This PR:
* Extends the `Operator.install_operator_subscription()` method with additional optional parameter `install_node` (with "Automatic" as the default).
* The method also automatically approves the related InstallPlan if install_mode is "Manual".

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

