### PR TITLE
test: change oc's --docker-image flag to --image

### DIFF
--- a/test/acceptance/features/steps/openshift.py
+++ b/test/acceptance/features/steps/openshift.py
@@ -563,7 +563,7 @@ spec:
 
     def new_app(self, name, image_name, namespace, bindingRoot=None, asDeploymentConfig=False):
         if ctx.cli == "oc":
-            cmd = f"{ctx.cli} new-app --docker-image={image_name} --name={name} -n {namespace}"
+            cmd = f"{ctx.cli} new-app --image={image_name} --name={name} -n {namespace}"
             if bindingRoot:
                 cmd = cmd + f" -e SERVICE_BINDING_ROOT={bindingRoot}"
             if asDeploymentConfig:


### PR DESCRIPTION
The `--docker-image` flag has been deprecated, so we should move away from using it.

# Changes

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

