### PR TITLE
Fix hidden dependency between scenarios in acceptance tests

### DIFF
--- a/test/acceptance/features/steps/cloudnativepostgresoperator.py
+++ b/test/acceptance/features/steps/cloudnativepostgresoperator.py
@@ -6,12 +6,13 @@ from behave import given
 class CloudNativePostgresOperator(Operator):
 
     def __init__(self, name="cloud-native-postgresql"):
-        self.name = name
-        self.pod_name_pattern = "postgresql-operator-controller-manager.*"
-        self.operator_catalog_source_name = "operatorhubio-catalog"
-        self.operator_catalog_channel = "stable"
-        self.operator_catalog_image = "quay.io/operatorhubio/catalog:latest"
-        self.package_name = name
+        super().__init__(
+            name=name,
+            pod_name_pattern="postgresql-operator-controller-manager.*",
+            operator_catalog_source_name="operatorhubio-catalog",
+            operator_catalog_channel="stable",
+            operator_catalog_image="quay.io/operatorhubio/catalog:latest",
+            package_name=name)
 
 
 @given(u'Cloud Native Postgres operator is running')

--- a/test/acceptance/features/steps/crunchypostgresoperator.py
+++ b/test/acceptance/features/steps/crunchypostgresoperator.py
@@ -7,15 +7,19 @@ from behave import given
 class CrunchyPostgresOperator(Operator):
 
     def __init__(self, name="pgo"):
-        self.name = name
         if ctx.cli == "oc":
-            self.operator_catalog_source_name = "certified-operators"
-            self.package_name = "crunchy-postgres-operator"
+            super().__init__(
+                name=name,
+                package_name="crunchy-postgres-operator",
+                operator_catalog_source_name="certified-operators",
+                operator_catalog_channel="v5")
         else:
-            self.operator_catalog_source_name = "operatorhubio-catalog"
-            self.package_name = "postgresql"
-            self.operator_subscription_csv_version = "postgresoperator.v5.0.5"
-        self.operator_catalog_channel = "v5"
+            super().__init__(
+                name=name,
+                package_name="postgresql",
+                operator_catalog_source_name="operatorhubio-catalog",
+                operator_subscription_csv_version="postgresoperator.v5.0.5",
+                operator_catalog_channel="v5")
 
 
 @given(u'Crunchy Data Postgres operator is running')

--- a/test/acceptance/features/steps/olm.py
+++ b/test/acceptance/features/steps/olm.py
@@ -9,22 +9,34 @@ class Operator(object):
 
     openshift = Openshift()
     cmd = Command()
-    pod_name_pattern = "{name}.*"
 
-    name = ""
-    operator_catalog_source_name = ""
-    operator_catalog_image = ""
-    operator_catalog_channel = ""
-    operator_subscription_csv_version = None
-    package_name = ""
+    def __init__(self,
+                 name="",
+                 operator_namespace="",
+                 package_name="",
+                 operator_catalog_source_name="",
+                 operator_catalog_image="",
+                 operator_catalog_channel="",
+                 operator_catalog_namespace="",
+                 operator_subscription_csv_version=None,
+                 pod_name_pattern="{name}.*"):
+        self.name = name
+        self.operator_namespace = operator_namespace if operator_namespace != "" else self.openshift.operators_namespace
+        self.package_name = package_name
+        self.operator_catalog_source_name = operator_catalog_source_name
+        self.operator_catalog_image = operator_catalog_image
+        self.operator_catalog_channel = operator_catalog_channel
+        self.operator_catalog_namespace = operator_catalog_namespace if operator_catalog_namespace != "" else self.openshift.olm_namespace
+        self.operator_subscription_csv_version = operator_subscription_csv_version
+        self.pod_name_pattern = pod_name_pattern
 
     def is_running(self, wait=False):
         if wait:
-            pod_name = self.openshift.wait_for_pod(self.pod_name_pattern.format(name=self.name), self.openshift.operators_namespace)
+            pod_name = self.openshift.wait_for_pod(self.pod_name_pattern.format(name=self.name), self.operator_namespace)
         else:
