### PR TITLE
DO NOT MERGE: nuke support for olm annotations

### DIFF
--- a/pkg/reconcile/pipeline/context/service/service.go
+++ b/pkg/reconcile/pipeline/context/service/service.go
@@ -2,9 +2,7 @@ package service
 
 import (
 	"context"
-	e "errors"
 
-	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/pkg/binding"
 	"github.com/redhat-developer/service-binding-operator/pkg/binding/registry"
 	"github.com/redhat-developer/service-binding-operator/pkg/client/kubernetes"
@@ -16,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
@@ -264,41 +261,5 @@ func (c *customResourceDefinition) IsBindable() (bool, error) {
 }
 
 func (c *customResourceDefinition) Descriptor() (*pipeline.CRDDescription, error) {
-	csvs, err := c.client.Resource(olmv1alpha1.SchemeGroupVersion.WithResource("clusterserviceversions")).Namespace(c.ns).List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	if len(csvs.Items) == 0 {
-		return nil, nil
-	}
-	for _, csv := range csvs.Items {
-		ownedPath := []string{"spec", "customresourcedefinitions", "owned"}
-
-		ownedCRDs, exists, err := unstructured.NestedSlice(csv.Object, ownedPath...)
-		if err != nil {
-			return nil, err
-		}
-		if !exists {
-			continue
-		}
-
-		for _, crd := range ownedCRDs {
-			crdDesciption := &pipeline.CRDDescription{}
-			data, ok := crd.(map[string]interface{})
-			if !ok {
-				return nil, e.New("cannot cast to map")
-			}
-			err := runtime.DefaultUnstructuredConverter.FromUnstructured(data, crdDesciption)
-			if err != nil {
-				return nil, err
-			}
-			if crdDesciption.Name == c.resource.GetName() && crdDesciption.Kind == c.kind() && crdDesciption.Version == c.serviceGVR.Version {
-				return crdDesciption, nil
-			}
-		}
-	}
 	return nil, nil
 }


### PR DESCRIPTION
Testing performance impact of dropping olm descriptors as a binding source; this intentionally breaks a bunch of stuff.

Signed-off-by: Andy Sadler <ansadler@redhat.com>

# Changes

Nukes support for olm annotations.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

