### PR TITLE
ci: run security checks on push to branch

### DIFF
--- a/.github/workflows/periodic-security-check.yaml
+++ b/.github/workflows/periodic-security-check.yaml
@@ -1,4 +1,8 @@
 on:
+  push:
+    branch:
+      - master
+      - 'release-v**.x'
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
# Changes

Recently in PRs, we've been getting warnings that our SAST tools don't have a known configuration for some branches.  To fix this warning, we need to add push hooks for `master` and the release branches to run security checks.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