-            pod_name = self.openshift.search_pod_in_namespace(self.pod_name_pattern.format(name=self.name), self.openshift.operators_namespace)
+            pod_name = self.openshift.search_pod_in_namespace(self.pod_name_pattern.format(name=self.name), self.operator_namespace)
         if pod_name is not None:
-            operator_pod_status = self.openshift.check_pod_status(pod_name, self.openshift.operators_namespace)
+            operator_pod_status = self.openshift.check_pod_status(pod_name, self.operator_namespace)
             print("The pod {} is running: {}".format(self.name, operator_pod_status))
             return operator_pod_status
         else:
@@ -32,7 +44,8 @@ class Operator(object):
 
     def install_catalog_source(self):
         if self.operator_catalog_image != "":
-            install_src_output = self.openshift.create_catalog_source(self.operator_catalog_source_name, self.operator_catalog_image)
+            install_src_output = self.openshift.create_catalog_source(
+                self.operator_catalog_source_name, self.operator_catalog_image, self.operator_catalog_namespace)
             if re.search(r'.*catalogsource.operators.coreos.com/%s\s(unchanged|created)' % self.operator_catalog_source_name, install_src_output) is None:
                 print("Failed to create {} catalog source".format(self.operator_catalog_source_name))
                 return False
@@ -40,7 +53,7 @@ class Operator(object):
 
     def install_operator_subscription(self, csv_version=None, install_mode=InstallMode.Automatic):
         install_sub_output = self.openshift.create_operator_subscription(
-            self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel,
+            self.package_name, self.operator_catalog_source_name, self.operator_catalog_channel, self.operator_catalog_namespace,
             self.operator_subscription_csv_version if csv_version is None else csv_version, install_mode)
         if re.search(r'.*subscription.operators.coreos.com/%s\s(unchanged|created)' % self.package_name, install_sub_output) is None:
             print("Failed to create {} operator subscription".format(self.package_name))

--- a/test/acceptance/features/steps/percona_mysql_operator.py
+++ b/test/acceptance/features/steps/percona_mysql_operator.py
@@ -6,19 +6,18 @@ from behave import given
 class PerconaMysqlOperator(Operator):
 
     def __init__(self, name="percona-xtradb-cluster-operator"):
-        self.name = name
-        if ctx.cli == "oc":
-            self.operator_catalog_source_name = "community-operators"
-        else:
-            self.operator_catalog_source_name = "operatorhubio-catalog"
-        self.operator_catalog_channel = "stable"
-        self.package_name = "percona-xtradb-cluster-operator"
+        super().__init__(
+            name=name,
+            operator_catalog_source_name="community-operators" if ctx.cli == "oc" else "operatorhubio-catalog",
+            operator_catalog_channel="stable",
+            package_name=name
+        )
 
 
 @given(u'Percona Mysql operator is running')
 def install(context):
     operator = PerconaMysqlOperator()
-    operator.openshift.operators_namespace = context.namespace.name
+    operator.operator_namespace = context.namespace.name
     if not operator.is_running():
         subscription = f'''
 ---
@@ -26,24 +25,25 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: operatorgroup
-  namespace: {operator.openshift.operators_namespace}
+  namespace: {operator.operator_namespace}
 spec:
   targetNamespaces:
-  - {operator.openshift.operators_namespace}
+  - {operator.operator_namespace}
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: '{operator.name}'
-  namespace: {operator.openshift.operators_namespace}
+  namespace: {operator.operator_namespace}
 spec:
   channel: '{operator.operator_catalog_channel}'
   installPlanApproval: Automatic
   name: '{operator.package_name}'
   source: '{operator.operator_catalog_source_name}'
-  sourceNamespace: {operator.openshift.olm_namespace}
+  sourceNamespace: {operator.operator_catalog_namespace}
         '''
         print(subscription)
         operator.openshift.apply(subscription)
