### PR TITLE
Remove debug info from final binary

### DIFF
--- a/make/build.mk
+++ b/make/build.mk
@@ -13,10 +13,12 @@ OPERATOR_INDEX_YAML ?= $(OPERATOR_INDEX_DIR)/index.yaml
 
 OPM_RENDER_OPTS := 
 
+GO_BUILD_FLAGS ?= -ldflags="-s -w" -trimpath
+
 .PHONY: build
 ## Build operator binary
 build:
-	$(GO) build -o bin/manager main.go
+	$(GO) build $(GO_BUILD_FLAGS) -o bin/manager main.go
 
 .PHONY: manifests
 ## Generate manifests e.g. CRD, RBAC etc.


### PR DESCRIPTION
# Changes

Use `-ldflags="-s -w"` and `-trimpath` in `go build` to strip debug tables and system paths from final binary.

From [https://pkg.go.dev/cmd/link](https://pkg.go.dev/cmd/link):
- `-s`: Omit the symbol table and debug information
- `-w`: Omit the DWARF symbol table.

From [https://pkg.go.dev/cmd/go](https://pkg.go.dev/cmd/go):
- `trimpath`: remove all file system paths from the resulting executable. Instead of absolute file system paths, the recorded file names will begin either a module path@version (when using modules), or a plain import path (when using the standard library, or GOPATH).

/kind enhancement

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)