### PR TITLE
crds: fetch csvs 1-by-1 when listing

### DIFF
--- a/controllers/crd/crd_controller.go
+++ b/controllers/crd/crd_controller.go
@@ -80,6 +80,11 @@ func (r *CrdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconc
 
 	toPersist := false
 
+	unstructuredCrd, err := converter.ToUnstructured(crd)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	for i := range crd.Spec.Versions {
 		if !crd.Spec.Versions[i].Served {
 			continue
@@ -94,7 +99,7 @@ func (r *CrdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconc
 		fakeServiceContent.SetName("s1")
 		fakeServiceContent.SetGroupVersionKind(gvk)
 		service, err := r.serviceBuilder.Build(fakeServiceContent, service.CrdReaderOption(func(gvk *schema.GroupVersionResource) (*unstructured.Unstructured, error) {
-			return converter.ToUnstructured(crd)
+			return unstructuredCrd, nil
 		}))
 		if err != nil {
 			return ctrl.Result{}, err


### PR DESCRIPTION
This should potentially fix a memory overhead issue when there are a lot of ClusterServiceVersion resources deployed on a cluster.

Signed-off-by: Andy Sadler <ansadler@redhat.com>

# Changes

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

