### PR TITLE
bump version to v1.3.2 for helm chart

### DIFF
--- a/charts/service-binding-operator/Chart.yaml
+++ b/charts/service-binding-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: service-binding-operator
 description: A Helm chart to deploy service binding operator
 type: application
-version: 1.3.1
-appVersion: "1.3.1"
+version: 1.3.2
+appVersion: "1.3.2"
 kubeVersion: ">= 1.19.2-0"
 icon: https://raw.githubusercontent.com/redhat-developer/service-binding-operator/master/assets/icon/sbo-logo.png
 keywords:

--- a/charts/service-binding-operator/templates/deployment.yaml
+++ b/charts/service-binding-operator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - --zap-log-level=info
         command:
         - /manager
-        image: {{.Values.image.image | default (printf "%s/%s" .Values.image.repository "servicebinding-operator@sha256:67c2a2502f59fac1e7ded9ed19b59bbd4e50f5559a13978a87ecd2283b81e067") | quote}}
+        image: {{.Values.image.image | default (printf "%s/%s" .Values.image.repository "servicebinding-operator@sha256:30bf7f0f21024bb2e1e4db901b1f5e89ab56e0f3197a919d2bbb670f3fe5223a") | quote}}
         imagePullPolicy: {{.Values.image.pullPolicy}}
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Signed-off-by: Andy Sadler <ansadler@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Bumps the version in our help chart manifest to v1.3.2.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

