### PR TITLE
ci: cleanup security checks

### DIFF
--- a/.github/workflows/merge-to-master.yaml
+++ b/.github/workflows/merge-to-master.yaml
@@ -97,17 +97,10 @@ jobs:
   security-scan:
     name: Security vulnerability scan
     runs-on: ubuntu-20.04
+    needs: ["release"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Wait for push
-        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
-        with:
-          ref: ${{ github.ref }}
-          check-name: "Release operator on Quay.io"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 60
 
       - name: Extract operator image ref
         id: operator-image-ref

--- a/.github/workflows/merge-to-release-branch.yaml
+++ b/.github/workflows/merge-to-release-branch.yaml
@@ -71,17 +71,10 @@ jobs:
   security-scan:
     name: Security vulnerability scan
     runs-on: ubuntu-20.04
+    needs: ["release"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Wait for push
-        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
-        with:
-          ref: ${{ github.ref }}
-          check-name: "Release operator on Quay.io"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 60
 
       - name: Extract operator image ref
         id: operator-image-ref

--- a/.github/workflows/periodic-security-check.yaml
+++ b/.github/workflows/periodic-security-check.yaml
@@ -1,8 +1,4 @@
 on:
-  push:
-    branch:
-      - master
-      - 'release-v**.x'
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
# Changes

This contains two improvements:
- I misconfigured our periodic security checks back in 39908ed30, and it wasn't caught in review. Turns out it was rather unnecessary with the checks we have in merge-to-master and merge-to-release-branch.  The neutral checks we're seeing are caused by something else; I'll need to investigate to figure out what's going on.
- Rather than waiting within the job itself, we can have the jobs for security checks get triggered when the push to quay is done in both the merge-to-master and merge-to-release-branch is done.  It should save a few seconds during checks, and it means we won't have a runner waiting doing nothing.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#docs) 
  included if any changes are user facing
- [ ] [Tests](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#tests)
  included if any functionality added or changed. For bugfixes please include tests that can catch regressions
- [ ] All acceptance test scenarios included in the PR which verifies a bugfix or a requested feature reported by a non-member are tagged with `@external-feedback` tag.
- [ ] Follows the [commit message standard](https://github.com/redhat-developer/service-binding-operator/blob/master/CONTRIBUTING.md#commits)

