### PR TITLE
Tweak golangci-lint to avoid out-of-memory in Github Actions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -753,7 +753,6 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -11,15 +11,26 @@ lint-yaml: ${YAML_FILES}
 	$(Q)$(PYTHON_VENV_DIR)/bin/pip install yamllint==1.23.0
 	$(Q)$(PYTHON_VENV_DIR)/bin/yamllint -c .yamllint $(YAML_FILES)
 
+GO_LINT_CMD = $(Q)GOFLAGS="$(GOFLAGS)" GOGC=30 GOCACHE=$(GOCACHE) $(OUTPUT_DIR)/golangci-lint ${V_FLAG} run --concurrency=1 --verbose --deadline=30m --disable-all --enable
+
 .PHONY: lint-go-code
 ## Checks GO code
 lint-go-code: $(GOLANGCI_LINT_BIN) fmt vet
 	# This is required for OpenShift CI enviroment
 	# Ref: https://github.com/openshift/release/pull/3438#issuecomment-482053250
-	$(Q)GOFLAGS="$(GOFLAGS)" GOCACHE="$(GOCACHE)" $(OUTPUT_DIR)/golangci-lint ${V_FLAG} run --deadline=30m
+	$(GO_LINT_CMD) deadcode
+	$(GO_LINT_CMD) gosimple
+	$(GO_LINT_CMD) staticcheck
+	$(GO_LINT_CMD) errcheck
+	$(GO_LINT_CMD) govet
+	$(GO_LINT_CMD) ineffassign
+	$(GO_LINT_CMD) structcheck
+	$(GO_LINT_CMD) typecheck
+	$(GO_LINT_CMD) unused
+	$(GO_LINT_CMD) varcheck
 
 $(GOLANGCI_LINT_BIN):
-	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.45.2
+	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.48.0
 
 .PHONY: lint-python-code
 ## Check the python code

--- a/pkg/client/kubernetes/whoami.go
+++ b/pkg/client/kubernetes/whoami.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	authenticationapi "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -11,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -55,7 +55,7 @@ func WhoAmI(config *rest.Config) (string, error) {
 	// from vendor/k8s.io/client-go/transport/round_trippers.go:HTTPWrappersForConfig function, tokenauth has preference over basicauth
 	if transportConfig.HasTokenAuth() {
 		if config.BearerTokenFile != "" {
-			d, err := ioutil.ReadFile(config.BearerTokenFile)
+			d, err := os.ReadFile(config.BearerTokenFile)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/reconcile/pipeline/context/impl.go
+++ b/pkg/reconcile/pipeline/context/impl.go
@@ -230,9 +230,7 @@ func (i *bindingImpl) Services() ([]pipeline.Service, error) {
 		}
 	}
 	services := make([]pipeline.Service, len(i.services))
-	for idx := 0; idx < len(i.services); idx++ {
-		services[idx] = i.services[idx]
-	}
+	copy(services, i.services)
 	return services, nil
 }
 

--- a/pkg/reconcile/pipeline/context/spec_binding_impl.go
+++ b/pkg/reconcile/pipeline/context/spec_binding_impl.go
@@ -12,7 +12,7 @@ import (
 	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
 	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline/context/service"
 	"golang.org/x/time/rate"
-	"k8s.io/api/authentication/v1"
+	v1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -134,9 +134,7 @@ func (i *specImpl) Services() ([]pipeline.Service, error) {
 		i.services = append(i.services, s)
 	}
 	services := make([]pipeline.Service, len(i.services))
-	for idx := 0; idx < len(i.services); idx++ {
-		services[idx] = i.services[idx]
-	}
+	copy(services, i.services)
 	return services, nil
 
 }


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR:
* Updates golangci-lint to latest version
* Splits execution of individual Go linters
* Fixes new issues found by the newer versions of the linters

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

