### PR TITLE
Fixed the type of execution_timestamp

### DIFF
--- a/test/performance/upload_data.py
+++ b/test/performance/upload_data.py
@@ -107,7 +107,7 @@ def read_metric_data(file_name):
     run_type = content['run_type']
     pull_number = content['pull_number']
     commit_id = content['commit_id']
-
+    execution_timestamp_in_string = execution_timestamp.strftime("%Y-%m-%d %H:%M:%S")
     for data in kpi_data:
         if data['name'] == 'usage':
             for metric in data['metrics']:
@@ -130,7 +130,7 @@ def read_metric_data(file_name):
             'run_type': run_type,
             'pull_number': pull_number,
             'commit_id': commit_id,
-            'execution_timestamp': execution_timestamp,
+            'execution_timestamp': execution_timestamp_in_string,
             'sbo_version': sbo_version,
             'openshift_version': openshift_version,
             'openshift_release': openshift_release}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Changed the type of execution_timestamp parameter to string while sending the data to opensearch. So that it is consistent with upload_time parameter.

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, test, documentation, enhancement
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

