### PR TITLE
Fix deploy/uninstall rule

### DIFF
--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -8,9 +8,9 @@ run: generate fmt vet install
 install: manifests kustomize kubectl
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
 
-.PHONY: uninstall kubectl
+.PHONY: uninstall
 ## Uninstall CRDs from a cluster
-uninstall: manifests kustomize
+uninstall: manifests kustomize kubectl
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete -f -
 
 .PHONY: deploy-cert-manager


### PR DESCRIPTION
# Changes

Fix an error in the deploy/uninstall rule.
The kubectl dependency was added to .PHONY instead of to the uninstall rule's dependencies.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

