### PR TITLE
Disable TLS verification for acceptance test setup

### DIFF
--- a/test/acceptance/openshift-setup.sh
+++ b/test/acceptance/openshift-setup.sh
@@ -20,7 +20,7 @@ else
 
   retries=50
   until [[ $retries == 0 ]]; do
-    oc login -u $USER -p $USER_TOKEN && break
+    oc login -u $USER -p $USER_TOKEN --insecure-skip-tls-verify=true && break
     sleep 5
     retries=$(($retries - 1))
   done;


### PR DESCRIPTION
# Changes

This PR disables the TLS verification for all the login attempts in `test/acceptance/openshift-setup.sh` script, instead of just the first occurence.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

