### PR TITLE
dependabot: adjust update policy to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,39 +3,45 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+    ignore:
+      # These projects usually require more manual intervention to bump than
+      # usual, so let's ignore them from normal dependabot updates for now.
+      - "k8s.io/*"
+      - "sigs.k8s.io/*"
+
 
   - package-ecosystem: gomod
     directory: "test/_projects/api-client"
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: gomod
     directory: "test/_projects/api-controller"
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: pip
     directory: "test/acceptance/features/"
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: pip
     directory: "hack/check-python/"
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: docker
     directory: "test/acceptance/resources/apps/generic-test-app/"
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
Daily updates for dependabot is a bit much with our current resources, so let's back off to weekly for now.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind enhancement

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

