### PR TITLE
Add install-tools and local-env rules to Makefiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,36 +174,76 @@ put us into an unreleasable state
   * End to end, i.e. acceptance tests
 * Unit tests:
   * Coverage should remain the same or increase
- 
+
+## Configure your local environment
+
+To compile and execute the Service Binding Operator, you must have on your machine the following dependencies:
+
+* Git
+* Go
+* Python3
+* Make
+* Docker
+
+Other dependencies are needed, but you can install them locally using the make rule `install-tools`.
+This rule will download into the local `./bin` folder all the missing tools needed to work with this repo.
+So, to install the dependencies locally and configure your shell to use them, use the following commands:
+
+```
+make install-tools
+eval $(make local-env)
+```
+
+If not present, the following dependencies will be downloaded:
+
+* minikube
+* opm
+* mockgen
+* kubectl-slice
+* yq
+* kustomize
+* controller-gen
+* gen-mocks
+* operator-sdk
+* kubectl
+* helm
+
 ## Running Acceptance Tests
 
-1. Set KUBECONFIG for both minikube and acceptance tests (it will be generated at minikube's start if it does not exist):
+1. Install dependencies
+
+```
+make install-tools
+eval $(make local-env)
+```
+
+2. Set KUBECONFIG for both minikube and acceptance tests (it will be generated at minikube's start if it does not exist):
 
 ```
 export KUBECONFIG=/tmp/minikubeconfig
 ```
 
-2. Start minikube:
+3. Start minikube:
 
 ```
 ./hack/start-minikube.sh
 ```
 
-3. Enable olm on minikube:
+4. Enable olm on minikube:
 
 
 ```
 minikube addons enable olm
 ```
 
-4. Deploy operator to the minikube cluster
+5. Deploy operator to the minikube cluster
 
 ```
 eval $(minikube docker-env)
 make deploy OPERATOR_REPO_REF=$(minikube ip):5000/sbo
 ```
 
-5. Execute all acceptance tests tagged with `@dev` using `kubectl` CLI:
+6. Execute all acceptance tests tagged with `@dev` using `kubectl` CLI:
 
 ```
 make test-acceptance TEST_ACCEPTANCE_TAGS="@dev" TEST_ACCEPTANCE_START_SBO=remote TEST_ACCEPTANCE_CLI=kubectl

--- a/make/acceptance.mk
+++ b/make/acceptance.mk
@@ -23,12 +23,12 @@ OLM_NAMESPACE ?=
 
 # Testing setup
 .PHONY: deploy-test-3rd-party-crds
-deploy-test-3rd-party-crds:
-	$(Q)kubectl --namespace $(TEST_NAMESPACE) apply -f ./test/third-party-crds/
+deploy-test-3rd-party-crds: kubectl
+	$(Q)$(KUBECTL) --namespace $(TEST_NAMESPACE) apply -f ./test/third-party-crds/
 
 .PHONY: create-test-namespace
-create-test-namespace:
-	$(Q)kubectl get namespace $(TEST_NAMESPACE) || kubectl create namespace $(TEST_NAMESPACE)
+create-test-namespace: kubectl
+	$(Q)$(KUBECTL) get namespace $(TEST_NAMESPACE) || $(KUBECTL) create namespace $(TEST_NAMESPACE)
 
 .PHONY: test-setup
 test-setup: test-cleanup create-test-namespace deploy-test-3rd-party-crds

--- a/make/common.mk
+++ b/make/common.mk
@@ -119,55 +119,253 @@ generate: controller-gen
 gen-mocks: mockgen
 	PATH=$(shell pwd)/bin:$(shell printenv PATH) $(GO) generate $(V_FLAG) ./...
 
-# Download controller-gen locally if necessary
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-controller-gen:
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0)
-
-# Download kustomize locally if necessary
-KUSTOMIZE = $(shell pwd)/bin/kustomize
-kustomize:
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
-
 # go-install-tool will 'go install' any package $2 and install it to $1.
 define go-install-tool
-@[ -f $(1) ] || { \
+[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+go mod init tmp 2>/dev/null ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2)@v$(3) ;\
 rm -rf $$TMP_DIR ;\
+echo "$$(basename $(1))@v$(3) installed" ;\
 }
 endef
 
+define output-install
+echo "$(1)@v$(2) installed"
+endef
+
+CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+CONTROLLER_GEN_VERSION ?= 0.7.0
+CONTROLLER_GEN_LOCAL_VERSION := $(shell [ -f $(CONTROLLER_GEN) ] && $(CONTROLLER_GEN) --version | cut -d' ' -f 2)
+CONTROLLER_GEN_HOST_VERSION := $(shell command -v controller-gen >/dev/null && controller-gen --version | cut -d' ' -f 2)
+controller-gen:
+	$(Q)mkdir -p $(dir $(CONTROLLER_GEN))
+ifneq (v$(CONTROLLER_GEN_VERSION), $(CONTROLLER_GEN_LOCAL_VERSION))
+	$(Q)rm -f $(CONTROLLER_GEN)
+ifeq (v$(CONTROLLER_GEN_VERSION),$(CONTROLLER_GEN_HOST_VERSION))
+	$(Q)ln -s $$(command -v controller-gen) $(CONTROLLER_GEN)
+	@echo "controller-gen found at $$(command -v controller-gen)"
+else
+	$(Q)$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_GEN_VERSION))
+endif
+endif
+
+
 YQ = $(shell pwd)/bin/yq
+YQ_VERSION ?= 4.26.1
+YQ_LOCAL_VERSION := $(shell [ -f $(YQ) ] && $(YQ) --version | cut -d' ' -f 3)
+YQ_HOST_VERSION := $(shell command -v yq >/dev/null && yq --version | cut -d' ' -f 3)
 yq:
-	$(call go-install-tool,$(YQ),github.com/mikefarah/yq/v4@v4.26.1)
+	$(Q)mkdir -p $(dir $(YQ))
+ifneq ($(YQ_VERSION), $(YQ_LOCAL_VERSION))
+	$(Q)rm -f $(YQ)
+ifeq ($(YQ_VERSION),$(YQ_HOST_VERSION))
+	$(Q)ln -s $$(command -v yq) $(YQ)
+	@echo "yq found at $$(command -v yq)"
+else
+	$(Q)$(call go-install-tool,$(YQ),github.com/mikefarah/yq/v4,$(YQ_VERSION))
+endif
+endif
 
 KUBECTL_SLICE = $(shell pwd)/bin/kubectl-slice
+KUBECTL_SLICE_VERSION ?= 1.1.0
+KUBECTL_SLICE_LOCAL_VERSION := $(shell [ -f $(KUBECTL_SLICE) ] && $(KUBECTL_SLICE) --version | cut -d' ' -f 3)
+KUBECTL_SLICE_HOST_VERSION := $(shell command -v kubectl-slice >/dev/null && kubectl-slice --version | cut -d' ' -f 3)
 kubectl-slice:
-	$(call go-install-tool,$(KUBECTL_SLICE),github.com/patrickdappollonio/kubectl-slice@v1.1.0)
+	$(Q)mkdir -p $(dir $(KUBECTL_SLICE))
+ifneq ($(KUBECTL_SLICE_VERSION), $(KUBECTL_SLICE_LOCAL_VERSION))
+	$(Q)rm -f $(KUBECTL_SLICE)
+ifeq ($(KUBECTL_SLICE_VERSION),$(KUBECTL_SLICE_HOST_VERSION))
+	$(Q)ln -s $$(command -v kubectl-slice) $(KUBECTL_SLICE)
+	@echo "kubectl-slice found at $$(command -v kubectl-slice)"
+else
+	$(Q){ \
+		rm -f $(KUBECTL_SLICE) ;\
+		arch=$$(case "$(ARCH)" in "amd64") echo "x86_64" ;; *) echo "$(ARCH)" ;; esac) ;\
+		mkdir -p $(KUBECTL_SLICE)-install ;\
+		curl -sSLo $(KUBECTL_SLICE)-install/kubectl-slice.tar.gz https://github.com/patrickdappollonio/kubectl-slice/releases/download/v$(KUBECTL_SLICE_VERSION)/kubectl-slice_$(KUBECTL_SLICE_VERSION)_$(OS)_$${arch}.tar.gz ;\
+		tar xvfz $(KUBECTL_SLICE)-install/kubectl-slice.tar.gz -C $(KUBECTL_SLICE)-install/ > /dev/null ;\
+		mv $(KUBECTL_SLICE)-install/kubectl-slice $(KUBECTL_SLICE) ;\
+		rm -rf $(KUBECTL_SLICE)-install ;\
+		$(call output-install,kubectl-slice,$(KUBECTL_SLICE_VERSION)) ;\
+	}
+endif
+endif
 
 MOCKGEN = $(shell pwd)/bin/mockgen
+MOCKGEN_VERSION ?= 1.6.0
+MOCKGEN_LOCAL_VERSION := $(shell [ -f $(MOCKGEN) ] && $(MOCKGEN) --version | cut -d' ' -f 3)
+MOCKGEN_HOST_VERSION := $(shell command -v mockgen >/dev/null && mockgen --version | cut -d' ' -f 3)
 mockgen:
-	$(call go-install-tool,$(MOCKGEN),github.com/golang/mock/mockgen@v1.6.0)
+	$(Q)mkdir -p $(dir $(MOCKGEN))
+ifneq (v$(MOCKGEN_VERSION), $(MOCKGEN_LOCAL_VERSION))
+	$(Q)rm -f $(MOCKGEN)
+ifeq (v$(MOCKGEN_VERSION),$(MOCKGEN_HOST_VERSION))
+	$(Q)ln -s $$(command -v mockgen) $(MOCKGEN)
+	@echo "mockgen found at $$(command -v mockgen)"
+else
+	$(Q)$(call go-install-tool,$(MOCKGEN),github.com/golang/mock/mockgen,$(MOCKGEN_VERSION))
+endif
+endif
+
+
+KUSTOMIZE = $(shell pwd)/bin/kustomize
+KUSTOMIZE_VERSION ?= 4.5.4
+KUSTOMIZE_LOCAL_VERSION := $(shell [ -f $(KUSTOMIZE) ] && $(KUSTOMIZE) version | cut -d' ' -f 1 | cut -d'/' -f 2)
+KUSTOMIZE_HOST_VERSION := $(shell command -v kustomize >/dev/null && kustomize version | cut -d' ' -f 1 | cut -d'/' -f 2)
+kustomize:
+	$(Q)mkdir -p $(dir $(KUSTOMIZE))
+ifneq (v$(KUSTOMIZE_VERSION), $(KUSTOMIZE_LOCAL_VERSION))
+	$(Q)rm -f $(KUSTOMIZE)
+ifeq (v$(KUSTOMIZE_VERSION),$(KUSTOMIZE_HOST_VERSION))
+	$(Q)ln -s $$(command -v kustomize) $(KUSTOMIZE)
+	@echo "kustomize found at $$(command -v kustomize)"
+else
+	$(Q){ \
+		set -e ;\
+		mkdir -p $(dir $(KUSTOMIZE)) ;\
+		rm -f $(KUSTOMIZE) ; \
+		mkdir -p $(KUSTOMIZE)-install ;\
+		curl -sSLo $(KUSTOMIZE)-install/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(KUSTOMIZE_VERSION)/kustomize_v$(KUSTOMIZE_VERSION)_$(OS)_$(ARCH).tar.gz ;\
+		tar xzvf $(KUSTOMIZE)-install/kustomize.tar.gz -C $(KUSTOMIZE)-install/ >/dev/null ;\
+		mv $(KUSTOMIZE)-install/kustomize $(KUSTOMIZE) ;\
+		rm -rf $(KUSTOMIZE)-install ;\
+		chmod +x $(KUSTOMIZE) ;\
+		$(call output-install,kustomize,$(KUSTOMIZE_VERSION)) ;\
+	}
+endif
+endif
 
 .PHONY: opm
 OPM ?=  $(shell pwd)/bin/opm
+OPM_VERSION ?= 1.22.0
+OPM_LOCAL_VERSION := $(shell [ -f $(OPM) ] && $(OPM) version | cut -d'"' -f 2)
+OPM_HOST_VERSION := $(shell command -v opm >/dev/null && opm version | cut -d'"' -f 2)
 opm:
-ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.22.0/$(OS)-$(ARCH)-opm ;\
-	chmod +x $(OPM) ;\
-	}
+	$(Q)mkdir -p $(dir $(OPM))
+ifneq (v$(OPM_VERSION), $(OPM_LOCAL_VERSION))
+	$(Q)rm -f $(OPM)
+ifeq (v$(OPM_VERSION),$(OPM_HOST_VERSION))
+	$(Q)ln -s $$(command -v opm) $(OPM)
+	@echo "opm found at $$(command -v opm)"
 else
-OPM = $(shell which opm)
+	$(Q){ \
+		set -e ;\
+		mkdir -p $(dir $(OPM)) ;\
+		rm -f $(OPM) ; \
+		curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v$(OPM_VERSION)/$(OS)-$(ARCH)-opm ;\
+		chmod +x $(OPM) ;\
+		$(call output-install,opm,$(OPM_VERSION)) ;\
+	}
 endif
 endif
+
+.PHONY: minikube
+MINIKUBE ?=  $(shell pwd)/bin/minikube
+MINIKUBE_VERSION ?= 1.26.1
+MINIKUBE_LOCAL_VERSION = $(shell [ -f $(MINIKUBE) ] && $(MINIKUBE) version --short)
+MINIKUBE_HOST_VERSION = $(shell command -v minikube >/dev/null && minikube version --short)
+minikube:
+	$(Q)mkdir -p $(dir $(MINIKUBE))
+ifneq (v$(MINIKUBE_VERSION), $(MINIKUBE_LOCAL_VERSION))
+	$(Q)rm -f $(MINIKUBE)
+ifeq (v$(MINIKUBE_VERSION),$(MINIKUBE_HOST_VERSION))
+	$(Q)ln -s $$(command -v minikube) $(MINIKUBE)
+	@echo "minikube found at $$(command -v minikube)"
+else
+	$(Q){ \
+		set -e ;\
+		mkdir -p $(dir $(MINIKUBE)) ;\
+		rm -f $(MINIKUBE) ; \
+		curl -sSLo $(MINIKUBE)  https://storage.googleapis.com/minikube/releases/v$(MINIKUBE_VERSION)/minikube-$(OS)-$(ARCH) ;\
+		chmod +x $(MINIKUBE) ;\
+		$(call output-install,minikube,$(MINIKUBE_VERSION)) ;\
+	}
+endif
+endif
+
+.PHONY: operator-sdk
+OPERATOR_SDK ?=  $(shell pwd)/bin/operator-sdk
+OPERATOR_SDK_VERSION ?= 1.24.0
+OPERATOR_SDK_LOCAL_VERSION := $(shell [ -f $(OPERATOR_SDK) ] && $(OPERATOR_SDK) version | cut -d'"' -f 2)
+OPERATOR_SDK_HOST_VERSION := $(shell command -v operator-sdk >/dev/null && operator-sdk version | cut -d'"' -f 2)
+operator-sdk:
+	$(Q)mkdir -p $(dir $(OPERATOR_SDK))
+ifneq (v$(OPERATOR_SDK_VERSION), $(OPERATOR_SDK_LOCAL_VERSION))
+	$(Q)rm -f $(OPERATOR_SDK)
+ifeq (v$(OPERATOR_SDK_VERSION),$(OPERATOR_SDK_HOST_VERSION))
+	$(Q)ln -s $$(command -v operator-sdk) $(OPERATOR_SDK)
+	@echo "operator-sdk found at $$(command -v operator-sdk)"
+else
+	$(Q){ \
+		set -e ;\
+		mkdir -p $(dir $(OPERATOR_SDK)) ;\
+		rm -f $(OPERATOR_SDK) ; \
+		curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v$(OPERATOR_SDK_VERSION)/operator-sdk_$(OS)_$(ARCH) ;\
+		chmod +x $(OPERATOR_SDK) ;\
+		$(call output-install,operator-sdk,$(OPERATOR_SDK_VERSION)) ;\
+	}
+endif
+endif
+
+.PHONY: kubectl
+KUBECTL ?=  $(shell pwd)/bin/kubectl
+KUBECTL_VERSION ?= 1.25.3
+KUBECTL_LOCAL_VERSION := $(shell [ -f $(KUBECTL) ] && $(KUBECTL) version --client --output yaml | grep 'gitVersion:' | tr -d ' ' | cut -d':' -f 2)
+KUBECTL_HOST_VERSION := $(shell command -v kubectl >/dev/null && kubectl version --client --output yaml | grep 'gitVersion:' | tr -d ' ' | cut -d':' -f 2)
+kubectl:
+	$(Q)mkdir -p $(dir $(KUBECTL))
+ifneq ($(KUBECTL_HOST_VERSION),)
+	$(Q)rm -f $(KUBECTL)
+	$(Q)ln -s $$(command -v kubectl) $(KUBECTL)
+	@echo "kubectl found at $$(command -v kubectl)"
+else ifneq (v$(KUBECTL_VERSION), $(KUBECTL_LOCAL_VERSION))
+	$(Q){ \
+		set -e ;\
+		mkdir -p $(dir $(KUBECTL)) ;\
+		rm -f $(KUBECTL) ; \
+		curl -sSLo $(KUBECTL) https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/$(OS)/$(ARCH)/kubectl ;\
+		chmod +x $(KUBECTL) ;\
+		$(call output-install,kubectl,$(KUBECTL_VERSION)) ;\
+	}
+endif
+
+.PHONY: helm
+HELM ?=  $(shell pwd)/bin/helm
+HELM_VERSION ?= 3.10.1
+HELM_LOCAL_VERSION := $(shell [ -f $(HELM) ] && $(HELM) version --short | cut -d'+' -f 1)
+HELM_HOST_VERSION := $(shell command -v helm >/dev/null && helm version --short | cut -d'+' -f 1)
+helm:
+	$(Q)mkdir -p $(dir $(HELM))
+ifneq (v$(HELM_VERSION), $(HELM_LOCAL_VERSION))
+	$(Q)rm -f $(HELM)
+ifeq (v$(HELM_VERSION),$(HELM_HOST_VERSION))
+	$(Q)ln -s $$(command -v helm) $(HELM)
+	@echo "helm found at $$(command -v helm)"
+else
+	$(Q){ \
+		set -e ;\
+		mkdir -p $(dir $(HELM)) $(HELM)-install ;\
+		curl -sSLo $(HELM)-install/helm.tar.gz https://get.helm.sh/helm-v$(HELM_VERSION)-$(OS)-$(ARCH).tar.gz ;\
+		tar xvfz $(HELM)-install/helm.tar.gz -C $(HELM)-install >/dev/null ;\
+		rm -f $(HELM) ; \
+		cp $(HELM)-install/$(OS)-$(ARCH)/helm $(HELM) ;\
+		rm -r $(HELM)-install ;\
+		chmod +x $(HELM) ;\
+		$(call output-install,helm,$(HELM_VERSION)) ;\
+	}
+endif
+endif
+
+.PHONY: install-tools
+install-tools: controller-gen helm kubectl kubectl-slice kustomize minikube mockgen operator-sdk opm yq
+	@echo
+	@echo run '`eval $$(make local-env)`' to configure your shell to use tools in the ./bin folder
+
+.PHONY: local-env
+local-env:
+	@echo export PATH=$(shell pwd)/bin:$$PATH
 
 all: build

--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -5,26 +5,26 @@ run: generate fmt vet install
 
 .PHONY: install
 ## Install CRDs into a cluster
-install: manifests kustomize
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+install: manifests kustomize kubectl
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
 
-.PHONY: uninstall
+.PHONY: uninstall kubectl
 ## Uninstall CRDs from a cluster
 uninstall: manifests kustomize
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete -f -
 
 .PHONY: deploy-cert-manager
-deploy-cert-manager:
-	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
-	kubectl rollout status -n cert-manager deploy/cert-manager-webhook -w --timeout=120s
+deploy-cert-manager: kubectl
+	$(KUBECTL) apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
+	$(KUBECTL) rollout status -n cert-manager deploy/cert-manager-webhook -w --timeout=120s
 
 .PHONY: deploy
 ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: manifests kustomize image deploy-cert-manager
+deploy: manifests kustomize kubectl image deploy-cert-manager
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(OPERATOR_IMAGE_REF)
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 ## UnDeploy controller from the configured Kubernetes cluster in ~/.kube/config
-undeploy:
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
+undeploy: kustomize kubectl
+	$(KUSTOMIZE) build config/default | $(KUBECTL) delete -f -


### PR DESCRIPTION
If required tool version is found on the host, then it will be linked into the ./bin folder. Otherwise, it will be downloaded.

Signed-off-by: Francesco Ilario <filario@redhat.com>

# Changes

Added `install-tools` and `local-env` rules to makefiles.
Leveraging on these rules, it is now possible to easily install the needed version of each dependency.

/kind enhancement

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

