### PR TITLE
cherry-pick(release-v1.3.x): Use community version of Percona MongoDB Operator in acceptance tests

### DIFF
--- a/test/acceptance/features/steps/perconamongodboperator.py
+++ b/test/acceptance/features/steps/perconamongodboperator.py
@@ -8,8 +8,9 @@ class PerconaMongoDBOperator(Operator):
     def __init__(self, name="percona-server-mongodb-operator"):
         super().__init__(
             name=name,
-            operator_catalog_source_name="community-operators" if ctx.cli == "oc" else "operatorhubio-catalog",
+            operator_catalog_source_name="operatorhubio-catalog",
             operator_catalog_channel="stable",
+            operator_catalog_image="quay.io/operatorhubio/catalog:latest",
             package_name=name
         )
 
@@ -19,6 +20,8 @@ def install_percona_mongodb_operator(context):
     operator = PerconaMongoDBOperator()
     operator.operator_namespace = context.namespace.name
     if not operator.is_running():
+        if ctx.cli == "oc":
+            operator.install_catalog_source()
         subscription = f'''
 ---
 apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

Currently, Percona MongoDB operator is not available in `community-operators` catalog for OpenShift 4.12 which causes the acceptance testing PR checks for OpenShift 4.12 to fail.

# Changes

This PR:
* Changes the catalog for Percona MongoDB operator on OpenShift in tests from the `community-operators` to Operatorhub.io.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