+        operator.openshift.approve_operator_subscription_in_namespace(operator.name, operator.operator_namespace)
         operator.is_running(wait=True)
     print("Percona Mysql operator is running")

--- a/test/acceptance/features/steps/perconamongodboperator.py
+++ b/test/acceptance/features/steps/perconamongodboperator.py
@@ -6,19 +6,18 @@ from behave import given
 class PerconaMongoDBOperator(Operator):
 
     def __init__(self, name="percona-server-mongodb-operator"):
-        self.name = name
-        if ctx.cli == "oc":
-            self.operator_catalog_source_name = "community-operators"
-        else:
-            self.operator_catalog_source_name = "operatorhubio-catalog"
-        self.operator_catalog_channel = "stable"
-        self.package_name = name
+        super().__init__(
+            name=name,
+            operator_catalog_source_name="community-operators" if ctx.cli == "oc" else "operatorhubio-catalog",
+            operator_catalog_channel="stable",
+            package_name=name
+        )
 
 
 @given(u'Percona MongoDB operator is running')
 def install_percona_mongodb_operator(context):
     operator = PerconaMongoDBOperator()
-    operator.openshift.operators_namespace = context.namespace.name
+    operator.operator_namespace = context.namespace.name
     if not operator.is_running():
         subscription = f'''
 ---
@@ -26,24 +25,25 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: operatorgroup
-  namespace: {operator.openshift.operators_namespace}
+  namespace: {operator.operator_namespace}
 spec:
   targetNamespaces:
-  - {operator.openshift.operators_namespace}
+  - {operator.operator_namespace}
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: '{operator.name}'
-  namespace: {operator.openshift.operators_namespace}
+  namespace: {operator.operator_namespace}
 spec:
   channel: '{operator.operator_catalog_channel}'
   installPlanApproval: Automatic
   name: '{operator.package_name}'
   source: '{operator.operator_catalog_source_name}'
-  sourceNamespace: {operator.openshift.olm_namespace}
+  sourceNamespace: {operator.operator_catalog_namespace}
         '''
         print(subscription)
         operator.openshift.apply(subscription)
+        operator.openshift.approve_operator_subscription_in_namespace(operator.name, operator.operator_namespace)
         operator.is_running(wait=True)
     print("Percona MongoDB operator is running")

--- a/test/acceptance/features/steps/rabbitmq_operator.py
+++ b/test/acceptance/features/steps/rabbitmq_operator.py
@@ -5,13 +5,13 @@ from behave import given
 class RabbitMqOperator(Operator):
 
     def __init__(self, name="rabbitmq-cluster-operator"):
-        self.name = name
+        super().__init__(name=name)
 
 
 @given(u'RabbitMQ operator is running')
 def install(_context):
     operator = RabbitMqOperator()
-    operator.openshift.operators_namespace = "rabbitmq-system"
+    operator.operator_namespace = "rabbitmq-system"
     if not operator.is_running():
         operator.openshift.apply_yaml_file("https://github.com/rabbitmq/cluster-operator/releases/download/v1.9.0/cluster-operator.yml")
         operator.is_running(wait=True)

--- a/test/acceptance/features/steps/redisoperator.py
+++ b/test/acceptance/features/steps/redisoperator.py
@@ -6,13 +6,12 @@ from behave import given
 class RedisOperator(Operator):
 
     def __init__(self, name="redis-operator"):
-        self.name = name
-        if ctx.cli == "oc":
-            self.operator_catalog_source_name = "community-operators"
-        else:
-            self.operator_catalog_source_name = "operatorhubio-catalog"
-        self.operator_catalog_channel = "stable"
-        self.package_name = name
+        super().__init__(
+            name=name,
+            operator_catalog_source_name="community-operators" if ctx.cli == "oc" else "operatorhubio-catalog",
+            operator_catalog_channel="stable",
+            package_name=name
+        )
 
 
 @given(u'Opstree Redis operator is running')

