### PR TITLE
Add GH workflows for cherry-picking PRs to release branches

### DIFF
--- a/.github/workflows/pr-cherry-pick-clean.yaml
+++ b/.github/workflows/pr-cherry-pick-clean.yaml
@@ -1,0 +1,28 @@
+name: "Clean cherry pick PR branch"
+
+on:
+  pull_request_target:
+    branches:
+      - 'release-v**.x'
+    types: [closed]
+
+jobs:
+  delete-cherry-pick-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: delete-cherry-pick-branch
+        uses: actions/github-script@v6
+        env:
+          REPO: ${{ secrets.SBO_CHERRY_PICK_REPO }}
+        with:
+          github-token: ${{ secrets.SBO_CHERRY_PICK_BOT_TOKEN }}
+          script: |
+            const [owner, repo] = process.env.REPO.split('/');
+            const ref = `heads/${context.payload.pull_request.head.ref}`;
+            const deleteParams = { owner, repo, ref };
+            console.log(`Deleting branch: "${ref}"`);
+            try {
+              github.rest.git.deleteRef(deleteParams);
+            } catch(e) {
+              console.log("Cannot delete branch; error:", e);
+            }

--- a/.github/workflows/pr-cherry-picks.yaml
+++ b/.github/workflows/pr-cherry-picks.yaml
@@ -1,0 +1,84 @@
+name: "Cherry pick PR to release branches"
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types: [closed]
+
+jobs:
+  cherry_pick_release_v1_1_x:
+    runs-on: ubuntu-latest
+    name: Cherry pick into release-v1.1.x branch
+    if: contains(github.event.pull_request.labels.*.name, 'release/v1.1.x') && github.event.pull_request.merged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup SSH for cherry-pick repo
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SBO_CHERRY_PICK_REPO_SSH_PRIVATE_KEY }}
+      - name: Cherry pick into release-v1.1.x
+        uses: pmacik/github-cherry-pick-action@main
+        with:
+          cherry-pick-repo: ${{ secrets.SBO_CHERRY_PICK_REPO }}
+          token: ${{ secrets.SBO_CHERRY_PICK_BOT_TOKEN }}
+          branch: release-v1.1.x
+          exclude-labels: |
+            release/v1.2.x
+            release/v1.3.x
+          labels: |
+            cherry-pick
+          title-prefix: "cherry-pick(release-v1.1.x): "
+  cherry_pick_release_v1_2_x:
+    runs-on: ubuntu-latest
+    name: Cherry pick into release-v1.2.x branch
+    if: contains(github.event.pull_request.labels.*.name, 'release/v1.2.x') && github.event.pull_request.merged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup SSH for cherry-pick repo
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SBO_CHERRY_PICK_REPO_SSH_PRIVATE_KEY }}
+      - name: Cherry pick into release-v1.2.x
+        uses: pmacik/github-cherry-pick-action@main
+        with:
+          cherry-pick-repo: ${{ secrets.SBO_CHERRY_PICK_REPO }}
+          token: ${{ secrets.SBO_CHERRY_PICK_BOT_TOKEN }}
+          branch: release-v1.2.x
+          exclude-labels: |
+            release/v1.1.x
+            release/v1.3.x
+          labels: |
+            cherry-pick
+          title-prefix: "cherry-pick(release-v1.2.x): "
+  cherry_pick_release_v1_3_x:
+    runs-on: ubuntu-latest
+    name: Cherry pick into release-v1.3.x branch
+    if: contains(github.event.pull_request.labels.*.name, 'release/v1.3.x') && github.event.pull_request.merged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup SSH for cherry-pick repo
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SBO_CHERRY_PICK_REPO_SSH_PRIVATE_KEY }}
+      - name: Cherry pick into release-v1.2.x
+        uses: pmacik/github-cherry-pick-action@main
+        with:
+          cherry-pick-repo: ${{ secrets.SBO_CHERRY_PICK_REPO }}
+          token: ${{ secrets.SBO_CHERRY_PICK_BOT_TOKEN }}
+          branch: release-v1.3.x
+          exclude-labels: |
+            release/v1.1.x
+            release/v1.2.x
+          labels: |
+            cherry-pick
+          title-prefix: "cherry-pick(release-v1.3.x): "


### PR DESCRIPTION
# Changes

This PR adds GH workflows to automate release-branch cherry-picking process. It goes as follows - as soon as the release-labeled PR to master is merged:

* A cherry-pick PR branch is created based on the release branch label of the original PR
* Original PR commit from master is cherry-picked and added on top of the cherry-pick PR branch
* A cherry-pick PR is sent from the cherry-pick PR branch to the release branch
* Normal PR checking flow is excercised including all the CI and approval
* Once the cherry-pick PR is merged the cherry-pick PR branch is deleted

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

