### PR TITLE
ci: bump python version to 3.11

### DIFF
--- a/.github/workflows/merge-to-master.yaml
+++ b/.github/workflows/merge-to-master.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
           architecture: "x64"
 
       - name: Setup CLI

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
           architecture: "x64"
 
       - name: Checkout repo
@@ -85,7 +85,7 @@ jobs:
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
           architecture: "x64"
 
       - name: Setup-cli
@@ -165,7 +165,7 @@ jobs:
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
           architecture: "x64"
 
       - name: Setup-cli
@@ -246,7 +246,7 @@ jobs:
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
           architecture: "x64"
 
       - name: Setup-cli
@@ -326,7 +326,7 @@ jobs:
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
           architecture: "x64"
 
       - name: Setup-cli
@@ -406,7 +406,7 @@ jobs:
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
           architecture: "x64"
 
       - name: Setup-cli
@@ -497,7 +497,7 @@ jobs:
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
           architecture: "x64"
 
       - name: Set up CLI


### PR DESCRIPTION
This was causing some small issues in linting; might as well bump it to latest available.

# Changes

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

