### PR TITLE
Stop using deprecated features in GH actions

### DIFF
--- a/.github/actions/check-skip-acceptance-tests/action.yaml
+++ b/.github/actions/check-skip-acceptance-tests/action.yaml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - id: check-skip-test
-      uses: actions/github-script@v6.1.0
+      uses: actions/github-script@v6.3.3
       with:
         result-encoding: string
         script: |

--- a/.github/workflows/merge-to-master.yaml
+++ b/.github/workflows/merge-to-master.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PATH
         run: |
@@ -26,12 +26,12 @@ jobs:
           echo "PATH=$PATH:$GITHUB_WORKSPACE/bin/" >> $GITHUB_ENV
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "^1.17"
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
           architecture: "x64"
@@ -54,10 +54,10 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "^1.17"
 
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: generate website
         env:
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Wait for push
         uses: lewagon/wait-on-check-action@1b1630e169116b58a4b933d5ad7effc46d3d312d
@@ -113,7 +113,7 @@ jobs:
         id: operator-image-ref
         run: |
           export OIR=$(make operator-image-ref)
-          echo "::set-output name=operator-image-ref::${OIR}"
+          echo "operator-image-ref=${OIR}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner in IaC mode
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/merge-to-release-branch.yaml
+++ b/.github/workflows/merge-to-release-branch.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PATH
         run: |
@@ -26,7 +26,7 @@ jobs:
           echo "PATH=$PATH:$GITHUB_WORKSPACE/bin/" >> $GITHUB_ENV
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "^1.17"
 
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "^1.17"
 
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Wait for push
         uses: lewagon/wait-on-check-action@1b1630e169116b58a4b933d5ad7effc46d3d312d
@@ -87,7 +87,7 @@ jobs:
         id: operator-image-ref
         run: |
           export OIR=$(make operator-repo-ref):$(git rev-parse --short=8 HEAD)
-          echo "::set-output name=operator-image-ref::${OIR}"
+          echo "operator-image-ref=${OIR}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner in IaC mode
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/pr-checks-build-images.yaml
+++ b/.github/workflows/pr-checks-build-images.yaml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "^1.17"
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup CLI
         uses: ./.github/actions/setup-cli
@@ -64,13 +64,13 @@ jobs:
           tar -czvf ${ARTIFACTS}/registry.tar.gz -C ${GITHUB_WORKSPACE} registry
 
       - name: Archive images
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: operator-images-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
           path: ${{env.ARTIFACTS}}/*.tar.gz
 
       - name: Archive image references
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
           path: ${{env.ARTIFACTS}}/*.refs

--- a/.github/workflows/pr-checks-clean-images.yaml
+++ b/.github/workflows/pr-checks-clean-images.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Clean PR images
         uses: ./.github/actions/clean-images

--- a/.github/workflows/pr-checks-push-images.yaml
+++ b/.github/workflows/pr-checks-push-images.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Wait for build
         uses: lewagon/wait-on-check-action@1b1630e169116b58a4b933d5ad7effc46d3d312d
@@ -28,7 +28,7 @@ jobs:
           wait-interval: 60
 
       - name: Download images
-        uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
+        uses: pmacik/action-download-multiple-artifacts@node16
         with:
           names: operator-images-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -23,18 +23,18 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "^1.17"
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
           architecture: "x64"
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run linters
         run: make lint
@@ -45,12 +45,12 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "^1.17"
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Unit Tests with Code Coverage
         run: |
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check if acceptance tests can be skipped
         id: check-skip-acceptance
@@ -82,7 +82,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
           architecture: "x64"
@@ -104,7 +104,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
+        uses: pmacik/action-download-multiple-artifacts@node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -138,7 +138,7 @@ jobs:
         run: |
           testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         with:
           name: kubernetes-with-olm-test-results
@@ -154,7 +154,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check if acceptance tests can be skipped
         id: check-skip-acceptance
@@ -162,7 +162,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
           architecture: "x64"
@@ -184,7 +184,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
+        uses: pmacik/action-download-multiple-artifacts@node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -218,7 +218,7 @@ jobs:
         run: |
           testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         with:
           name: optional-annotations
@@ -235,7 +235,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check if acceptance tests can be skipped
         id: check-skip-acceptance
@@ -243,7 +243,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
           architecture: "x64"
@@ -265,7 +265,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
+        uses: pmacik/action-download-multiple-artifacts@node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -299,7 +299,7 @@ jobs:
         run: |
           testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         with:
           name: supported-operators-kubernetes
@@ -315,7 +315,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check if acceptance tests can be skipped
         id: check-skip-acceptance
@@ -323,7 +323,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
           architecture: "x64"
@@ -345,7 +345,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
+        uses: pmacik/action-download-multiple-artifacts@node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -379,7 +379,7 @@ jobs:
         run: |
           testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         with:
           name: workload-resource-mapping
@@ -397,7 +397,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check if acceptance tests can be skipped
         id: check-skip-acceptance
@@ -405,7 +405,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
           architecture: "x64"
@@ -418,7 +418,7 @@ jobs:
 
       - name: Set up Go
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "^1.16"
 
@@ -440,7 +440,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
+        uses: pmacik/action-download-multiple-artifacts@node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -476,7 +476,7 @@ jobs:
         run: |
           testspace [${{ env.TEST_RUN }}]${{ env.TEST_RESULTS }}/TEST*.xml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}
         with:
           name: kubernetes-without-olm-test-results
@@ -488,7 +488,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -506,7 +506,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Wait for push
         uses: lewagon/wait-on-check-action@1b1630e169116b58a4b933d5ad7effc46d3d312d
@@ -517,7 +517,7 @@ jobs:
           wait-interval: 60
 
       - name: Download image references
-        uses: marcofaggian/action-download-multiple-artifacts@v3.0.8
+        uses: pmacik/action-download-multiple-artifacts@node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -525,7 +525,7 @@ jobs:
         id: operator-image-ref
         run: |
           source ./operator.refs
-          echo "::set-output name=operator-image-ref::${OPERATOR_IMAGE_REF}"
+          echo "operator-image-ref=${OPERATOR_IMAGE_REF}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner in IaC mode
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/pr-cherry-picks.yaml
+++ b/.github/workflows/pr-cherry-picks.yaml
@@ -13,7 +13,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'release/v1.1.x') && github.event.pull_request.merged
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup SSH for cherry-pick repo
@@ -38,7 +38,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'release/v1.2.x') && github.event.pull_request.merged
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup SSH for cherry-pick repo
@@ -63,7 +63,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'release/v1.3.x') && github.event.pull_request.merged
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup SSH for cherry-pick repo

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check if acceptance tests can be skipped
         id: check-skip-acceptance


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Github Actions give the following warning about deprecating node12 based actions:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: ...
```
and the following warning about deprecating use of `set-output` command:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

# Changes

This PR:
* Updates version of actions that use `node12` to versions that use `node16`.
* Replaces usage of `set-outout` command by writting to the new `GITHUB_OUTPUT` environment variable

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

