### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/merge-to-master.yaml
+++ b/.github/workflows/merge-to-master.yaml
@@ -66,7 +66,7 @@ jobs:
           make test
 
       - name: Upload Code Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 #v3
         with:
           file: cover.out
           verbose: true
@@ -88,7 +88,7 @@ jobs:
           touch ./out/site/.nojekyll
 
       - name: Publish to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7 #v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./out/site
@@ -116,7 +116,7 @@ jobs:
           echo "operator-image-ref=${OIR}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@8bd2f9fbda2109502356ff8a6a89da55b1ead252 #master
         with:
           image-ref: ${{ steps.operator-image-ref.outputs.operator-image-ref }}
           format: 'sarif'
@@ -126,6 +126,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 #v2
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/merge-to-release-branch.yaml
+++ b/.github/workflows/merge-to-release-branch.yaml
@@ -62,7 +62,7 @@ jobs:
           make test
 
       - name: Upload Code Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 #v3
         with:
           file: cover.out
           verbose: true
@@ -90,7 +90,7 @@ jobs:
           echo "operator-image-ref=${OIR}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@8bd2f9fbda2109502356ff8a6a89da55b1ead252 #master
         with:
           image-ref: ${{ steps.operator-image-ref.outputs.operator-image-ref }}
           format: 'sarif'
@@ -100,6 +100,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 #v2
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/periodic-security-check.yaml
+++ b/.github/workflows/periodic-security-check.yaml
@@ -17,7 +17,7 @@ jobs:
           echo "operator-image-ref=${OIR}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@8bd2f9fbda2109502356ff8a6a89da55b1ead252 #master
         with:
           image-ref: ${{ steps.operator-image-ref.outputs.operator-image-ref }}
           format: 'sarif'
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 #v2
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -39,11 +39,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run gosec
-        uses: securego/gosec@v2.15.0
+        uses: securego/gosec@a459eb0ba387d9bd083d5c2e2354dbeef2465038 #v2.15.0
         with:
           args: '-no-fail -fmt sarif -out gosec.sarif ./...'
 
       - name: Upload gosec scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 #v2
         with:
           sarif_file: 'gosec.sarif'

--- a/.github/workflows/pr-checks-push-images.yaml
+++ b/.github/workflows/pr-checks-push-images.yaml
@@ -28,7 +28,7 @@ jobs:
           wait-interval: 60
 
       - name: Download images
-        uses: pmacik/action-download-multiple-artifacts@node16
+        uses: pmacik/action-download-multiple-artifacts@d5a97e5ca4863fd85690e0df73816c312c27de4b #node16
         with:
           names: operator-images-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -58,7 +58,7 @@ jobs:
           make test
 
       - name: Upload Code Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 #v3
         with:
           file: cover.out
           verbose: true
@@ -105,7 +105,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: pmacik/action-download-multiple-artifacts@node16
+        uses: pmacik/action-download-multiple-artifacts@d5a97e5ca4863fd85690e0df73816c312c27de4b #node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -130,7 +130,7 @@ jobs:
 
       - name: Setup Testspace
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: testspace-com/setup-testspace@v1
+        uses: testspace-com/setup-testspace@ee1482f978eb5010ec27b6f6372904f01f2edd68 #v1
         with:
           domain: ${{ github.repository_owner }}
 
@@ -185,7 +185,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: pmacik/action-download-multiple-artifacts@node16
+        uses: pmacik/action-download-multiple-artifacts@d5a97e5ca4863fd85690e0df73816c312c27de4b #node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -210,7 +210,7 @@ jobs:
 
       - name: Setup Testspace
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: testspace-com/setup-testspace@v1
+        uses: testspace-com/setup-testspace@ee1482f978eb5010ec27b6f6372904f01f2edd68 #v1
         with:
           domain: ${{ github.repository_owner }}
 
@@ -266,7 +266,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: pmacik/action-download-multiple-artifacts@node16
+        uses: pmacik/action-download-multiple-artifacts@d5a97e5ca4863fd85690e0df73816c312c27de4b #node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -291,7 +291,7 @@ jobs:
 
       - name: Setup Testspace
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: testspace-com/setup-testspace@v1
+        uses: testspace-com/setup-testspace@ee1482f978eb5010ec27b6f6372904f01f2edd68 #v1
         with:
           domain: ${{ github.repository_owner }}
 
@@ -346,7 +346,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: pmacik/action-download-multiple-artifacts@node16
+        uses: pmacik/action-download-multiple-artifacts@d5a97e5ca4863fd85690e0df73816c312c27de4b #node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -371,7 +371,7 @@ jobs:
 
       - name: Setup Testspace
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: testspace-com/setup-testspace@v1
+        uses: testspace-com/setup-testspace@ee1482f978eb5010ec27b6f6372904f01f2edd68 #v1
         with:
           domain: ${{ github.repository_owner }}
 
