### PR TITLE
Fix SBO checks for OpenShift 4.9

### DIFF
--- a/test/acceptance/features/steps/servicebindingoperator.py
+++ b/test/acceptance/features/steps/servicebindingoperator.py
@@ -38,15 +38,14 @@ class Servicebindingoperator():
             return False
 
         if csv_version is not None:
-            cmd = f"{ctx.cli} wait --for=jsonpath='{{.metadata.labels.olm\\.owner}}'={csv_version} \
-                deployment/service-binding-operator -n {sbo_namespace} --timeout=300s"
-            output, code = self.cmd.run(cmd)
+            cmd = f"{ctx.cli} get deployment/service-binding-operator -o jsonpath='{{.metadata.labels.olm\\.owner}}' -n {sbo_namespace}"
+            (output, code) = polling2.poll(target=lambda: tuple(self.cmd.run(cmd)),
+                                           check_success=lambda o: o[1] == 0 and o[0] == csv_version, step=5, timeout=300, ignore_exceptions=(ValueError,))
             assert code == 0, f"Non-zero return code while trying to check SBO deployment is owned by {csv_version} CSV: {output}"
 
-            cmd = f"{ctx.cli} wait --for=jsonpath='{{.metadata.ownerReferences[0].name}}'={csv_version} \
-                secrets/service-binding-operator-service-cert -n {sbo_namespace}"
-            output, code = polling2.poll(target=lambda: tuple(self.cmd.run(cmd)),
-                                         check_success=lambda o: o[1] == 0, step=5, timeout=300, ignore_exceptions=(ValueError,))
+            cmd = f"{ctx.cli} get secrets/service-binding-operator-service-cert -o jsonpath='{{.metadata.ownerReferences[0].name}}' -n {sbo_namespace}"
+            (output, code) = polling2.poll(target=lambda: tuple(self.cmd.run(cmd)),
+                                           check_success=lambda o: o[1] == 0 and o[0] == csv_version, step=5, timeout=300, ignore_exceptions=(ValueError,))
             assert code == 0, f"Non-zero return code while trying to check SBO cert secret is owned by {csv_version} CSV: {output}"
 
         output, code = self.cmd.run(f"{ctx.cli} rollout status -w deployment/service-binding-operator -n {sbo_namespace}")


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

The acceptance testing framework is not working properly with `oc` `v4.9` - it assumes parameters of `oc` (the `--for=jsonpath=...` option for `oc wait` subcommand) that are available in later versions (`v4.10+`) but not yet available in `v4.9`.

Dependency for https://github.com/openshift/release/pull/34341

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR:
* Fix the framework for OCP 4.9 by replacing the `oc wait --for=jsonpath='...'` command with polling the command `oc get ...` for expected response (with use of `polling2` Python library)
* Depends on: https://github.com/redhat-developer/service-binding-operator/pull/1311

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

