### PR TITLE
cherry-pick(release-v1.2.x): crds: Ignore non-served versions in crd controller

### DIFF
--- a/controllers/crd/crd_controller.go
+++ b/controllers/crd/crd_controller.go
@@ -81,6 +81,9 @@ func (r *CrdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconc
 	toPersist := false
 
 	for i := range crd.Spec.Versions {
+		if !crd.Spec.Versions[i].Served {
+			continue
+		}
 		gvk := schema.GroupVersionKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind, Version: crd.Spec.Versions[i].Name}
 		if !crd.GetDeletionTimestamp().IsZero() {
 			r.bindableKinds.Delete(gvk)


### PR DESCRIPTION
This might help with the errors we were seeing in OCP 4.11 logs.

Signed-off-by: Andy Sadler <ansadler@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

