### PR TITLE
Add polling to App.get_generation in tests

### DIFF
--- a/test/acceptance/features/steps/app.py
+++ b/test/acceptance/features/steps/app.py
@@ -45,7 +45,11 @@ class App(object):
     def get_generation(self):
         deployment_name = self.openshift.get_deployment_name_in_namespace(
                             self.format_pattern(self.deployment_name_pattern), self.namespace, resource=self.resource)
-        return int(self.openshift.get_resource_info_by_jsonpath(self.resource, deployment_name, self.namespace, "{.metadata.generation}"))
+        generation = polling2.poll(
+                target=lambda: self.openshift.get_resource_info_by_jsonpath(self.resource, deployment_name, self.namespace, "{.metadata.generation}"),
+                check_success=lambda x: x is not None,
+                step=5, timeout=800)
+        return int(generation)
 
 
 @step(u'jsonpath "{json_path}" on "{res_name}" should return "{json_value}"')


### PR DESCRIPTION
# Changes

Make tests more robust adding a polling on `App.get_generation`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [x] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [x] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [x] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

