### PR TITLE
Compare various KPIs to the threshold values and fail if any is crossed

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -144,7 +144,7 @@ endef
 
 YQ = $(shell pwd)/bin/yq
 yq:
-	$(call go-install-tool,$(YQ),github.com/mikefarah/yq/v4@v4.9.8)
+	$(call go-install-tool,$(YQ),github.com/mikefarah/yq/v4@v4.26.1)
 
 KUBECTL_SLICE = $(shell pwd)/bin/kubectl-slice
 kubectl-slice:


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

# Changes

This PR:
* Introduces `test-performance-thresholds` Makefile targed that compares various vaules from `kpi.yaml` generated by `make test-performance-collect-kpi` to the threshold values defined in environment variables `TEST_PERFORMANCE_AVG_MEMORY`, `TEST_PERFORMANCE_MAX_MEMORY`, `TEST_PERFORMANCE_AVG_CPU`, `TEST_PERFORMANCE_MAX_CPU`. If any of the threshold is crossed it fails.
* The `test-performance-thresholds` is to be executed as part of `performance*` OpenShift CI jobs (https://github.com/openshift/release/pull/33192) (after the `test-performance-collect-kpi` step) and fails the job if any of the thresholds is crossed.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

