### PR TITLE
cherry-pick(release-v1.2.x): Fix or temporarily disable tests for supported operators that does not currently work with OCP 4.12

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -66,6 +66,7 @@ jobs:
   acceptance:
     name: Acceptance Tests with Kubernetes and using OLM
     runs-on: ubuntu-20.04
+    timeout-minutes: 90
 
     env:
       EXTRA_BEHAVE_ARGS: "--tags=~@knative --tags=~@openshift --tags=~@examples --tags=~@supported-operator --tags=~@optional-annotations --tags=~@workload-resource-mapping --tags=~@disable-github-actions"
@@ -230,6 +231,7 @@ jobs:
     env:
       EXTRA_BEHAVE_ARGS: "--tags=@supported-operator --tags=~@disable-github-actions"
       TEST_RUN: Supported_Operators_Acceptance_tests_Kubernetes_with_OLM
+      DELETE_NAMESPACE: never
 
     steps:
       - name: Checkout Git Repository
@@ -386,6 +388,7 @@ jobs:
   acceptance_without_olm:
     name: Acceptance tests running on Kubernetes without using OLM
     runs-on: ubuntu-20.04
+    timeout-minutes: 90
 
     env:
       EXTRA_BEHAVE_ARGS: "--tags=~@knative --tags=~@openshift --tags=~@olm --tags=~@disable-github-actions"

--- a/samples/apps/spring-petclinic/pgcluster-deployment.yaml
+++ b/samples/apps/spring-petclinic/pgcluster-deployment.yaml
@@ -5,7 +5,7 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.4-0
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.5-1
   postgresVersion: 14
   instances:
     - name: instance1
@@ -17,7 +17,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.40-1
       repos:
       - name: repo1
         volume:

--- a/test/acceptance/features/gettingStartedGuide.feature
+++ b/test/acceptance/features/gettingStartedGuide.feature
@@ -25,6 +25,7 @@ Feature: Getting Started Guide
   @disable.arch.ppc64le
   @disable.arch.s390x
   @disable.arch.arm64
+  @disable-openshift-4.12
   Scenario: Connecting PetClinic application to an Operator-backed PostgreSQL database
     Given Crunchy Data Postgres operator is running
     * PetClinic sample application is installed

--- a/test/acceptance/features/steps/cloudnativepostgresoperator.py
+++ b/test/acceptance/features/steps/cloudnativepostgresoperator.py
@@ -10,7 +10,7 @@ class CloudNativePostgresOperator(Operator):
             name=name,
             pod_name_pattern="postgresql-operator-controller-manager.*",
             operator_catalog_source_name="operatorhubio-catalog",
-            operator_catalog_channel="stable",
+            operator_catalog_channel="stable-v1.17",
             operator_catalog_image="quay.io/operatorhubio/catalog:latest",
             package_name=name)
 

--- a/test/acceptance/features/steps/crunchypostgresoperator.py
+++ b/test/acceptance/features/steps/crunchypostgresoperator.py
@@ -13,7 +13,7 @@ class CrunchyPostgresOperator(Operator):
         else:
             package_name = "postgresql"
             catalog_source_name = "operatorhubio-catalog"
-        csv = "postgresoperator.v5.1.2"
+        csv = "postgresoperator.v5.2.0"
         channel = "v5"
 
         super().__init__(

--- a/test/acceptance/features/supportExistingOperatorBackedServices.feature
+++ b/test/acceptance/features/supportExistingOperatorBackedServices.feature
@@ -93,6 +93,7 @@ Feature: Support a number of existing operator-backed services out of the box
            """
 
   @external-feedback
+  @disable-openshift-4.12
   Scenario: Bind test application to Postgres provisioned by Crunchy Data Postgres operator
     Given Crunchy Data Postgres operator is running
     * Generic test application is running
@@ -103,7 +104,7 @@ Feature: Support a number of existing operator-backed services out of the box
           metadata:
             name: hippo
           spec:
-            image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.4-0
+            image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.5-1
             postgresVersion: 14
             instances:
               - name: instance1
@@ -115,7 +116,7 @@ Feature: Support a number of existing operator-backed services out of the box
                       storage: 1Gi
             backups:
               pgbackrest:
-                image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
+                image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.40-1
                 repos:
                 - name: repo1
                   volume:
@@ -251,6 +252,7 @@ Feature: Support a number of existing operator-backed services out of the box
     And File "/bindings/$scenario_id/password" exists in application pod
     And Application can connect to the projected MySQL database
 
+  @disable-openshift-4.12
   Scenario: Bind test application to Mysql provisioned by Percona Mysql operator
     Given Percona Mysql operator is running
     * Generic test application is running


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Currently:
* Latest Crunchy Postgres Operator (v5.2.0) is not compatible with OCP 4.12 due to https://github.com/CrunchyData/postgres-operator-examples/issues/151
* Latest Percona Mysql Operator fails to install on OCP 4.12 

# Changes


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

