### PR TITLE
Expose binding secret without requiring a workload

### DIFF
--- a/pkg/reconcile/pipeline/api.go
+++ b/pkg/reconcile/pipeline/api.go
@@ -183,6 +183,9 @@ type Context interface {
 	// Returns error if occurrs
 	Close() error
 
+	// Persists the secret containing binding data into the cluster.
+	PersistSecret() error
+
 	// Sets context condition
 	SetCondition(condition *metav1.Condition)
 

--- a/pkg/reconcile/pipeline/context/impl.go
+++ b/pkg/reconcile/pipeline/context/impl.go
@@ -446,11 +446,7 @@ func (i *impl) persistSecret() (string, error) {
 	return name, err
 }
 
-func (i *impl) Close() error {
-	if i.err != nil {
-		i.SetCondition(apis.Conditions().NotBindingReady().Reason("ProcessingError").Msg(i.err.Error()).Build())
-		return i.persistBinding()
-	}
+func (i *impl) PersistSecret() error {
 	secretName, err := i.persistSecret()
 	if err != nil {
 		i.SetCondition(apis.Conditions().NotBindingReady().Reason("ErrorPersistingSecret").Msg(err.Error()).Build())
@@ -459,6 +455,14 @@ func (i *impl) Close() error {
 	}
 	if secretName != "" {
 		i.setStatusSecretName(secretName)
+	}
+	return nil
+}
+
+func (i *impl) Close() error {
+	if i.err != nil {
+		i.SetCondition(apis.Conditions().NotBindingReady().Reason("ProcessingError").Msg(i.err.Error()).Build())
+		return i.persistBinding()
 	}
 	for _, app := range i.applications {
 		if app.IsUpdated() {

--- a/pkg/reconcile/pipeline/handler/project/impl.go
+++ b/pkg/reconcile/pipeline/handler/project/impl.go
@@ -13,6 +13,10 @@ import (
 
 func PreFlightCheck(mandatoryBindingKeys ...string) func(pipeline.Context) {
 	return func(ctx pipeline.Context) {
+		if ctx.PersistSecret() != nil {
+			ctx.SetCondition(apis.Conditions().NotCollectionReady().Build())
+			return
+		}
 		ctx.SetCondition(apis.Conditions().CollectionReady().DataCollected().Build())
 		applications, err := ctx.Applications()
 		if err != nil {

--- a/pkg/reconcile/pipeline/mocks/mocks_pipeline.go
+++ b/pkg/reconcile/pipeline/mocks/mocks_pipeline.go
@@ -241,6 +241,20 @@ func (mr *MockContextMockRecorder) NamingTemplate() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamingTemplate", reflect.TypeOf((*MockContext)(nil).NamingTemplate))
 }
 
+// PersistSecret mocks base method.
+func (m *MockContext) PersistSecret() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PersistSecret")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PersistSecret indicates an expected call of PersistSecret.
+func (mr *MockContextMockRecorder) PersistSecret() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersistSecret", reflect.TypeOf((*MockContext)(nil).PersistSecret))
+}
+
 // ReadConfigMap mocks base method.
 func (m *MockContext) ReadConfigMap(arg0, arg1 string) (*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Signed-off-by: Andy Sadler <ansadler@redhat.com>

# Changes

/kind enhancement

This exposes the relevant binding secret without requiring a workload to be present.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

