### PR TITLE
Rebind workloads when their mappings change

### DIFF
--- a/apis/common.go
+++ b/apis/common.go
@@ -3,18 +3,20 @@ package apis
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
+
 	"k8s.io/api/authentication/v1"
 	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	finalizerName          = "finalizer.servicebinding.openshift.io"
 	requesterAnnotationKey = "servicebinding.io/requester"
+	MappingAnnotationKey   = "servicebinding.io/mapping"
 )
 
 func MaybeAddFinalizer(obj Object) bool {

--- a/apis/webhooks/suite_test.go
+++ b/apis/webhooks/suite_test.go
@@ -1,0 +1,13 @@
+package webhooks_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBindingHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Binding Handlers Suite")
+}

--- a/apis/webhooks/validator.go
+++ b/apis/webhooks/validator.go
@@ -1,0 +1,175 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/redhat-developer/service-binding-operator/apis"
+	"github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/apis/spec/v1beta1"
+	"github.com/redhat-developer/service-binding-operator/pkg/client/kubernetes"
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+type MappingValidator struct {
+	client dynamic.Interface
+	lookup kubernetes.K8STypeLookup
+}
+
+// log is for logging in this package.
+var log = logf.Log.WithName("WebHook Spec ClusterWorkloadResourceMapping")
+
+func NewMappingValidator(config *rest.Config, mapper meta.RESTMapper) (*MappingValidator, error) {
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	validator := &MappingValidator{
+		client: client,
+		lookup: kubernetes.ResourceLookup(mapper),
+	}
+
+	return validator, nil
+}
+
+func (validator *MappingValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1beta1.ClusterWorkloadResourceMapping{}).
+		WithValidator(validator).
+		Complete()
+}
+
+var _ webhook.CustomValidator = &MappingValidator{}
+
+func (validator *MappingValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	mapping := obj.(*v1beta1.ClusterWorkloadResourceMapping)
+	err := mapping.ValidateCreate()
+	if err != nil {
+		log.Error(err, "Error validating mapping (create)", "mapping", mapping.Name)
+	}
+	return err
+}
+
+func (validator *MappingValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	mapping := newObj.(*v1beta1.ClusterWorkloadResourceMapping)
+	if err := mapping.ValidateCreate(); err != nil {
+		log.Error(err, "Error validating mapping (update)", "mapping", mapping.Name)
+		return err
+	}
+	oldMapping := oldObj.(*v1beta1.ClusterWorkloadResourceMapping)
+	err := Serialize(ctx, oldMapping, validator.client, validator.lookup)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (validator *MappingValidator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func Serialize(ctx context.Context, mapping *v1beta1.ClusterWorkloadResourceMapping, client dynamic.Interface, lookup kubernetes.K8STypeLookup) error {
+	serialized, err := json.Marshal(mapping)
+	if err != nil {
+		return err
+	}
+	numItems := 0
+
+	gvr := v1beta1.GroupVersionResource
+	data, err := client.Resource(gvr).List(ctx, v1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, binding := range data.Items {
+		// we should filter out service bindings that the mapping doesn't affect.
+		sb := v1beta1.ServiceBinding{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(binding.Object, &sb)
+		if err != nil {
+			// short circuit, something's gone terribly wrong
+			return err
+		}
+
+		gvk, _ := sb.Spec.Workload.GroupVersionKind()
+		workloadGVR, err := lookup.ResourceForKind(*gvk)
+		if err != nil {
+			return err
+		}
+		if !mapping.AcceptsGVR(workloadGVR) {
+			// not a relevant binding, skip it
+			continue
+		}
+
+		annotations := binding.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{
+				apis.MappingAnnotationKey: string(serialized),
+			}
+		} else {
+			annotations[apis.MappingAnnotationKey] = string(serialized)
+		}
+		binding.SetAnnotations(annotations)
+
+		x, err := client.Resource(gvr).Namespace(sb.Namespace).Update(ctx, &binding, v1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		log.Info("deployed service binding", "annotations", x.GetAnnotations())
+		numItems += 1
+	}
+
+	gvr = v1alpha1.GroupVersionResource
+	data, err = client.Resource(gvr).List(ctx, v1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, binding := range data.Items {
+		sb := v1alpha1.ServiceBinding{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(binding.Object, &sb)
+		if err != nil {
+			return err
+		}
+
+		var workloadGVR *schema.GroupVersionResource
+		if sb.Spec.Application.Kind != "" {
+			gvk, _ := sb.Spec.Application.GroupVersionKind()
+			if workloadGVR, err = lookup.ResourceForKind(*gvk); err != nil {
+				return err
+			}
+		} else {
+			workloadGVR, _ = sb.Spec.Application.GroupVersionResource()
+		}
+		if !mapping.AcceptsGVR(workloadGVR) {
+			continue
+		}
+
+		annotations := binding.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{
+				apis.MappingAnnotationKey: string(serialized),
+			}
+		} else {
+			annotations[apis.MappingAnnotationKey] = string(serialized)
+		}
+		binding.SetAnnotations(annotations)
+
+		x, err := client.Resource(gvr).Namespace(sb.Namespace).Update(ctx, &binding, v1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		log.Info("deployed service binding", "annotations", x.GetAnnotations())
+		numItems += 1
+	}
+	log.Info("Rebinding", "num_objects", numItems)
+	return nil
+}

--- a/apis/webhooks/validator_test.go
+++ b/apis/webhooks/validator_test.go
@@ -1,0 +1,306 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-developer/service-binding-operator/apis"
+	"github.com/redhat-developer/service-binding-operator/apis/binding/v1alpha1"
+	"github.com/redhat-developer/service-binding-operator/apis/spec/v1beta1"
+	"github.com/redhat-developer/service-binding-operator/pkg/client/kubernetes/mocks"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+var _ = Describe("Validate", func() {
+	var (
+		mockCtrl  *gomock.Controller
+		validator MappingValidator
+		ctx       context.Context
+		mapping   v1beta1.ClusterWorkloadResourceMapping
+		scheme    *runtime.Scheme
+		lookup    *mocks.MockK8STypeLookup
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		scheme = runtime.NewScheme()
+		Expect(v1beta1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(v1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		ctx = context.Background()
+		mapping = v1beta1.ClusterWorkloadResourceMapping{
+			Spec: v1beta1.ClusterWorkloadResourceMappingSpec{
+				Versions: []v1beta1.ClusterWorkloadResourceMappingTemplate{
+					v1beta1.DefaultTemplate,
+				},
+			},
+		}
+		lookup = mocks.NewMockK8STypeLookup(mockCtrl)
+		validator = MappingValidator{
+			client: nil,
+			lookup: lookup,
+		}
+	})
+
+	var _ = Describe("Create", func() {
+		It("should accept a valid mapping", func() {
+			err := validator.ValidateCreate(ctx, &mapping)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject an invalid mapping", func() {
+			mapping.Spec.Versions[0].Volumes = "foo.bar"
+			err := validator.ValidateCreate(ctx, &mapping)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	var _ = Describe("Update", func() {
+		It("should reject an invalid mapping", func() {
+			oldMapping := mapping.DeepCopy()
+			mapping.Spec.Versions[0].Volumes = "foo.bar"
+			err := validator.ValidateUpdate(ctx, oldMapping, &mapping)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should accept a valid mapping", func() {
+			oldMapping := mapping.DeepCopy()
+			mapping.Spec.Versions[0].Volumes = ".spec.volumes"
+			validator.client = fake.NewSimpleDynamicClient(scheme)
+			err := validator.ValidateUpdate(ctx, oldMapping, &mapping)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should serialize old mappings into relevant service bindings", func() {
+			mapping.Name = "foos.bar"
+			oldMapping := mapping.DeepCopy()
+			mapping.Spec.Versions[0].Volumes = ".spec.volumes"
+			relevantSB := v1beta1.ServiceBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "relevant",
+				},
+				Spec: v1beta1.ServiceBindingSpec{
+					Workload: v1beta1.ServiceBindingWorkloadReference{
+						APIVersion: "bar/v1",
+						Kind:       "Foo",
+						Name:       "x",
+					},
+				},
+			}
+			irrelevantSB := v1beta1.ServiceBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "irrelevant",
+				},
+				Spec: v1beta1.ServiceBindingSpec{
+					Workload: v1beta1.ServiceBindingWorkloadReference{
+						APIVersion: "bar/v1",
+						Kind:       "Spam",
+						Name:       "x",
+					},
+				},
+			}
+			validator.client = fake.NewSimpleDynamicClient(scheme, &relevantSB, &irrelevantSB)
+			spamGVK := schema.GroupVersionKind{Group: "bar", Version: "v1", Kind: "Spam"}
+			spamGVR := schema.GroupVersionResource{Group: "bar", Version: "v1", Resource: "spams"}
+			lookup.EXPECT().ResourceForKind(spamGVK).Return(&spamGVR, nil).Times(2)
+			fooGVK := schema.GroupVersionKind{Group: "bar", Version: "v1", Kind: "Foo"}
+			fooGVR := schema.GroupVersionResource{Group: "bar", Version: "v1", Resource: "foos"}
+			lookup.EXPECT().ResourceForKind(fooGVK).Return(&fooGVR, nil).Times(2)
+
+			err := validator.ValidateUpdate(ctx, oldMapping, &mapping)
+			Expect(err).NotTo(HaveOccurred())
+
+			oldData, err := json.Marshal(oldMapping)
+			Expect(err).NotTo(HaveOccurred())
+
+			data, err := validator.client.Resource(v1beta1.GroupVersionResource).
+				Get(ctx, "relevant", v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data.GetAnnotations()).To(Equal(map[string]string{apis.MappingAnnotationKey: string(oldData)}))
+
+			data, err = validator.client.Resource(v1beta1.GroupVersionResource).
+				Get(ctx, "irrelevant", v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data.GetAnnotations()).To(BeEmpty())
+		})
+	})
+
+	var _ = Describe("Delete", func() {
+		It("should not need to validate deletes", func() {
+			err := validator.ValidateDelete(ctx, &mapping)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("Serialize", func() {
+
+	var (
+		mockCtrl *gomock.Controller
+		binding1 v1beta1.ServiceBinding
+		binding2 v1alpha1.ServiceBinding
+		mapping  v1beta1.ClusterWorkloadResourceMapping
+		lookup   *mocks.MockK8STypeLookup
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		binding1 = v1beta1.ServiceBinding{
+			ObjectMeta: v1.ObjectMeta{Name: "foo", Namespace: "bar"},
+			Spec: v1beta1.ServiceBindingSpec{
+				Workload: v1beta1.ServiceBindingWorkloadReference{
+					APIVersion: "foo.bar/v1",
+					Kind:       "Baz",
+					Name:       "spam",
+				},
+			},
+		}
+
+		binding2 = v1alpha1.ServiceBinding{
+			ObjectMeta: v1.ObjectMeta{Name: "foo", Namespace: "bar"},
+			Spec: v1alpha1.ServiceBindingSpec{
+				Application: v1alpha1.Application{
+					Ref: v1alpha1.Ref{
+						Group:   "foo.bar",
+						Version: "v1",
+						Kind:    "Baz",
+						Name:    "spam",
+					},
+				},
+			},
+		}
+
+		mapping = v1beta1.ClusterWorkloadResourceMapping{
+			ObjectMeta: v1.ObjectMeta{Name: "baz.foo.bar"},
+			Spec: v1beta1.ClusterWorkloadResourceMappingSpec{
+				Versions: []v1beta1.ClusterWorkloadResourceMappingTemplate{
+					v1beta1.DefaultTemplate,
+				},
+			},
+		}
+		lookup = mocks.NewMockK8STypeLookup(mockCtrl)
+		lookup.EXPECT().ResourceForKind(schema.GroupVersionKind{
+			Group:   "foo.bar",
+			Kind:    "Baz",
+			Version: "v1",
+		}).Return(&schema.GroupVersionResource{
+			Group:    "foo.bar",
+			Resource: "baz",
+			Version:  "v1",
+		}, nil).AnyTimes()
+	})
+
+	It("should serialize the mapping into annotations", func() {
+		scheme := runtime.NewScheme()
+		Expect(v1beta1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(v1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		client := fake.NewSimpleDynamicClient(scheme, &binding1, &binding2, &mapping)
+
+		data, err := json.Marshal(mapping)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = Serialize(context.Background(), &mapping, client, lookup)
+		Expect(err).NotTo(HaveOccurred())
+
+		bindingUnstructured, err := client.
+			Resource(v1beta1.GroupVersionResource).
+			Namespace("bar").
+			Get(context.Background(), "foo", v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bindingUnstructured.GetAnnotations()[apis.MappingAnnotationKey]).To(Equal(string(data)))
+
+		bindingUnstructured, err = client.
+			Resource(v1alpha1.GroupVersionResource).
+			Namespace("bar").
+			Get(context.Background(), "foo", v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bindingUnstructured.GetAnnotations()[apis.MappingAnnotationKey]).To(Equal(string(data)))
+	})
+
+	It("should not modify existing annotations", func() {
+		annotations := map[string]string{
+			"foo": "bar",
+		}
+		binding1.SetAnnotations(annotations)
+		binding2.SetAnnotations(annotations)
+
+		scheme := runtime.NewScheme()
+		Expect(v1beta1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(v1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		client := fake.NewSimpleDynamicClient(scheme, &binding1, &binding2, &mapping)
+
+		data, err := json.Marshal(mapping)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = Serialize(context.Background(), &mapping, client, lookup)
+		Expect(err).NotTo(HaveOccurred())
+
+		bindingUnstructured, err := client.
+			Resource(v1beta1.GroupVersionResource).
+			Namespace("bar").
+			Get(context.Background(), "foo", v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bindingUnstructured.GetAnnotations()[apis.MappingAnnotationKey]).To(Equal(string(data)))
+		Expect(bindingUnstructured.GetAnnotations()["foo"]).To(Equal("bar"))
+
+		bindingUnstructured, err = client.
+			Resource(v1alpha1.GroupVersionResource).
+			Namespace("bar").
+			Get(context.Background(), "foo", v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bindingUnstructured.GetAnnotations()[apis.MappingAnnotationKey]).To(Equal(string(data)))
+		Expect(bindingUnstructured.GetAnnotations()["foo"]).To(Equal("bar"))
+	})
+
+	It("should ignore irrelevant bindings", func() {
+		mapping.Name = "spam.foo.bar"
+		scheme := runtime.NewScheme()
+		Expect(v1beta1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(v1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		client := fake.NewSimpleDynamicClient(scheme, &binding1, &binding2, &mapping)
+
+		err := Serialize(context.Background(), &mapping, client, lookup)
+		Expect(err).NotTo(HaveOccurred())
+
+		bindingUnstructured, err := client.
+			Resource(v1beta1.GroupVersionResource).
+			Namespace("bar").
+			Get(context.Background(), "foo", v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bindingUnstructured.GetAnnotations()).NotTo(HaveKey(apis.MappingAnnotationKey))
+
+		bindingUnstructured, err = client.
+			Resource(v1alpha1.GroupVersionResource).
+			Namespace("bar").
+			Get(context.Background(), "foo", v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bindingUnstructured.GetAnnotations()).NotTo(HaveKey(apis.MappingAnnotationKey))
+	})
+
+	It("should use the resource field from the service binding when available", func() {
+		mapping.Name = "spam.foo.bar"
+		scheme := runtime.NewScheme()
+		Expect(v1beta1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(v1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
+
+		binding2.Spec.Application.Kind = ""
+		binding2.Spec.Application.Resource = "baz"
+
+		client := fake.NewSimpleDynamicClient(scheme, &binding2, &mapping)
+
+		err := Serialize(context.Background(), &mapping, client, lookup)
+		Expect(err).NotTo(HaveOccurred())
+
+		bindingUnstructured, err := client.
+			Resource(v1alpha1.GroupVersionResource).
+			Namespace("bar").
+			Get(context.Background(), "foo", v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bindingUnstructured.GetAnnotations()).NotTo(HaveKey(apis.MappingAnnotationKey))
+	})
+})

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -55,9 +55,10 @@ func (r *BindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 	r.pipeline = pipeline
+	p := predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})
 	return ctrl.NewControllerManagedBy(mgr).
 		For(r.ReconcilingObject()).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(p).
 		WithOptions(controller.Options{MaxConcurrentReconciles: MaxConcurrentReconciles}).
 		Complete(r)
 }

--- a/main.go
+++ b/main.go
@@ -164,7 +164,15 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "SPEC ServiceBinding")
 		os.Exit(1)
 	}
-	if err = (&specv1beta1.ClusterWorkloadResourceMapping{}).SetupWebhookWithManager(mgr); err != nil {
+	mappingValidator, err := webhooks.NewMappingValidator(
+		mgr.GetConfig(),
+		mgr.GetRESTMapper(),
+	)
+	if err != nil {
+		setupLog.Error(err, "unable to initialize webhook", "webhook", "ClusterWorkloadResourceMapping")
+		os.Exit(1)
+	}
+	if err = mappingValidator.SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ClusterWorkloadResourceMapping")
 		os.Exit(1)
 	}

--- a/pkg/reconcile/pipeline/api.go
+++ b/pkg/reconcile/pipeline/api.go
@@ -133,8 +133,14 @@ type Context interface {
 	// if no application found, return an error
 	Applications() ([]Application, error)
 
-	// Returns true if binding is about to be removed
+	// Returns true if the binding needs to be removed
 	UnbindRequested() bool
+
+	// Returns true if the binding is being removed
+	IsRemoved() bool
+
+	// Cleans temporary annotations on the underlying resources
+	CleanAnnotations() bool
 
 	BindingSecretName() string
 

--- a/pkg/reconcile/pipeline/context/spec_binding_impl.go
+++ b/pkg/reconcile/pipeline/context/spec_binding_impl.go
@@ -112,6 +112,16 @@ func (i *specImpl) EnvBindings() []*pipeline.EnvBinding {
 	return result
 }
 
+func (i *specImpl) CleanAnnotations() bool {
+	annotations := i.serviceBinding.GetAnnotations()
+	_, found := annotations[apis.MappingAnnotationKey]
+	if found {
+		delete(annotations, apis.MappingAnnotationKey)
+		i.serviceBinding.SetAnnotations(annotations)
+	}
+	return found
+}
+
 func (i *specImpl) Services() ([]pipeline.Service, error) {
 	if i.services == nil {
 		serviceRef := i.serviceBinding.Spec.Service

--- a/pkg/reconcile/pipeline/context/spec_binding_impl_test.go
+++ b/pkg/reconcile/pipeline/context/spec_binding_impl_test.go
@@ -932,6 +932,45 @@ var _ = Describe("Spec API Context", func() {
 		})
 
 	})
+
+	Describe("CleanAnnotations", func() {
+		var (
+			sb  *specapi.ServiceBinding
+			ctx pipeline.Context
+			err error
+		)
+
+		BeforeEach(func() {
+			sb = &specapi.ServiceBinding{}
+			ctx, err = Provider(nil, nil, nil).Get(sb)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should clean mapping annotations when present", func() {
+			sb.SetAnnotations(map[string]string{
+				apis.MappingAnnotationKey: "foo",
+			})
+			Expect(ctx.CleanAnnotations()).To(BeTrue())
+			Expect(sb.GetAnnotations()).To(BeEmpty())
+		})
+
+		It("should not touch other annotations present", func() {
+			sb.SetAnnotations(map[string]string{
+				apis.MappingAnnotationKey: "foo",
+				"spam":                    "eggs",
+			})
+			Expect(ctx.CleanAnnotations()).To(BeTrue())
+			Expect(sb.GetAnnotations()).To(Equal(map[string]string{"spam": "eggs"}))
+		})
+
+		It("should return false when mapping annotations are not present", func() {
+			sb.SetAnnotations(map[string]string{
+				"spam": "eggs",
+			})
+			Expect(ctx.CleanAnnotations()).To(BeFalse())
+			Expect(sb.GetAnnotations()).To(Equal(map[string]string{"spam": "eggs"}))
+		})
+	})
 })
 
 func scheme(objs ...runtime.Object) *runtime.Scheme {

--- a/pkg/reconcile/pipeline/handler/mapping/impl.go
+++ b/pkg/reconcile/pipeline/handler/mapping/impl.go
@@ -3,8 +3,9 @@ package mapping
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
 	"text/template"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/reconcile/pipeline"
 )
 
 func Handle(ctx pipeline.Context) {

--- a/pkg/reconcile/pipeline/handler/project/impl.go
+++ b/pkg/reconcile/pipeline/handler/project/impl.go
@@ -229,7 +229,12 @@ func Unbind(ctx pipeline.Context) {
 			}
 		}
 	}
-	ctx.StopProcessing()
+
+	if ctx.CleanAnnotations() {
+		ctx.RetryProcessing(nil)
+	} else {
+		ctx.StopProcessing()
+	}
 }
 
 func stop(ctx pipeline.Context, err error) {

--- a/pkg/reconcile/pipeline/mocks/mocks_pipeline.go
+++ b/pkg/reconcile/pipeline/mocks/mocks_pipeline.go
@@ -133,6 +133,20 @@ func (mr *MockContextMockRecorder) BindingSecretName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindingSecretName", reflect.TypeOf((*MockContext)(nil).BindingSecretName))
 }
 
+// CleanAnnotations mocks base method.
+func (m *MockContext) CleanAnnotations() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanAnnotations")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CleanAnnotations indicates an expected call of CleanAnnotations.
+func (mr *MockContextMockRecorder) CleanAnnotations() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanAnnotations", reflect.TypeOf((*MockContext)(nil).CleanAnnotations))
+}
+
 // Close mocks base method.
 func (m *MockContext) Close() error {
 	m.ctrl.T.Helper()
@@ -211,6 +225,20 @@ func (m *MockContext) HasLabelSelector() bool {
 func (mr *MockContextMockRecorder) HasLabelSelector() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasLabelSelector", reflect.TypeOf((*MockContext)(nil).HasLabelSelector))
+}
+
+// IsRemoved mocks base method.
+func (m *MockContext) IsRemoved() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRemoved")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsRemoved indicates an expected call of IsRemoved.
+func (mr *MockContextMockRecorder) IsRemoved() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRemoved", reflect.TypeOf((*MockContext)(nil).IsRemoved))
 }
 
 // Mappings mocks base method.

--- a/test/acceptance/features/steps/app.py
+++ b/test/acceptance/features/steps/app.py
@@ -58,3 +58,16 @@ def resource_jsonpath_value(context, json_path, res_name, json_value=""):
     (crdName, name) = res_name.split("/")
     polling2.poll(lambda: openshift.get_resource_info_by_jsonpath(crdName, name, context.namespace.name, json_path) == json_value,
                   step=5, timeout=800, ignore_exceptions=(json.JSONDecodeError,))
+
+
+@step(u'jsonpath "{json_path}" on "{res_name}" should contain "{json_value}"')
+def resource_jsonpath_contains(context, json_path, res_name, json_value):
+    openshift = Openshift()
+    json_path = substitute_scenario_id(context, json_path)
+    res_name = substitute_scenario_id(context, res_name)
+    json_value = json.loads(substitute_scenario_id(context, json_value))
+    (crdName, name) = res_name.split("/")
+    actual_value = polling2.poll(lambda: openshift.get_resource_info_by_jsonpath(crdName, name, context.namespace.name, json_path),
+                                 step=5, timeout=800, ignore_exceptions=(json.JSONDecodeError))
+    data = json.loads(actual_value)
+    assert json_value in data, "Expected {str(json_value)} in {str(data)}"


### PR DESCRIPTION
Signed-off-by: Andy Sadler <ansadler@redhat.com>

# Changes

This works in three stages:

1. During workload mapping's validation webhook, we serialize the old mapping into the `servicebinding.io/mapping` annotation on all relevant service bindings.
2. We run our reconcile pipeline once, to unbind the workload using the serialized mapping.  Once completed, we delete the mapping and immediate trigger reprocessing of the service binding.
3. We re-run our reconcile pipeline as normal using the new mapping to project data as expected.

/kind enhancement

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

