### PR TITLE
feature: add RedisCluster CRD to supported Service Binding types

### DIFF
--- a/charts/service-binding-operator/templates/clusterrole.yaml
+++ b/charts/service-binding-operator/templates/clusterrole.yaml
@@ -289,6 +289,7 @@ rules:
   - redis.redis.opstreelabs.in
   resources:
   - redis
+  - rediscluster
   verbs:
   - get
   - list

--- a/config/rbac/opstree_redis_clusterrole.yaml
+++ b/config/rbac/opstree_redis_clusterrole.yaml
@@ -9,6 +9,7 @@ rules:
       - redis.redis.opstreelabs.in
     resources:
       - redis
+      - rediscluster
     verbs:
       - get
       - list

--- a/pkg/binding/registry/registry.go
+++ b/pkg/binding/registry/registry.go
@@ -21,6 +21,11 @@ func New() Registry {
 				"service.binding/host":     "path={.metadata.name}",
 				"service.binding/password": "path={.spec.kubernetesConfig.redisSecret.name},objectType=Secret,sourceKey=password,optional=true",
 			},
+			schema.GroupVersionKind{Group: "redis.redis.opstreelabs.in", Version: "v1beta1", Kind: "RedisCluster"}: {
+				"service.binding/type":     "rediscluster",
+				"service.binding/host":     "path={.metadata.name}",
+				"service.binding/password": "path={.spec.kubernetesConfig.redisSecret.name},objectType=Secret,sourceKey=password,optional=true",
+			},
 			schema.GroupVersionKind{Group: "postgres-operator.crunchydata.com", Version: "v1beta1", Kind: "PostgresCluster"}: {
 				"service.binding/type":     "postgresql",
 				"service.binding/provider": "crunchydata",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This adds the [RedisCluster CRD type](https://ot-redis-operator.netlify.app/docs/crd-reference/redis-api/#rediscluster) to the supported Service Binding registry bindings.

/kind enhancement

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