@@ -432,7 +432,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: pmacik/action-download-multiple-artifacts@node16
+        uses: pmacik/action-download-multiple-artifacts@d5a97e5ca4863fd85690e0df73816c312c27de4b #node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -460,7 +460,7 @@ jobs:
 
       - name: Setup Testspace
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true'  && always() }}
-        uses: testspace-com/setup-testspace@v1
+        uses: testspace-com/setup-testspace@ee1482f978eb5010ec27b6f6372904f01f2edd68 #v1
         with:
           domain: ${{ github.repository_owner }}
 
@@ -530,7 +530,7 @@ jobs:
 
       - name: Extract image references
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: pmacik/action-download-multiple-artifacts@node16
+        uses: pmacik/action-download-multiple-artifacts@d5a97e5ca4863fd85690e0df73816c312c27de4b #node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -557,7 +557,7 @@ jobs:
 
       - name: Setup Testspace
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
-        uses: testspace-com/setup-testspace@v1
+        uses: testspace-com/setup-testspace@ee1482f978eb5010ec27b6f6372904f01f2edd68 #v1
         with:
           domain: ${{ github.repository_owner }}
 
@@ -607,7 +607,7 @@ jobs:
           wait-interval: 60
 
       - name: Download image references
-        uses: pmacik/action-download-multiple-artifacts@node16
+        uses: pmacik/action-download-multiple-artifacts@d5a97e5ca4863fd85690e0df73816c312c27de4b #node16
         with:
           names: operator-refs-${{github.event.pull_request.number}}-${{github.event.pull_request.head.sha}}
 
@@ -618,7 +618,7 @@ jobs:
           echo "operator-image-ref=${OPERATOR_IMAGE_REF}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@8bd2f9fbda2109502356ff8a6a89da55b1ead252 #master
         with:
           image-ref: ${{ steps.operator-image-ref.outputs.operator-image-ref }}
           format: 'sarif'
@@ -628,7 +628,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 #v2
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -640,11 +640,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run gosec
-        uses: securego/gosec@v2.15.0
+        uses: securego/gosec@a459eb0ba387d9bd083d5c2e2354dbeef2465038 #v2.15.0
         with:
           args: '-no-fail -fmt sarif -out gosec.sarif ./...'
 
       - name: Upload gosec scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 #v2
         with:
           sarif_file: 'gosec.sarif'

--- a/.github/workflows/pr-cherry-picks.yaml
+++ b/.github/workflows/pr-cherry-picks.yaml
@@ -17,11 +17,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup SSH for cherry-pick repo
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@fc49353b67b2b7c1e0e6a600572d01a69f2672dd #v0.5.4
         with:
           ssh-private-key: ${{ secrets.SBO_CHERRY_PICK_REPO_SSH_PRIVATE_KEY }}
       - name: Cherry pick into release-v1.1.x
-        uses: pmacik/github-cherry-pick-action@main
+        uses: pmacik/github-cherry-pick-action@8dcbeacb35b51706f9dc209a5944159baf3e0288 #main
         with:
           cherry-pick-repo: ${{ secrets.SBO_CHERRY_PICK_REPO }}
           token: ${{ secrets.SBO_CHERRY_PICK_BOT_TOKEN }}
@@ -42,11 +42,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup SSH for cherry-pick repo
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@fc49353b67b2b7c1e0e6a600572d01a69f2672dd #v0.5.4
         with:
           ssh-private-key: ${{ secrets.SBO_CHERRY_PICK_REPO_SSH_PRIVATE_KEY }}
       - name: Cherry pick into release-v1.2.x
-        uses: pmacik/github-cherry-pick-action@main
+        uses: pmacik/github-cherry-pick-action@8dcbeacb35b51706f9dc209a5944159baf3e0288 #main
         with:
           cherry-pick-repo: ${{ secrets.SBO_CHERRY_PICK_REPO }}
           token: ${{ secrets.SBO_CHERRY_PICK_BOT_TOKEN }}
@@ -67,11 +67,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup SSH for cherry-pick repo
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@fc49353b67b2b7c1e0e6a600572d01a69f2672dd #v0.5.4
         with:
           ssh-private-key: ${{ secrets.SBO_CHERRY_PICK_REPO_SSH_PRIVATE_KEY }}
       - name: Cherry pick into release-v1.2.x
-        uses: pmacik/github-cherry-pick-action@main
+        uses: pmacik/github-cherry-pick-action@8dcbeacb35b51706f9dc209a5944159baf3e0288 #main
         with:
           cherry-pick-repo: ${{ secrets.SBO_CHERRY_PICK_REPO }}
           token: ${{ secrets.SBO_CHERRY_PICK_BOT_TOKEN }}


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