--- a/test/acceptance/features/steps/serverless_operator.py
+++ b/test/acceptance/features/steps/serverless_operator.py
@@ -9,28 +9,31 @@ class ServerlessOperator(Operator):
     operator_catalog_channel = "alpha" if ctx.cli == "kubectl" else "4.5"
 
     def __init__(self, name="serverless-operator"):
-        self.name = "knative-operator" if ctx.cli == "kubectl" else name
-        self.package_name = self.name
+        operator_name = "knative-operator" if ctx.cli == "kubectl" else name
+        super().__init__(
+            name=operator_name,
+            package_name=operator_name
+        )
 
     def is_running(self, wait=False):
         currentCSV = self.openshift.get_current_csv(self.name, self.operator_catalog_source_name, self.operator_catalog_channel)
         if wait:
-            polling2.poll(lambda: self.openshift.search_resource_in_namespace("csvs", currentCSV, self.openshift.operators_namespace),
+            polling2.poll(lambda: self.openshift.search_resource_in_namespace("csvs", currentCSV, self.operator_namespace),
                           check_success=lambda v: v is not None, step=1, timeout=100)
         else:
-            if self.openshift.search_resource_in_namespace("csvs", currentCSV, self.openshift.operators_namespace) is None:
+            if self.openshift.search_resource_in_namespace("csvs", currentCSV, self.operator_namespace) is None:
                 return False
 
         expectedDeployments = self.openshift.get_resource_info_by_jsonpath(
-            "csv", currentCSV, self.openshift.operators_namespace, "{.spec.install.spec.deployments[*].name}").split()
+            "csv", currentCSV, self.operator_namespace, "{.spec.install.spec.deployments[*].name}").split()
         found_pod_names = []
         for deployment in expectedDeployments:
             if wait:
-                found_pod_name = self.openshift.wait_for_pod(self.pod_name_pattern.format(name=deployment), self.openshift.operators_namespace)
+                found_pod_name = self.openshift.wait_for_pod(self.pod_name_pattern.format(name=deployment), self.operator_namespace)
             else:
-                found_pod_name = self.openshift.search_pod_in_namespace(self.pod_name_pattern.format(name=deployment), self.openshift.operators_namespace)
+                found_pod_name = self.openshift.search_pod_in_namespace(self.pod_name_pattern.format(name=deployment), self.operator_namespace)
             if found_pod_name is not None:
-                operator_pod_status = self.openshift.check_pod_status(found_pod_name, self.openshift.operators_namespace)
+                operator_pod_status = self.openshift.check_pod_status(found_pod_name, self.operator_namespace)
                 print("The pod {} is running: {}".format(found_pod_name, operator_pod_status))
                 found_pod_names.append(found_pod_name)
         if len(found_pod_names) == len(expectedDeployments):


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Currently, the `Operator` class uses class attributes such as `Openshift.operators_namespace` and `Openshift.olm_namespace` to define what namespace to install the operator in and the namespace for catalog source.

That information is supposed to be local to the operator class but the `Operator` class uses the 
 `Openshift` class attributes (which is shared between all instances of that class) for setting those namespaces for the instances of the operator. That is fine when the namespaces are the default ones (`operators` or `openshift-operators` and `olm` or `openshift-marketplace` respectively).

In order to change the namespace for the operator or the catalog source the operator currently changes the `Openshift.operators_namespace` or the `Openshift.olm_namespace` attributes directly. However, since those are the class attributes they are global and shared among all the operator instances.

So in case there is a sequence of scenarios executed in which one scenario uses an operator to set the namespaces to a non-default values (such as `PerconaMysqlOperator`) that namespace is set globally and so any operator used in any following scenarios that assumes the default namespaces would actually use the ones set by the non-default operator.

Also, most of the other attributes of the `Operator` class are class attributes and so shared between instances.

That causes a hidden dependency between scenarios.

# Changes

This PR:
* Changes the class attributes of `Operator` class to instance attributes so that it belongs only to the particular instance. 
* Introduces `operator_namespace` and `operator_catalog_namespace` attributes to the `Operator` class
* Updates the `Operator` class to use the above instance attributes instead of the global ones.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

